### PR TITLE
Remove reference paths

### DIFF
--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -1,5 +1,3 @@
-/// <reference path="../typings/main.d.ts" />
-
 import {
   NetworkInterface,
   Request,

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -1,5 +1,3 @@
-/// <reference path="../typings/main.d.ts" />
-
 // For development only!
 import * as _ from 'lodash';
 

--- a/src/diffAgainstStore.ts
+++ b/src/diffAgainstStore.ts
@@ -1,5 +1,3 @@
-/// <reference path="../typings/main.d.ts" />
-
 import {
   isArray,
   isNull,

--- a/src/networkInterface.ts
+++ b/src/networkInterface.ts
@@ -1,5 +1,3 @@
-/// <reference path="../typings/main.d.ts" />
-
 // ensure env has promise support
 // this should probably be moved elsewhere / should be part of the extra
 // deps for older environemnts

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,5 +1,3 @@
-/// <reference path="../typings/main.d.ts" />
-
 import { parse } from 'graphql';
 
 import {

--- a/src/queryPrinting.ts
+++ b/src/queryPrinting.ts
@@ -1,5 +1,3 @@
-/// <reference path="../typings/main.d.ts" />
-
 import { print } from 'graphql';
 
 export function printNodeQuery({

--- a/src/readFromStore.ts
+++ b/src/readFromStore.ts
@@ -1,5 +1,3 @@
-/// <reference path="../typings/main.d.ts" />
-
 import {
   parseFragmentIfString,
   parseQueryIfString,

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,5 +1,3 @@
-/// <reference path="../typings/main.d.ts" />
-
 import {
   SelectionSet,
 } from 'graphql';

--- a/src/storeUtils.ts
+++ b/src/storeUtils.ts
@@ -1,5 +1,3 @@
-/// <reference path="../typings/main.d.ts" />
-
 import {
   Field,
   Argument,

--- a/src/writeToStore.ts
+++ b/src/writeToStore.ts
@@ -1,5 +1,3 @@
-/// <reference path="../typings/main.d.ts" />
-
 import {
   isString,
   isNumber,

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -1,5 +1,3 @@
-/// <reference path="../typings/main.d.ts" />
-
 import {
   QueryManager,
 } from '../src/QueryManager';

--- a/test/diffAgainstStore.ts
+++ b/test/diffAgainstStore.ts
@@ -1,5 +1,3 @@
-/// <reference path="../typings/main.d.ts" />
-
 import { assert } from 'chai';
 
 import { diffQueryAgainstStore } from '../src/diffAgainstStore';

--- a/test/networkInterface.ts
+++ b/test/networkInterface.ts
@@ -1,5 +1,3 @@
-/// <reference path="../typings/main.d.ts" />
-
 import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 

--- a/test/queryPrinting.ts
+++ b/test/queryPrinting.ts
@@ -1,5 +1,3 @@
-/// <reference path="../typings/main.d.ts" />
-
 import { assert } from 'chai';
 import { printNodeQuery } from '../src/queryPrinting';
 

--- a/test/readFromStore.ts
+++ b/test/readFromStore.ts
@@ -1,5 +1,3 @@
-/// <reference path="../typings/main.d.ts" />
-
 import { assert } from 'chai';
 import * as _ from 'lodash';
 

--- a/test/roundtrip.ts
+++ b/test/roundtrip.ts
@@ -1,5 +1,3 @@
-/// <reference path="../typings/main.d.ts" />
-
 import { assert } from 'chai';
 
 import { writeQueryToStore } from '../src/writeToStore';

--- a/test/writeToStore.ts
+++ b/test/writeToStore.ts
@@ -1,5 +1,3 @@
-/// <reference path="../typings/main.d.ts" />
-
 import { assert } from 'chai';
 import * as _ from 'lodash';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,10 +12,9 @@
     "pretty": true,
     "removeComments": true
   },
-  "exclude": [
-    "node_modules",
-    "typings",
-    "lib",
-    "test-lib"
-  ]
+  "files": [
+    "typings/main.d.ts",
+    "src/index.ts",
+    "test/tests.ts"
+   ]
 }


### PR DESCRIPTION
We now define a list of entry files we want to include in the build instead of using a `exclude` list of directories.