### PR TITLE
Run Travis / Appveyor on latest Node LTS / stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - "5.1"
-  - "4.2"
+  - "5"
+  - "4"
 install:
   - npm install -g coveralls
   - npm install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,8 @@
 environment:
   matrix:
     # node.js
-    - nodejs_version: "5.1"
-    - nodejs_version: "4.2"
+    - nodejs_version: "5"
+    - nodejs_version: "4"
 
 # Install scripts. (runs after repo cloning)
 install:


### PR DESCRIPTION
This PR updates Travis and Appveyor to always run on the latest versions of both LTS and stable. Since Travis uses `nvm` (also see https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Choosing-Node-versions-to-test-against), we can just use `4` to load the latest LTS version (which will be the 4.x series until the next LTS is released) and `5` to run the latest stable version (which is currently 5.x). See also https://raw.githubusercontent.com/nodejs/LTS/master/schedule.png. I believe Appveyor follows the same semantics (https://www.appveyor.com/docs/lang/nodejs-iojs#selecting-node-js-or-io-js-version).