### PR TITLE
Add tests and handling for null response fields

### DIFF
--- a/src/diffAgainstStore.ts
+++ b/src/diffAgainstStore.ts
@@ -2,6 +2,7 @@
 
 import {
   isArray,
+  isNull,
   has,
 } from 'lodash';
 
@@ -114,6 +115,12 @@ export function diffSelectionSetAgainstStore({
 
     if (! field.selectionSet) {
       result[resultFieldKey] = storeObj[storeFieldKey];
+      return;
+    }
+
+    if (isNull(storeObj[storeFieldKey])) {
+      // Basically any field in a GraphQL response can be null
+      result[resultFieldKey] = null;
       return;
     }
 

--- a/test/readFromStore.ts
+++ b/test/readFromStore.ts
@@ -196,4 +196,40 @@ describe('reading from the store', () => {
       });
     }, /field missingField on object/);
   });
+
+  it('runs a nested fragment where the reference is null', () => {
+    const result = {
+      id: 'abcd',
+      stringField: 'This is a string!',
+      numberField: 5,
+      nullField: null,
+      nestedObj: null,
+    };
+
+    const store = {
+      abcd: _.assign({}, _.assign({}, _.omit(result, 'nestedObj')), { nestedObj: null }),
+    } as Store;
+
+    const queryResult = readFragmentFromStore({
+      store,
+      fragment: `
+        fragment FragmentName on Item {
+          stringField,
+          numberField,
+          nestedObj {
+            stringField,
+            numberField
+          }
+        }
+      `,
+      rootId: 'abcd',
+    });
+
+    // The result of the query shouldn't contain __data_id fields
+    assert.deepEqual(queryResult, {
+      stringField: 'This is a string!',
+      numberField: 5,
+      nestedObj: null,
+    });
+  });
 });

--- a/test/writeToStore.ts
+++ b/test/writeToStore.ts
@@ -358,6 +358,40 @@ describe('writing to the store', () => {
       'abcd': _.assign({}, result, result2),
     });
   });
+
+  it('properly normalizes a nested object that returns null', () => {
+    const fragment = `
+      fragment Item on ItemType {
+        id,
+        stringField,
+        numberField,
+        nullField,
+        nestedObj {
+          id,
+          stringField,
+          numberField,
+          nullField
+        }
+      }
+    `;
+
+    const result = {
+      id: 'abcd',
+      stringField: 'This is a string!',
+      numberField: 5,
+      nullField: null,
+      nestedObj: null,
+    };
+
+    assertEqualSansDataId(writeFragmentToStore({
+      fragment,
+      result: _.cloneDeep(result),
+    }), {
+      [result.id]: _.assign({}, _.assign({}, _.omit(result, 'nestedObj')), {
+        nestedObj: null,
+      }),
+    });
+  });
 });
 
 function assertEqualSansDataId(a, b) {


### PR DESCRIPTION
The response from the GraphQL fragment:

```
fragment FragmentName on Item {
  stringField,
  numberField,
  nestedObj {
    stringField,
    numberField
  }
}
```

Can contain a null field instead of any field or a nested object:

```js
const result = {
  id: 'abcd',
  stringField: 'This is a string!',
  numberField: 5,
  nullField: null,
  nestedObj: null,
};
```

This PR handles that correctly, whereas before it would have errored when reading from the store.