### PR TITLE
[WIP] Support for null values returned from lists

### DIFF
--- a/src/writeToStore.ts
+++ b/src/writeToStore.ts
@@ -188,12 +188,19 @@ function writeFieldToStore({
 
         thisIdList.push(clonedItem['__data_id']);
 
-        writeSelectionSetToStore({
-          result: clonedItem,
-          store,
-          selectionSet: field.selectionSet,
-          variables,
-        });
+        if (isNull(item)) {
+          writeNullValueToStore({
+            dataId: clonedItem['__data_id'],
+            store,
+          });
+        } else {
+          writeSelectionSetToStore({
+            result: clonedItem,
+            store,
+            selectionSet: field.selectionSet,
+            variables,
+          });
+        }
       });
 
       storeValue = thisIdList;
@@ -225,6 +232,16 @@ function writeFieldToStore({
   }) as StoreObject;
 
   store[dataId] = newStoreObj;
+}
+
+function writeNullValueToStore({
+  store,
+  dataId,
+}: {
+  store: Store,
+  dataId: string,
+}) {
+  store[dataId] = null;
 }
 
 function isField(selection: Selection): selection is Field {

--- a/test/writeToStore.ts
+++ b/test/writeToStore.ts
@@ -353,6 +353,53 @@ describe('writing to the store', () => {
     });
   });
 
+  it('properly normalizes a nested array without IDs and a null item', () => {
+    const fragment = `
+      fragment Item on ItemType {
+        id,
+        stringField,
+        numberField,
+        nullField,
+        nestedArray {
+          stringField,
+          numberField,
+          nullField
+        }
+      }
+    `;
+
+    const result = {
+      id: 'abcd',
+      stringField: 'This is a string!',
+      numberField: 5,
+      nullField: null,
+      nestedArray: [
+        null,
+        {
+          stringField: 'This is a string also!',
+          numberField: 7,
+          nullField: null,
+        },
+      ],
+    };
+
+    const normalized = writeFragmentToStore({
+      fragment,
+      result: _.cloneDeep(result),
+    });
+
+    assertEqualSansDataId(normalized, {
+      [result.id]: _.assign({}, _.assign({}, _.omit(result, 'nestedArray')), {
+        nestedArray: [
+          `${result.id}.nestedArray.0`,
+          `${result.id}.nestedArray.1`,
+        ],
+      }),
+      [`${result.id}.nestedArray.0`]: result.nestedArray[0],
+      [`${result.id}.nestedArray.1`]: result.nestedArray[1],
+    });
+  });
+
   it('properly normalizes an array of non-objects', () => {
     const fragment = `
       fragment Item on ItemType {


### PR DESCRIPTION
Just wanted to make sure we all liked this path (per #65). Pretty straightforward, but I do want to add some more tests and clean up.

Basically, if an item in the array of objects is null, the store is populated like this:

```
{ abcd: 
   { id: 'abcd',
     nestedArray: [ 'abcd.nestedArray.0', 'abcd.nestedArray.1' ] },
  'abcd.nestedArray.0': null,
  'abcd.nestedArray.1': 
   { stringField: 'This is a string also!',
     numberField: 7,
     nullField: null } }
```

Thoughts?