### PR TITLE
Add windows testing via Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,27 @@
+# Test against this version of Node.js
+environment:
+  matrix:
+    # node.js
+    - nodejs_version: "5.1"
+    - nodejs_version: "4.2"
+
+# Install scripts. (runs after repo cloning)
+install:
+  # Get the latest stable version of Node.js or io.js
+  - ps: Install-Product node $env:nodejs_version
+  # install modules
+  - npm install -g typings tsc
+  - npm install
+
+# Post-install test scripts.
+test_script:
+  # run tests
+  - npm test
+
+# artifacts:
+#   - path: ./junit/xunit.xml
+#   - path: ./xunit.xml
+
+# nothing to compile in this project
+build: off
+deploy: off

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./lib/index.js",
   "scripts": {
     "pretest": "npm run compile",
-    "test": "istanbul cover _mocha -- --reporter spec --full-trace test-lib/test/tests.js",
+    "test": "./node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha -- --reporter spec --full-trace test-lib/test/tests.js",
     "posttest": "npm run lint",
     "postinstall": "./node_modules/.bin/typings i",
     "compile": "tsc",


### PR DESCRIPTION
This PR brings support for using the free tier of [Appveyor](http://www.appveyor.com/) to test this project on windows alongside the linux test travis is running. An apollosstack account will need to be setup on appveyor, then this project selected to build it. We can also add an Appveyor badge if wanted once that is configured.

Example build: https://ci.appveyor.com/project/NewSpring/apollo-client/build/1.0.5