### PR TITLE
Arrays of Scalar Values

### DIFF
--- a/src/writeToStore.ts
+++ b/src/writeToStore.ts
@@ -5,9 +5,7 @@ import {
   isNull,
   isArray,
   isUndefined,
-  isObject,
   assign,
-  find,
 } from 'lodash';
 
 import {
@@ -171,13 +169,9 @@ function writeFieldToStore({
     storeValue = value;
   } else if (isArray(value)) {
 
-    const firstNonNullValue = find(value, (val) => {
-      return !isNull(val);
-    });
-
     // GraphQL lists should be of the same type.
     // If it's an array of scalar values, don't normalize.
-    if (! isObject(firstNonNullValue)) {
+    if (isNull(field.selectionSet)) {
       storeValue = value;
     } else {
 

--- a/test/readFromStore.ts
+++ b/test/readFromStore.ts
@@ -271,4 +271,70 @@ describe('reading from the store', () => {
       nestedObj: null,
     });
   });
+
+  it('runs an array of non-objects', () => {
+    const result = {
+      id: 'abcd',
+      stringField: 'This is a string!',
+      numberField: 5,
+      nullField: null,
+      simpleArray: ['one', 'two', 'three'],
+    };
+
+    const store = {
+      abcd: _.assign({}, _.assign({}, _.omit(result, 'simpleArray')), { simpleArray: result.simpleArray }) as StoreObject,
+    } as Store;
+
+    const queryResult = readFragmentFromStore({
+      store,
+      fragment: `
+        fragment FragmentName on Item {
+          stringField,
+          numberField,
+          simpleArray
+        }
+      `,
+      rootId: 'abcd',
+    });
+
+    // The result of the query shouldn't contain __data_id fields
+    assert.deepEqual(queryResult, {
+      stringField: 'This is a string!',
+      numberField: 5,
+      simpleArray: ['one', 'two', 'three'],
+    });
+  });
+
+  it('runs an array of non-objects with null', () => {
+    const result = {
+      id: 'abcd',
+      stringField: 'This is a string!',
+      numberField: 5,
+      nullField: null,
+      simpleArray: [null, 'two', 'three'],
+    };
+
+    const store = {
+      abcd: _.assign({}, _.assign({}, _.omit(result, 'simpleArray')), { simpleArray: result.simpleArray }) as StoreObject,
+    } as Store;
+
+    const queryResult = readFragmentFromStore({
+      store,
+      fragment: `
+        fragment FragmentName on Item {
+          stringField,
+          numberField,
+          simpleArray
+        }
+      `,
+      rootId: 'abcd',
+    });
+
+    // The result of the query shouldn't contain __data_id fields
+    assert.deepEqual(queryResult, {
+      stringField: 'This is a string!',
+      numberField: 5,
+      simpleArray: [null, 'two', 'three'],
+    });
+  });
 });

--- a/test/writeToStore.ts
+++ b/test/writeToStore.ts
@@ -353,6 +353,76 @@ describe('writing to the store', () => {
     });
   });
 
+  it('properly normalizes an array of non-objects', () => {
+    const fragment = `
+      fragment Item on ItemType {
+        id,
+        stringField,
+        numberField,
+        nullField,
+        simpleArray
+      }
+    `;
+
+    const result = {
+      id: 'abcd',
+      stringField: 'This is a string!',
+      numberField: 5,
+      nullField: null,
+      simpleArray: ['one', 'two', 'three'],
+    };
+
+    const normalized = writeFragmentToStore({
+      fragment,
+      result: _.cloneDeep(result),
+    });
+
+    assertEqualSansDataId(normalized, {
+      [result.id]: _.assign({}, _.assign({}, _.omit(result, 'simpleArray')), {
+        simpleArray: [
+          result.simpleArray[0],
+          result.simpleArray[1],
+          result.simpleArray[2],
+        ],
+      }),
+    });
+  });
+
+  it('properly normalizes an array of non-objects with null', () => {
+    const fragment = `
+      fragment Item on ItemType {
+        id,
+        stringField,
+        numberField,
+        nullField,
+        simpleArray
+      }
+    `;
+
+    const result = {
+      id: 'abcd',
+      stringField: 'This is a string!',
+      numberField: 5,
+      nullField: null,
+      simpleArray: [null, 'two', 'three'],
+    };
+
+    const normalized = writeFragmentToStore({
+      fragment,
+      result: _.cloneDeep(result),
+    });
+
+    assertEqualSansDataId(normalized, {
+      [result.id]: _.assign({}, _.assign({}, _.omit(result, 'simpleArray')), {
+        simpleArray: [
+          result.simpleArray[0],
+          result.simpleArray[1],
+          result.simpleArray[2],
+        ],
+      }),
+    });
+  });
+
   it('merges nodes', () => {
     const fragment = `
       fragment Item on ItemType {


### PR DESCRIPTION
Since lists from GraphQL should be of the same type, this basically just places the array in the store as is if the first non-null item in the array is a scalar.

Does this make sense, or do we want to try to denormalize it? That looks like it will be a little messier, as the GraphQL parser doesn't treat arrays of scalars that way.