### PR TITLE
Enable query diffing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ node_js:
 install:
   - npm install -g typings tsc coveralls
   - npm install
-  - npm run coverage
 
 script:
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install:
 
 script:
   - npm test
+  - npm run coverage
   - coveralls < ./coverage/lcov.info
 
 # Allow Travis tests to run in containers.

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "redux": "^3.3.1"
   },
   "devDependencies": {
+    "async": "^1.5.2",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.2.0",
     "dataloader": "^1.1.0",

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -94,10 +94,9 @@ export class QueryManager {
   public watchQuery({
      query,
      variables,
-  }: {
-    query: string,
-    variables?: Object,
-  }): WatchedQueryHandle {
+     forceFetch = true,
+     returnPartialData = false,
+  }: WatchQueryOptions): WatchedQueryHandle {
     const queryDef = parseQuery(query);
 
     const watchHandle = this.watchSelectionSet({
@@ -107,11 +106,14 @@ export class QueryManager {
       variables,
     });
 
-    // XXX diff query against store to reduce network
-    const request = {
+    let request = {
       query: query,
       variables,
-    } as Request;
+    };
+
+    if (! forceFetch) {
+      throw new Error('query diffing not implemented');
+    }
 
     this.networkInterface.query(request)
       .then((result: GraphQLResult) => {
@@ -134,6 +136,14 @@ export class QueryManager {
       }).catch((errors: GraphQLError[]) => {
         this.handleQueryErrorsAndStop(watchHandle.id, errors);
       });
+
+    if (returnPartialData) {
+      // Needs to be async to allow component to register result callback, even though we have
+      // the data right away
+      setTimeout(() => {
+        throw new Error('partial result return not implemented');
+      }, 0);
+    }
 
     return watchHandle;
   }
@@ -226,3 +236,10 @@ export interface WatchedQueryHandle {
 }
 
 export type QueryResultCallback = (error: GraphQLError[], result?: any) => void;
+
+export interface WatchQueryOptions {
+  query: string;
+  variables?: Object;
+  forceFetch?: boolean;
+  returnPartialData?: boolean;
+}

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -54,9 +54,9 @@ export class QueryManager {
     networkInterface,
     store,
   }: {
-      networkInterface: NetworkInterface,
-      store: ReduxStore,
-    }) {
+    networkInterface: NetworkInterface,
+    store: ReduxStore,
+  }) {
     // XXX this might be the place to do introspection for inserting the `id` into the query? or
     // is that the network interface?
     this.networkInterface = networkInterface;
@@ -74,9 +74,9 @@ export class QueryManager {
     mutation,
     variables,
   }: {
-      mutation: string,
-      variables?: Object,
-    }): Promise<any> {
+    mutation: string,
+    variables?: Object,
+  }): Promise<any> {
     const mutationDef = parseMutation(mutation);
 
     const request = {

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -242,18 +242,20 @@ export class QueryManager {
 
         if (errors && errors.length) {
           this.handleQueryErrorsAndStop(queryId, errors);
+        } else {
+          // XXX handle multiple GraphQLResults
+          // XXX handle partial responses where there was an error, right now we just bail out
+          // completely if there are any execution errors
+          const resultWithDataId = assign({
+            __data_id: 'ROOT_QUERY',
+          }, result.data);
+
+          this.store.dispatch(createQueryResultAction({
+            result: resultWithDataId,
+            variables: request.variables,
+            selectionSet,
+          }));
         }
-
-        // XXX handle multiple GraphQLResults
-        const resultWithDataId = assign({
-          __data_id: 'ROOT_QUERY',
-        }, result.data);
-
-        this.store.dispatch(createQueryResultAction({
-          result: resultWithDataId,
-          variables: request.variables,
-          selectionSet,
-        }));
       }).catch((errors: GraphQLError[]) => {
         this.handleQueryErrorsAndStop(queryId, errors);
       });

--- a/src/diffAgainstStore.ts
+++ b/src/diffAgainstStore.ts
@@ -111,7 +111,7 @@ export function diffSelectionSetAgainstStore({
 
   const missingSelections: Field[] = [];
 
-  const storeObj = store[rootId];
+  const storeObj = store[rootId] || {};
 
   selectionSet.selections.forEach((selection) => {
     if (selection.kind !== 'Field') {
@@ -186,6 +186,12 @@ export function diffSelectionSetAgainstStore({
   // If we weren't able to resolve some selections from the store, construct them into
   // a query we can fetch from the server
   if (missingSelections.length) {
+    const id = storeObj['id'];
+    if (typeof id !== 'string' && rootId !== 'ROOT_QUERY') {
+      throw new Error(
+        `Can't generate query to refetch object ${rootId}, since it doesn't have a string id.`);
+    }
+
     let typeName: string;
 
     if (rootId === 'ROOT_QUERY') {

--- a/src/diffAgainstStore.ts
+++ b/src/diffAgainstStore.ts
@@ -17,7 +17,6 @@ import {
 
 import {
   Store,
-  StoreValue,
 } from './store';
 
 import {
@@ -25,13 +24,9 @@ import {
   Field,
 } from 'graphql';
 
-export interface DiffQueryStore {
-  result: DiffResult;
+export interface QueryDiffResult {
+  result: any;
   missingSelectionSets: MissingSelectionSet[];
-}
-
-export interface DiffResult {
-  [resultFieldKey: string]: StoreValue | DiffResult | DiffResult[];
 }
 
 export interface MissingSelectionSet {
@@ -48,7 +43,7 @@ export function diffQueryAgainstStore({
   store: Store,
   query: string
   variables?: Object,
-}): DiffQueryStore {
+}): QueryDiffResult {
   const queryDef = parseQuery(query);
 
   return diffSelectionSetAgainstStore({
@@ -70,7 +65,7 @@ export function diffFragmentAgainstStore({
   fragment: string,
   rootId: string,
   variables?: Object,
-}): DiffQueryStore {
+}): QueryDiffResult {
   const fragmentDef = parseFragment(fragment);
 
   return diffSelectionSetAgainstStore({
@@ -105,12 +100,12 @@ export function diffSelectionSetAgainstStore({
   rootId: string,
   throwOnMissingField: Boolean,
   variables: Object,
-}): DiffQueryStore {
+}): QueryDiffResult {
   if (selectionSet.kind !== 'SelectionSet') {
     throw new Error('Must be a selection set.');
   }
 
-  const result: DiffResult = {};
+  const result = {};
 
   const missingSelectionSets: MissingSelectionSet[] = [];
 

--- a/src/diffAgainstStore.ts
+++ b/src/diffAgainstStore.ts
@@ -191,14 +191,21 @@ export function diffSelectionSetAgainstStore({
   // If we weren't able to resolve some selections from the store, construct them into
   // a query we can fetch from the server
   if (missingSelections.length) {
-    if (! storeObj.__typename) {
+    let typeName: string;
+
+    if (rootId === 'ROOT_QUERY') {
+      // We don't need to do anything interesting to fetch root queries, like have an ID
+      typeName = 'Query';
+    } else if (! storeObj.__typename) {
       throw new Error(
         `Can't generate query to refetch object ${rootId}, since __typename wasn't in the store.`);
+    } else {
+      typeName = storeObj.__typename;
     }
 
     missingSelectionSets.push({
       id: rootId,
-      typeName: storeObj.__typename,
+      typeName,
       selectionSet: {
         kind: 'SelectionSet',
         selections: missingSelections,

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import {
 import {
   QueryManager,
   WatchedQueryHandle,
+  WatchQueryOptions,
 } from './QueryManager';
 
 export class ApolloClient {
@@ -39,11 +40,7 @@ export class ApolloClient {
     });
   }
 
-  public watchQuery({
-    query,
-  }: {
-    query: string,
-  }): WatchedQueryHandle {
-    return this.queryManager.watchQuery({ query });
+  public watchQuery(options: WatchQueryOptions): WatchedQueryHandle {
+    return this.queryManager.watchQuery(options);
   }
 }

--- a/src/queryPrinting.ts
+++ b/src/queryPrinting.ts
@@ -24,6 +24,15 @@ function nodeQueryDefinition({
   typeName,
   selectionSet,
 }) {
+  const idField = {
+    kind: 'Field',
+    alias: null,
+    name: {
+      kind: 'Name',
+      value: 'id',
+    },
+  };
+
   return {
     kind: 'OperationDefinition',
     operation: 'query',
@@ -57,6 +66,7 @@ function nodeQueryDefinition({
           selectionSet: {
             kind: 'SelectionSet',
             selections: [
+              idField,
               inlineFragmentSelection({
                 typeName,
                 selectionSet,

--- a/src/queryPrinting.ts
+++ b/src/queryPrinting.ts
@@ -1,6 +1,7 @@
 import {
   print,
   SelectionSet,
+  OperationDefinition,
 } from 'graphql';
 
 import {
@@ -8,14 +9,7 @@ import {
 } from './diffAgainstStore';
 
 export function printQueryForMissingData(missingSelectionSets: MissingSelectionSet[]) {
-  const queryDocumentAst = {
-    kind: 'Document',
-    definitions: [
-      queryDefinition(missingSelectionSets),
-    ],
-  };
-
-  return print(queryDocumentAst);
+  return printQueryFromDefinition(queryDefinition(missingSelectionSets));
 }
 
 const idField = {
@@ -27,7 +21,19 @@ const idField = {
   },
 };
 
-function queryDefinition(missingSelectionSets: MissingSelectionSet[]) {
+export function printQueryFromDefinition(queryDef: OperationDefinition) {
+  const queryDocumentAst = {
+    kind: 'Document',
+    definitions: [
+      queryDef,
+    ],
+  };
+
+  return print(queryDocumentAst);
+}
+
+export function queryDefinition(
+    missingSelectionSets: MissingSelectionSet[]): OperationDefinition {
   const selections = missingSelectionSets.map((missingSelectionSet: MissingSelectionSet, index) => {
     if (missingSelectionSet.id === 'ROOT_QUERY') {
       if (missingSelectionSet.selectionSet.selections.length > 1) {

--- a/src/queryPrinting.ts
+++ b/src/queryPrinting.ts
@@ -11,7 +11,7 @@ export function printQueryForMissingData(missingSelectionSets: MissingSelectionS
   const queryDocumentAst = {
     kind: 'Document',
     definitions: [
-      nodeQueryDefinition(missingSelectionSets),
+      queryDefinition(missingSelectionSets),
     ],
   };
 
@@ -27,10 +27,18 @@ const idField = {
   },
 };
 
-function nodeQueryDefinition(missingSelectionSets: MissingSelectionSet[]) {
+function queryDefinition(missingSelectionSets: MissingSelectionSet[]) {
   const selections = missingSelectionSets.map((missingSelectionSet: MissingSelectionSet, index) => {
+    if (missingSelectionSet.id === 'ROOT_QUERY') {
+      if (missingSelectionSet.selectionSet.selections.length > 1) {
+        throw new Error('Multiple root queries, cannot print that yet.');
+      }
+
+      return missingSelectionSet.selectionSet.selections[0];
+    }
+
     return nodeSelection({
-      alias: `node_${index}`,
+      alias: `__node_${index}`,
       id: missingSelectionSet.id,
       typeName: missingSelectionSet.typeName,
       selectionSet: missingSelectionSet.selectionSet,

--- a/src/storeUtils.ts
+++ b/src/storeUtils.ts
@@ -24,7 +24,7 @@ function isVariable(value: Value): value is Variable {
 }
 
 export function storeKeyNameFromField(field: Field, variables?: Object): string {
-  if (field.arguments.length) {
+  if (field.arguments && field.arguments.length) {
     const argObj: Object = {};
 
     field.arguments.forEach(({name, value}) => {

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -398,7 +398,7 @@ describe('QueryManager', () => {
     });
   });
 
-  it('diffs root queries', (done) => {
+  it('diffs queries', (done) => {
     testDiffing([
       {
         query: `

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -468,6 +468,27 @@ describe('QueryManager', () => {
         },
         variables: {},
       },
+      {
+        query: `
+          {
+            people_one(id: "1") {
+              id
+              name
+              age
+            }
+          }
+        `,
+        diffedQuery: null,
+        diffedQueryResponse: null,
+        fullResponse: {
+          people_one: {
+            id: 'lukeId',
+            name: 'Luke Skywalker',
+            age: 45,
+          },
+        },
+        variables: {},
+      },
     ], done);
   });
 });
@@ -506,7 +527,7 @@ function mockNetworkInterface(
 }
 
 function requestToKey(request: Request): string {
-  const query = print(parse(request.query));
+  const query = request.query && print(parse(request.query));
 
   return JSON.stringify({
     variables: request.variables,

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -23,7 +23,13 @@ import {
 
 import {
   GraphQLResult,
+  parse,
+  print,
 } from 'graphql';
+
+import {
+  waterfall,
+} from 'async';
 
 describe('QueryManager', () => {
   it('works with one query', (done) => {
@@ -306,7 +312,6 @@ describe('QueryManager', () => {
       assert.deepEqual(resultData, data);
       done();
     }).catch((err) => {
-      console.error(err);
       throw err;
     });
   });
@@ -345,7 +350,6 @@ describe('QueryManager', () => {
       assert.deepEqual(resultData, data);
       done();
     }).catch((err) => {
-      console.error(err);
       throw err;
     });
   });
@@ -390,9 +394,77 @@ describe('QueryManager', () => {
       assert.deepEqual(store.getState()['5'], { id: '5', isPrivate: true });
       done();
     }).catch((err) => {
-      console.error(err);
       throw err;
     });
+  });
+
+  it('diffs root queries', (done) => {
+    testDiffing([
+      {
+        query: `
+          {
+            people_one(id: "1") {
+              __typename,
+              id,
+              name
+            }
+          }
+        `,
+        diffedQuery: `
+          {
+            people_one(id: "1") {
+              __typename,
+              id,
+              name
+            }
+          }
+        `,
+        diffedQueryResponse: {
+          people_one: {
+            __typename: 'Person',
+            id: 'lukeId',
+            name: 'Luke Skywalker',
+          },
+        },
+        fullResponse: {
+          people_one: {
+            __typename: 'Person',
+            id: 'lukeId',
+            name: 'Luke Skywalker',
+          },
+        },
+        variables: {},
+      },
+      {
+        query: `
+          {
+            people_one(id: "1") {
+              name
+              age
+            }
+          }
+        `,
+        diffedQuery: `
+          {
+            people_one(id: "1") {
+              age
+            }
+          }
+        `,
+        diffedQueryResponse: {
+          people_one: {
+            age: 45,
+          },
+        },
+        fullResponse: {
+          people_one: {
+            name: 'Luke Skywalker',
+            age: 45,
+          },
+        },
+        variables: {},
+      },
+    ], done);
   });
 });
 
@@ -408,27 +480,96 @@ function mockNetworkInterface(
 
   // Populate set of mocked requests
   requestResultArray.forEach(({ request, result }) => {
-    requestToResultMap[JSON.stringify(request)] = result as GraphQLResult;
+    requestToResultMap[requestToKey(request)] = result as GraphQLResult;
   });
 
   // A mock for the query method
   const queryMock = (request: Request) => {
     return new Promise((resolve, reject) => {
-      const resultData = requestToResultMap[JSON.stringify(request)];
+      const resultData = requestToResultMap[requestToKey(request)];
 
       if (! resultData) {
-        throw new Error(`Passed request that wasn't mocked: ${JSON.stringify(request)}`);
+        throw new Error(`Passed request that wasn't mocked: ${requestToKey(request)}`);
       }
 
-      if (resultData.data) {
-        resolve(resultData);
-      } else {
-        reject(resultData.errors);
-      }
+      resolve(resultData);
     });
   };
 
   return {
     query: queryMock,
   } as NetworkInterface;
+}
+
+function requestToKey(request: Request): string {
+  const query = print(parse(request.query));
+
+  return JSON.stringify({
+    variables: request.variables,
+    debugName: request.debugName,
+    query,
+  });
+}
+
+function testDiffing(
+  queryArray: {
+    // The query the UI asks for
+    query: string,
+
+    // The query that we expect to be sent to the server
+    diffedQuery: string,
+
+    // The response the server would return for the diffedQuery
+    diffedQueryResponse: any,
+
+    // The result the actual UI receives, after all data is fetched
+    fullResponse: any,
+
+    // Variables to use in all queries
+    variables?: Object,
+  }[],
+  done: () => void
+) {
+  const networkInterface = mockNetworkInterface(queryArray.map(({
+    diffedQuery,
+    diffedQueryResponse,
+    variables = {},
+  }) => {
+    return {
+      request: { query: diffedQuery, variables },
+      result: { data: diffedQueryResponse },
+    };
+  }));
+
+  const queryManager = new QueryManager({
+    networkInterface,
+    store: createApolloStore(),
+  });
+
+  const steps = queryArray.map(({ query, fullResponse, variables }) => {
+    return (cb) => {
+      const handle = queryManager.watchQuery({
+        query,
+        variables,
+        forceFetch: false,
+      });
+
+      handle.onResult((error, result) => {
+        if (error) {
+          console.log(error);
+        }
+
+        assert.deepEqual(result, fullResponse);
+        cb();
+      });
+    };
+  });
+
+  waterfall(steps, (err, res) => {
+    if (err) {
+      throw err;
+    }
+
+    done();
+  });
 }

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -28,7 +28,7 @@ import {
 } from 'graphql';
 
 import {
-  waterfall,
+  series,
 } from 'async';
 
 describe('QueryManager', () => {
@@ -446,13 +446,17 @@ describe('QueryManager', () => {
         `,
         diffedQuery: `
           {
-            people_one(id: "1") {
-              age
+            __node_0: node(id: "lukeId") {
+              id
+              ... on Person {
+                age
+              }
             }
           }
         `,
         diffedQueryResponse: {
-          people_one: {
+          __node_0: {
+            id: 'lukeId',
             age: 45,
           },
         },
@@ -555,17 +559,19 @@ function testDiffing(
       });
 
       handle.onResult((error, result) => {
-        if (error) {
-          console.log(error);
-        }
+        // if (error) {
+        //   // XXX error handling??
+        //   console.log(error);
+        // }
 
         assert.deepEqual(result, fullResponse);
         cb();
+        handle.stop();
       });
     };
   });
 
-  waterfall(steps, (err, res) => {
+  series(steps, (err, res) => {
     if (err) {
       throw err;
     }

--- a/test/diffAgainstStore.ts
+++ b/test/diffAgainstStore.ts
@@ -131,7 +131,7 @@ describe('diffing queries against the store', () => {
     });
 
     assert.equal(printQueryForMissingData(missingSelectionSets), `{
-  node(id: "lukeId") {
+  node_0: node(id: "lukeId") {
     id
     ... on Person {
       age

--- a/test/diffAgainstStore.ts
+++ b/test/diffAgainstStore.ts
@@ -132,6 +132,7 @@ describe('diffing queries against the store', () => {
 
     assert.equal(printNodeQuery(diffedSelectionSet), `{
   node(id: "lukeId") {
+    id
     ... on Person {
       age
     }

--- a/test/diffAgainstStore.ts
+++ b/test/diffAgainstStore.ts
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 import { diffQueryAgainstStore } from '../src/diffAgainstStore';
 import { writeQueryToStore } from '../src/writeToStore';
 import { stripLoc } from '../src/debug';
-import { printNodeQuery } from '../src/queryPrinting';
+import { printQueryForMissingData } from '../src/queryPrinting';
 
 describe('diffing queries against the store', () => {
   it('returns nothing when the store is enough', () => {
@@ -125,12 +125,12 @@ describe('diffing queries against the store', () => {
       }
     `;
 
-    const diffedSelectionSet = diffQueryAgainstStore({
+    const { missingSelectionSets } = diffQueryAgainstStore({
       store,
       query: secondQuery,
-    }).missingSelectionSets[0];
+    });
 
-    assert.equal(printNodeQuery(diffedSelectionSet), `{
+    assert.equal(printQueryForMissingData(missingSelectionSets), `{
   node(id: "lukeId") {
     id
     ... on Person {

--- a/test/diffAgainstStore.ts
+++ b/test/diffAgainstStore.ts
@@ -131,11 +131,68 @@ describe('diffing queries against the store', () => {
     });
 
     assert.equal(printQueryForMissingData(missingSelectionSets), `{
-  node_0: node(id: "lukeId") {
+  __node_0: node(id: "lukeId") {
     id
     ... on Person {
       age
     }
+  }
+}
+`);
+  });
+
+  it('generates the right queries when the store is missing multiple nodes', () => {
+    const firstQuery = `
+      {
+        people_one(id: "1") {
+          __typename,
+          id,
+          name
+        }
+      }
+    `;
+
+    const result = {
+      people_one: {
+        __typename: 'Person',
+        id: 'lukeId',
+        name: 'Luke Skywalker',
+      },
+    };
+
+    const store = writeQueryToStore({
+      result,
+      query: firstQuery,
+    });
+
+    const secondQuery = `
+      {
+        people_one(id: "1") {
+          name,
+          age
+        }
+        people_one(id: "4") {
+          name,
+          age
+        }
+      }
+    `;
+
+    const { missingSelectionSets } = diffQueryAgainstStore({
+      store,
+      query: secondQuery,
+    });
+
+    assert.equal(printQueryForMissingData(missingSelectionSets), `{
+  __node_0: node(id: "lukeId") {
+    id
+    ... on Person {
+      age
+    }
+  }
+  people_one(id: "4") {
+    name
+    age
   }
 }
 `);

--- a/test/queryPrinting.ts
+++ b/test/queryPrinting.ts
@@ -29,6 +29,7 @@ describe('printing queries', () => {
       selectionSet,
     }), `{
   node(id: "lukeId") {
+    id
     ... on Person {
       age
     }

--- a/test/queryPrinting.ts
+++ b/test/queryPrinting.ts
@@ -1,5 +1,5 @@
 import { assert } from 'chai';
-import { printNodeQuery } from '../src/queryPrinting';
+import { printQueryForMissingData } from '../src/queryPrinting';
 
 describe('printing queries', () => {
   it('converts selection set to a query string', () => {
@@ -23,11 +23,13 @@ describe('printing queries', () => {
     };
 
     // Note - the indentation inside template strings is meaningful!
-    assert.equal(printNodeQuery({
-      id,
-      typeName,
-      selectionSet,
-    }), `{
+    assert.equal(printQueryForMissingData([
+      {
+        id,
+        typeName,
+        selectionSet,
+      },
+    ]), `{
   node(id: "lukeId") {
     id
     ... on Person {

--- a/test/queryPrinting.ts
+++ b/test/queryPrinting.ts
@@ -30,7 +30,7 @@ describe('printing queries', () => {
         selectionSet,
       },
     ]), `{
-  node(id: "lukeId") {
+  node_0: node(id: "lukeId") {
     id
     ... on Person {
       age

--- a/test/queryPrinting.ts
+++ b/test/queryPrinting.ts
@@ -30,7 +30,7 @@ describe('printing queries', () => {
         selectionSet,
       },
     ]), `{
-  node_0: node(id: "lukeId") {
+  __node_0: node(id: "lukeId") {
     id
     ... on Person {
       age

--- a/typings.json
+++ b/typings.json
@@ -3,6 +3,7 @@
     "lodash": "registry:npm/lodash#4.0.0+20160305082308"
   },
   "ambientDependencies": {
+    "async": "registry:dt/async#1.4.2+20160316155526",
     "chai": "registry:dt/chai#3.4.0+20160317120654",
     "chai-as-promised": "registry:dt/chai-as-promised#0.0.0+20160317120654",
     "es6-promise": "registry:dt/es6-promise#0.0.0+20160317120654",


### PR DESCRIPTION
Working on implementing #42, looking for feedback on the design there! Not ready for feedback on the implementation though.

## Todo

- [x] Make query diffing actually output one query with all of the different nodes required
- [x] Make query diffing use variables where the original query used variables
- [x] Call the query diff function inside `QueryManager` when the appropriate option is passed
- [ ] Make sure to handle the case where the server doesn't implement the Relay ID spec