### PR TITLE
Pass errors to handler function in network interface

### DIFF
--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -37,8 +37,7 @@ export class QueryManager {
   private store: ReduxStore;
   private selectionSetMap: { [queryId: number]: SelectionSetWithRoot };
 
-  private dataCallbacks: { [queryId: number]: QueryResultCallback[]};
-  private errorCallbacks: { [queryId: number]: QueryErrorCallback[]};
+  private resultCallbacks: { [queryId: number]: QueryResultCallback[]};
 
   private idCounter = 0;
 
@@ -55,8 +54,7 @@ export class QueryManager {
     this.store = store;
 
     this.selectionSetMap = {};
-    this.dataCallbacks = {};
-    this.errorCallbacks = {};
+    this.resultCallbacks = {};
 
     this.store.subscribe(() => {
       this.broadcastNewStore(this.store.getState());
@@ -77,21 +75,20 @@ export class QueryManager {
       variables,
     } as Request;
 
-    return this.networkInterface.query([
-      request,
-    ]).then((result) => {
-      const resultWithDataId = assign({
-        __data_id: 'ROOT_MUTATION',
-      }, result[0].data);
+    return this.networkInterface.query(request)
+      .then((result) => {
+        const resultWithDataId = assign({
+          __data_id: 'ROOT_MUTATION',
+        }, result.data);
 
-      this.store.dispatch(createQueryResultAction({
-        result: resultWithDataId,
-        selectionSet: mutationDef.selectionSet,
-        variables,
-      }));
+        this.store.dispatch(createQueryResultAction({
+          result: resultWithDataId,
+          selectionSet: mutationDef.selectionSet,
+          variables,
+        }));
 
-      return result[0].data;
-    });
+        return result.data;
+      });
   }
 
   public watchQuery({
@@ -116,40 +113,27 @@ export class QueryManager {
       variables,
     } as Request;
 
-    this.networkInterface.query([
-      request,
-    ]).then((result) => {
-      let errors: GraphQLError[] = [];
-      let results: GraphQLResult[] = [...result];
+    this.networkInterface.query(request)
+      .then((result: GraphQLResult) => {
+        let errors: GraphQLError[] = result.errors;
 
-      // pick errors off of mixed errors and data objects so they
-      // can be handled without blocking the good data
-      // that did come through
-      results = results.map((x: GraphQLResult) => {
-        if (x.errors && x.errors.length) {
-          errors = errors.concat(x.errors);
+        if (errors && errors.length) {
+          this.handleQueryErrorsAndStop(watchHandle.id, errors);
         }
 
-        return { data: x.data };
-      });
+        // XXX handle multiple GraphQLResults
+        const resultWithDataId = assign({
+          __data_id: 'ROOT_QUERY',
+        }, result.data);
 
-      if (errors.length) {
+        this.store.dispatch(createQueryResultAction({
+          result: resultWithDataId,
+          selectionSet: queryDef.selectionSet,
+          variables,
+        }));
+      }).catch((errors: GraphQLError[]) => {
         this.handleQueryErrorsAndStop(watchHandle.id, errors);
-      }
-
-      // XXX handle multiple GraphQLResults
-      const resultWithDataId = assign({
-        __data_id: 'ROOT_QUERY',
-      }, result[0].data);
-
-      this.store.dispatch(createQueryResultAction({
-        result: resultWithDataId,
-        selectionSet: queryDef.selectionSet,
-        variables,
-      }));
-    }).catch((errors: GraphQLError[]) => {
-      this.handleQueryErrorsAndStop(watchHandle.id, errors);
-    });
+      });
 
     return watchHandle;
   }
@@ -183,34 +167,27 @@ export class QueryManager {
       stop: () => {
         this.stopQuery(queryId);
       },
-      onData: (callback) => {
-        if (isStopped()) {
-          throw new Error('Query was stopped. Please create a new one.');
-        }
-
-        this.registerDataCallback(queryId, callback);
-      },
-      onError: (callback) => {
+      onResult: (callback) => {
         if (isStopped()) { throw new Error('Query was stopped. Please create a new one.'); }
-        this.registerErrorCallback(queryId, callback);
+
+        this.registerResultCallback(queryId, callback);
       },
     };
   }
 
   private stopQuery(queryId) {
     delete this.selectionSetMap[queryId];
-    delete this.dataCallbacks[queryId];
-    delete this.errorCallbacks[queryId];
+    delete this.registerResultCallback[queryId];
   }
 
   private broadcastQueryChange(queryId: string, result: any) {
-    this.dataCallbacks[queryId].forEach((callback) => {
-      callback(result);
+    this.resultCallbacks[queryId].forEach((callback) => {
+      callback(null, result);
     });
   }
 
   private handleQueryErrorsAndStop(queryId: string, errors: GraphQLError[]) {
-    const errorCallbacks: QueryErrorCallback[] = this.errorCallbacks[queryId];
+    const errorCallbacks: QueryResultCallback[] = this.resultCallbacks[queryId];
 
     this.stopQuery(queryId);
 
@@ -224,21 +201,14 @@ export class QueryManager {
     }
   }
 
-  private registerDataCallback(queryId: string, callback: QueryResultCallback): void {
-    if (! this.dataCallbacks[queryId]) {
-      this.dataCallbacks[queryId] = [];
+  private registerResultCallback(queryId: string, callback: QueryResultCallback): void {
+    if (! this.resultCallbacks[queryId]) {
+      this.resultCallbacks[queryId] = [];
     }
 
-    this.dataCallbacks[queryId].push(callback);
+    this.resultCallbacks[queryId].push(callback);
   }
 
-  private registerErrorCallback(queryId: string, callback: QueryErrorCallback): void {
-    if (! this.errorCallbacks[queryId]) {
-      this.errorCallbacks[queryId] = [];
-    }
-
-    this.errorCallbacks[queryId].push(callback);
-  }
 }
 
 export interface SelectionSetWithRoot {
@@ -252,10 +222,7 @@ export interface WatchedQueryHandle {
   id: string;
   isStopped: () => boolean;
   stop();
-  onData(callback: QueryResultCallback);
-  onError(callback: QueryErrorCallback);
+  onResult(callback: QueryResultCallback);
 }
 
-export type QueryResultCallback = (result: any) => void;
-export type QueryErrorCallback = (errors: GraphQLError[]) => void;
-
+export type QueryResultCallback = (error: GraphQLError[], result?: any) => void;

--- a/src/networkInterface.ts
+++ b/src/networkInterface.ts
@@ -55,7 +55,7 @@ export function createNetworkInterface(uri: string, opts: RequestInit = {}): Net
         .then(result => result.json())
         .then((payload: GraphQLResult) => {
           if (payload.hasOwnProperty('errors')) {
-            throw payload;
+            throw payload as GraphQLError;
           } else if (!payload.hasOwnProperty('data')) {
             throw new Error(
               `Server response was missing for query '${request.debugName}'.`

--- a/src/networkInterface.ts
+++ b/src/networkInterface.ts
@@ -48,9 +48,7 @@ export function createNetworkInterface(uri: string, opts: RequestInit = {}): Net
   };
 
   function query(requests: Array<Request>): Promise<Array<GraphQLResult | GraphQLError>> {
-    let clonedRequests = [...requests];
-
-    return Promise.all(clonedRequests.map(request => (
+    return Promise.all(requests.map(request => (
       fetchFromRemoteEndpoint(request)
         .then(result => result.json())
         .then((payload: GraphQLResult) => {

--- a/src/networkInterface.ts
+++ b/src/networkInterface.ts
@@ -61,7 +61,7 @@ export function createNetworkInterface(uri: string, opts: RequestInit = {}): Net
               `Server response was missing for query '${request.debugName}'.`
             );
           } else {
-            return payload;
+            return payload as GraphQLResult;
           }
         })
     )));

--- a/test/networkInterface.ts
+++ b/test/networkInterface.ts
@@ -69,20 +69,18 @@ describe('network interface', () => {
       };
 
       return assert.eventually.deepEqual(
-        swapi.query([simpleRequest]),
-        [
-          {
-            data: {
-              allPeople: {
-                people: [
-                  {
-                    name: 'Luke Skywalker',
-                  },
-                ],
-              },
+        swapi.query(simpleRequest),
+        {
+          data: {
+            allPeople: {
+              people: [
+                {
+                  name: 'Luke Skywalker',
+                },
+              ],
             },
           },
-        ]
+        }
       );
     });
 
@@ -103,32 +101,29 @@ describe('network interface', () => {
         debugName: 'People query',
       };
 
-      // return assert.isRejected(swapi.query([simpleRequest]));
-      return assert.isRejected(
-        swapi.query([simpleRequest]),
-        [
-          {
-            errors: [
-              {
-                message: 'Syntax Error GraphQL request (8:9) Expected Name, found EOF',
-                locations: [
-                  {
-                    line: 8,
-                    column: 9,
-                  },
-                ],
-              },
-            ],
-          },
-        ]
+      return assert.eventually.deepEqual(
+        swapi.query(simpleRequest),
+        {
+          errors: [
+            {
+              message: 'Syntax Error GraphQL request (8:9) Expected Name, found EOF\n\n7:           }\n8:         \n           ^\n',
+              locations: [
+                {
+                  line: 8,
+                  column: 9,
+                },
+              ],
+            },
+          ],
+        }
       );
     });
 
-    it('should allow for multiple requests at once', () => {
-      const swapi = createNetworkInterface('http://graphql-swapi.parseapp.com/');
+    it('should throw on a network error', () => {
+      const nowhere = createNetworkInterface('http://does-not-exist.parseapp.com/');
 
       // this is a stub for the end user client api
-      const firstRequest = {
+      const doomedToFail = {
         query: `
           query people {
             allPeople(first: 1) {
@@ -142,47 +137,7 @@ describe('network interface', () => {
         debugName: 'People Query',
       };
 
-      const secondRequest = {
-        query: `
-          query ships {
-            allStarships(first: 1) {
-              starships {
-                name
-              }
-            }
-          }
-        `,
-        variables: {},
-        debugName: 'Ships Query',
-      };
-
-      return assert.eventually.deepEqual(
-        swapi.query([firstRequest, secondRequest]),
-        [
-          {
-            data: {
-              allPeople: {
-                people: [
-                  {
-                    name: 'Luke Skywalker',
-                  },
-                ],
-              },
-            },
-          },
-          {
-            data: {
-              allStarships: {
-                starships: [
-                  {
-                    name: 'CR90 corvette',
-                  },
-                ],
-              },
-            },
-          },
-        ]
-      );
+      return assert.isRejected(nowhere.query(doomedToFail));
     });
   });
 });

--- a/test/networkInterface.ts
+++ b/test/networkInterface.ts
@@ -86,7 +86,7 @@ describe('network interface', () => {
       );
     });
 
-    it('should throw an error if the request fails', () => {
+    it('should return errors if the server responds with them', () => {
       const swapi = createNetworkInterface('http://graphql-swapi.parseapp.com/');
 
       // this is a stub for the end user client api
@@ -103,7 +103,25 @@ describe('network interface', () => {
         debugName: 'People query',
       };
 
-      return assert.isRejected(swapi.query([simpleRequest]), /Server request for query/);
+      // return assert.isRejected(swapi.query([simpleRequest]));
+      return assert.isRejected(
+        swapi.query([simpleRequest]),
+        [
+          {
+            errors: [
+              {
+                message: 'Syntax Error GraphQL request (8:9) Expected Name, found EOF',
+                locations: [
+                  {
+                    line: 8,
+                    column: 9,
+                  },
+                ],
+              },
+            ],
+          },
+        ]
+      );
     });
 
     it('should allow for multiple requests at once', () => {


### PR DESCRIPTION
This fixes #33 

A GraphQL server can respond back to a query with both data and errors. The network interface does not currently handle that.

```
interface GraphQLResult {
  data?: Object;
  errors?: Array<GraphQLError>;
}
````

@stubailo how do you want me to handle this? If the result has data I can pass it back as a `<GraphQLResult>` and the query manager can split the data up?