### PR TITLE
Refactor apollo data in to top level key

### DIFF
--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -42,6 +42,7 @@ import {
 export class QueryManager {
   private networkInterface: NetworkInterface;
   private store: ApolloStore;
+  private apolloRootKey: string;
 
   private resultCallbacks: { [queryId: number]: QueryResultCallback[] };
 
@@ -50,19 +51,22 @@ export class QueryManager {
   constructor({
     networkInterface,
     store,
+    apolloRootKey,
   }: {
     networkInterface: NetworkInterface,
     store: ApolloStore,
+    apolloRootKey?: string,
   }) {
     // XXX this might be the place to do introspection for inserting the `id` into the query? or
     // is that the network interface?
     this.networkInterface = networkInterface;
     this.store = store;
+    this.apolloRootKey = apolloRootKey ? apolloRootKey : 'apollo';
 
     this.resultCallbacks = {};
 
     this.store.subscribe(() => {
-      this.broadcastNewStore(this.store.getState());
+      this.broadcastNewStore(this.store.getState()[this.apolloRootKey]);
     });
   }
 
@@ -143,7 +147,7 @@ export class QueryManager {
       // what data is missing from the store
       const { missingSelectionSets, result } = diffSelectionSetAgainstStore({
         selectionSet: querySS.selectionSet,
-        store: this.store.getState().data,
+        store: this.store.getState()[this.apolloRootKey].data,
         throwOnMissingField: false,
         rootId: querySS.id,
         variables,
@@ -246,7 +250,7 @@ export class QueryManager {
 
   public watchQueryInStore(queryId: string): WatchedQueryHandle {
     const isStopped = () => {
-      return !this.store.getState().queries[queryId];
+      return !this.store.getState()[this.apolloRootKey].queries[queryId];
     };
 
     return {

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -42,7 +42,7 @@ import {
 export class QueryManager {
   private networkInterface: NetworkInterface;
   private store: ApolloStore;
-  private apolloRootKey: string;
+  private reduxRootKey: string;
 
   private resultCallbacks: { [queryId: number]: QueryResultCallback[] };
 
@@ -51,22 +51,22 @@ export class QueryManager {
   constructor({
     networkInterface,
     store,
-    apolloRootKey,
+    reduxRootKey,
   }: {
     networkInterface: NetworkInterface,
     store: ApolloStore,
-    apolloRootKey?: string,
+    reduxRootKey?: string,
   }) {
     // XXX this might be the place to do introspection for inserting the `id` into the query? or
     // is that the network interface?
     this.networkInterface = networkInterface;
     this.store = store;
-    this.apolloRootKey = apolloRootKey ? apolloRootKey : 'apollo';
+    this.reduxRootKey = reduxRootKey ? reduxRootKey : 'apollo';
 
     this.resultCallbacks = {};
 
     this.store.subscribe(() => {
-      this.broadcastNewStore(this.store.getState()[this.apolloRootKey]);
+      this.broadcastNewStore(this.store.getState()[this.reduxRootKey]);
     });
   }
 
@@ -147,7 +147,7 @@ export class QueryManager {
       // what data is missing from the store
       const { missingSelectionSets, result } = diffSelectionSetAgainstStore({
         selectionSet: querySS.selectionSet,
-        store: this.store.getState()[this.apolloRootKey].data,
+        store: this.store.getState()[this.reduxRootKey].data,
         throwOnMissingField: false,
         rootId: querySS.id,
         variables,
@@ -250,7 +250,7 @@ export class QueryManager {
 
   public watchQueryInStore(queryId: string): WatchedQueryHandle {
     const isStopped = () => {
-      return !this.store.getState()[this.apolloRootKey].queries[queryId];
+      return !this.store.getState()[this.reduxRootKey].queries[queryId];
     };
 
     return {

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -55,13 +55,13 @@ export class QueryManager {
   }: {
     networkInterface: NetworkInterface,
     store: ApolloStore,
-    reduxRootKey?: string,
+    reduxRootKey: string,
   }) {
     // XXX this might be the place to do introspection for inserting the `id` into the query? or
     // is that the network interface?
     this.networkInterface = networkInterface;
     this.store = store;
-    this.reduxRootKey = reduxRootKey ? reduxRootKey : 'apollo';
+    this.reduxRootKey = reduxRootKey;
 
     this.resultCallbacks = {};
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,40 +25,40 @@ import {
 
 export class ApolloClient {
   public networkInterface: NetworkInterface;
-  public apolloStore: ApolloStore;
-  public apolloRootKey: string;
+  public store: ApolloStore;
+  public reduxRootKey: string;
   public queryManager: QueryManager;
 
   constructor({
     networkInterface,
-    apolloStore,
-    apolloRootKey,
+    store,
+    reduxRootKey,
   }: {
     networkInterface?: NetworkInterface,
-    apolloStore?: ApolloStore,
-    apolloRootKey?: string,
+    store?: ApolloStore,
+    reduxRootKey?: string,
   } = {}) {
-    this.apolloRootKey = apolloRootKey ? apolloRootKey : 'apollo';
+    this.reduxRootKey = reduxRootKey ? reduxRootKey : 'apollo';
 
     this.networkInterface = networkInterface ? networkInterface :
       createNetworkInterface('/graphql');
 
     // ensure existing store has apolloReducer
-    if (apolloStore &&
-       isUndefined(apolloStore.getState()[this.apolloRootKey])) {
+    if (store &&
+       isUndefined(store.getState()[this.reduxRootKey])) {
       throw new Error(
-        `Existing store does not use apolloReducer for ${this.apolloRootKey}`
+        `Existing store does not use apolloReducer for ${this.reduxRootKey}`
       );
     }
 
-    this.apolloStore = apolloStore ?
-      apolloStore :
-      createApolloStore(this.apolloRootKey);
+    this.store = store ?
+      store :
+      createApolloStore(this.reduxRootKey);
 
     this.queryManager = new QueryManager({
       networkInterface: this.networkInterface,
-      store: this.apolloStore,
-      apolloRootKey: this.apolloRootKey,
+      store: this.store,
+      reduxRootKey: this.reduxRootKey,
     });
   }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -2,6 +2,7 @@ import {
   createStore,
   compose,
   applyMiddleware,
+  combineReducers,
 } from 'redux';
 
 import {
@@ -59,7 +60,7 @@ export function apolloReducer(state = {} as Store, action: ApolloAction) {
   return newState;
 }
 
-export function createApolloStore(): ApolloStore {
+export function createApolloStore(apolloRootKey: string = 'apollo'): ApolloStore {
   const enhancers = [];
 
   if (typeof window !== 'undefined') {
@@ -71,5 +72,8 @@ export function createApolloStore(): ApolloStore {
 
   enhancers.push(applyMiddleware(crashReporter));
 
-  return createStore(apolloReducer, compose(...enhancers));
+  return createStore(
+    combineReducers({ [apolloRootKey]: apolloReducer }),
+    compose(...enhancers)
+  );
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -60,7 +60,7 @@ export function apolloReducer(state = {} as Store, action: ApolloAction) {
   return newState;
 }
 
-export function createApolloStore(apolloRootKey: string = 'apollo'): ApolloStore {
+export function createApolloStore(reduxRootKey: string = 'apollo'): ApolloStore {
   const enhancers = [];
 
   if (typeof window !== 'undefined') {
@@ -73,7 +73,7 @@ export function createApolloStore(apolloRootKey: string = 'apollo'): ApolloStore
   enhancers.push(applyMiddleware(crashReporter));
 
   return createStore(
-    combineReducers({ [apolloRootKey]: apolloReducer }),
+    combineReducers({ [reduxRootKey]: apolloReducer }),
     compose(...enhancers)
   );
 }

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -57,6 +57,7 @@ describe('QueryManager', () => {
     const queryManager = new QueryManager({
       networkInterface,
       store: createApolloStore(),
+      reduxRootKey: 'apollo',
     });
 
     const handle = queryManager.watchQuery({
@@ -104,6 +105,7 @@ describe('QueryManager', () => {
     const queryManager = new QueryManager({
       networkInterface,
       store: createApolloStore(),
+      reduxRootKey: 'apollo',
     });
 
     const handle = queryManager.watchQuery({
@@ -145,6 +147,7 @@ describe('QueryManager', () => {
     const queryManager = new QueryManager({
       networkInterface,
       store: createApolloStore(),
+      reduxRootKey: 'apollo',
     });
 
     const handle = queryManager.watchQuery({
@@ -178,6 +181,7 @@ describe('QueryManager', () => {
     const queryManager = new QueryManager({
       networkInterface,
       store: createApolloStore(),
+      reduxRootKey: 'apollo',
     });
 
     return queryManager.mutate({
@@ -212,6 +216,7 @@ describe('QueryManager', () => {
     const queryManager = new QueryManager({
       networkInterface,
       store: createApolloStore(),
+      reduxRootKey: 'apollo',
     });
 
     return queryManager.mutate({
@@ -251,6 +256,7 @@ describe('QueryManager', () => {
     const queryManager = new QueryManager({
       networkInterface,
       store,
+      reduxRootKey: 'apollo',
     });
 
     return queryManager.mutate({
@@ -292,6 +298,7 @@ describe('QueryManager', () => {
     const queryManager = new QueryManager({
       networkInterface,
       store,
+      reduxRootKey: 'apollo',
     });
 
     return queryManager.mutate({
@@ -485,6 +492,7 @@ describe('QueryManager', () => {
     const queryManager = new QueryManager({
       networkInterface,
       store: createApolloStore(),
+      reduxRootKey: 'apollo',
     });
 
     const handle1 = queryManager.watchQuery({
@@ -569,6 +577,7 @@ describe('QueryManager', () => {
     const queryManager = new QueryManager({
       networkInterface,
       store: createApolloStore(),
+      reduxRootKey: 'apollo',
     });
 
     let handle1Count = 0;
@@ -685,6 +694,7 @@ function testDiffing(
   const queryManager = new QueryManager({
     networkInterface,
     store: createApolloStore(),
+    reduxRootKey: 'apollo',
   });
 
   const steps = queryArray.map(({ query, fullResponse, variables }) => {

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -259,7 +259,7 @@ describe('QueryManager', () => {
       assert.deepEqual(result.data, data);
 
       // Make sure we updated the store with the new data
-      assert.deepEqual(store.getState().data['5'], { id: '5', isPrivate: true });
+      assert.deepEqual(store.getState()['apollo'].data['5'], { id: '5', isPrivate: true });
     });
   });
 
@@ -300,7 +300,50 @@ describe('QueryManager', () => {
       assert.deepEqual(result.data, data);
 
       // Make sure we updated the store with the new data
-      assert.deepEqual(store.getState().data['5'], { id: '5', isPrivate: true });
+      assert.deepEqual(store.getState()['apollo'].data['5'], { id: '5', isPrivate: true });
+    });
+  });
+
+  it('runs a mutation and puts the result in the store with root key', () => {
+    const mutation = `
+      mutation makeListPrivate {
+        makeListPrivate(id: "5") {
+          id,
+          isPrivate,
+        }
+      }
+    `;
+
+    const data = {
+      makeListPrivate: {
+        id: '5',
+        isPrivate: true,
+      },
+    };
+
+    const networkInterface = mockNetworkInterface([
+      {
+        request: { query: mutation },
+        result: { data },
+      },
+    ]);
+
+    const apolloRootKey = 'test';
+    const store = createApolloStore(apolloRootKey);
+
+    const queryManager = new QueryManager({
+      networkInterface,
+      store,
+      apolloRootKey,
+    });
+
+    return queryManager.mutate({
+      mutation,
+    }).then((result) => {
+      assert.deepEqual(result.data, data);
+
+      // Make sure we updated the store with the new data
+      assert.deepEqual(store.getState()[apolloRootKey].data['5'], { id: '5', isPrivate: true });
     });
   });
 

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -328,13 +328,13 @@ describe('QueryManager', () => {
       },
     ]);
 
-    const apolloRootKey = 'test';
-    const store = createApolloStore(apolloRootKey);
+    const reduxRootKey = 'test';
+    const store = createApolloStore(reduxRootKey);
 
     const queryManager = new QueryManager({
       networkInterface,
       store,
-      apolloRootKey,
+      reduxRootKey,
     });
 
     return queryManager.mutate({
@@ -343,7 +343,7 @@ describe('QueryManager', () => {
       assert.deepEqual(result.data, data);
 
       // Make sure we updated the store with the new data
-      assert.deepEqual(store.getState()[apolloRootKey].data['5'], { id: '5', isPrivate: true });
+      assert.deepEqual(store.getState()[reduxRootKey].data['5'], { id: '5', isPrivate: true });
     });
   });
 

--- a/test/client.ts
+++ b/test/client.ts
@@ -13,16 +13,18 @@ import {
 } from 'graphql';
 
 import {
-  rootReducer,
+  rootReducer as todosReducer,
 } from './fixtures/redux-todomvc';
 
 import {
   Store,
+  apolloReducer,
 } from '../src/store';
 
 import {
   createStore,
   Store as ReduxStore,
+  combineReducers,
 } from 'redux';
 
 import {
@@ -52,13 +54,74 @@ describe('client', () => {
   });
 
   it('can allow passing in a store', () => {
-    const apolloStore: ReduxStore = createStore(rootReducer);
+    const apolloStore: ReduxStore = createStore(
+      combineReducers({
+        todos: todosReducer,
+        apollo: apolloReducer,
+      })
+    );
 
     const client = new ApolloClient({
       apolloStore,
     });
 
     assert.deepEqual(client.apolloStore.getState(), apolloStore.getState());
+  });
+
+  it('throws an error if you pass in a store without apolloReducer', () => {
+    const apolloStore: ReduxStore = createStore(
+      combineReducers({
+        todos: todosReducer,
+      })
+    );
+
+    try {
+      /* tslint:disable */
+      new ApolloClient({
+        apolloStore,
+      });
+      /* tslint:enable */
+      assert.fail();
+    } catch (error) {
+      assert.equal(
+        error.message,
+        'Existing store does not use apolloReducer for apollo'
+      );
+    }
+
+  });
+
+  it('has a top level key by default', () => {
+    const client = new ApolloClient();
+
+    assert.deepEqual(
+      client.apolloStore.getState(),
+      {
+        apollo: {
+          queries: {},
+          mutations: {},
+          data: {},
+        },
+      }
+    );
+  });
+
+  it('can allow passing in a top level key', () => {
+    const apolloRootKey = 'test';
+    const client = new ApolloClient({
+      apolloRootKey,
+    });
+
+    assert.deepEqual(
+      client.apolloStore.getState(),
+      {
+        [apolloRootKey]: {
+          queries: {},
+          mutations: {},
+          data: {},
+        },
+      }
+    );
   });
 
   it('should allow for a single query to take place', (done) => {
@@ -99,6 +162,137 @@ describe('client', () => {
        });
   });
 
+  it('should allow for a single query with existing store', (done) => {
+    const apolloStore: ReduxStore = createStore(
+      combineReducers({
+        todos: todosReducer,
+        apollo: apolloReducer,
+      })
+    );
+
+    const query = `
+      query people {
+        allPeople(first: 1) {
+          people {
+            name
+          }
+        }
+      }
+    `;
+
+    const data = {
+      allPeople: {
+        people: [
+          {
+            name: 'Luke Skywalker',
+          },
+        ],
+      },
+    };
+
+    const networkInterface = mockNetworkInterface({
+      request: { query },
+      result: { data },
+    });
+
+    const client = new ApolloClient({
+      apolloStore,
+      networkInterface,
+    });
+
+    return client.query({ query })
+      .then((result) => {
+        assert.deepEqual(result, { data });
+        done();
+       });
+  });
+
+  it('can allow a custom top level key', (done) => {
+
+    const query = `
+      query people {
+        allPeople(first: 1) {
+          people {
+            name
+          }
+        }
+      }
+    `;
+
+    const data = {
+      allPeople: {
+        people: [
+          {
+            name: 'Luke Skywalker',
+          },
+        ],
+      },
+    };
+
+    const networkInterface = mockNetworkInterface({
+      request: { query },
+      result: { data },
+    });
+
+    const apolloRootKey = 'test';
+    const client = new ApolloClient({
+      networkInterface,
+      apolloRootKey,
+    });
+
+    return client.query({ query })
+      .then((result) => {
+        assert.deepEqual(result, { data });
+        done();
+       });
+  });
+
+  it('allows for a single query with existing store and custom key', (done) => {
+    const apolloRootKey = 'test';
+    const apolloStore: ReduxStore = createStore(
+      combineReducers({
+        todos: todosReducer,
+        [apolloRootKey]: apolloReducer,
+      })
+    );
+
+    const query = `
+      query people {
+        allPeople(first: 1) {
+          people {
+            name
+          }
+        }
+      }
+    `;
+
+    const data = {
+      allPeople: {
+        people: [
+          {
+            name: 'Luke Skywalker',
+          },
+        ],
+      },
+    };
+
+    const networkInterface = mockNetworkInterface({
+      request: { query },
+      result: { data },
+    });
+
+    const client = new ApolloClient({
+      apolloStore,
+      apolloRootKey,
+      networkInterface,
+    });
+
+    return client.query({ query })
+      .then((result) => {
+        assert.deepEqual(result, { data });
+        done();
+       });
+  });
   it('should return errors correctly for a single query', (done) => {
 
     const query = `

--- a/test/client.ts
+++ b/test/client.ts
@@ -41,7 +41,7 @@ chai.use(chaiAsPromised);
 describe('client', () => {
   it('does not require any arugments', () => {
     const client = new ApolloClient();
-    assert.isDefined(client.apolloStore);
+    assert.isDefined(client.store);
   });
 
   it('can allow passing in a network interface', () => {
@@ -54,7 +54,7 @@ describe('client', () => {
   });
 
   it('can allow passing in a store', () => {
-    const apolloStore: ReduxStore = createStore(
+    const store: ReduxStore = createStore(
       combineReducers({
         todos: todosReducer,
         apollo: apolloReducer,
@@ -62,14 +62,14 @@ describe('client', () => {
     );
 
     const client = new ApolloClient({
-      apolloStore,
+      store,
     });
 
-    assert.deepEqual(client.apolloStore.getState(), apolloStore.getState());
+    assert.deepEqual(client.store.getState(), store.getState());
   });
 
   it('throws an error if you pass in a store without apolloReducer', () => {
-    const apolloStore: ReduxStore = createStore(
+    const store: ReduxStore = createStore(
       combineReducers({
         todos: todosReducer,
       })
@@ -78,7 +78,7 @@ describe('client', () => {
     try {
       /* tslint:disable */
       new ApolloClient({
-        apolloStore,
+        store,
       });
       /* tslint:enable */
       assert.fail();
@@ -95,7 +95,7 @@ describe('client', () => {
     const client = new ApolloClient();
 
     assert.deepEqual(
-      client.apolloStore.getState(),
+      client.store.getState(),
       {
         apollo: {
           queries: {},
@@ -107,15 +107,15 @@ describe('client', () => {
   });
 
   it('can allow passing in a top level key', () => {
-    const apolloRootKey = 'test';
+    const reduxRootKey = 'test';
     const client = new ApolloClient({
-      apolloRootKey,
+      reduxRootKey,
     });
 
     assert.deepEqual(
-      client.apolloStore.getState(),
+      client.store.getState(),
       {
-        [apolloRootKey]: {
+        [reduxRootKey]: {
           queries: {},
           mutations: {},
           data: {},
@@ -163,7 +163,7 @@ describe('client', () => {
   });
 
   it('should allow for a single query with existing store', (done) => {
-    const apolloStore: ReduxStore = createStore(
+    const store: ReduxStore = createStore(
       combineReducers({
         todos: todosReducer,
         apollo: apolloReducer,
@@ -196,7 +196,7 @@ describe('client', () => {
     });
 
     const client = new ApolloClient({
-      apolloStore,
+      store,
       networkInterface,
     });
 
@@ -234,10 +234,10 @@ describe('client', () => {
       result: { data },
     });
 
-    const apolloRootKey = 'test';
+    const reduxRootKey = 'test';
     const client = new ApolloClient({
       networkInterface,
-      apolloRootKey,
+      reduxRootKey,
     });
 
     return client.query({ query })
@@ -248,11 +248,11 @@ describe('client', () => {
   });
 
   it('allows for a single query with existing store and custom key', (done) => {
-    const apolloRootKey = 'test';
-    const apolloStore: ReduxStore = createStore(
+    const reduxRootKey = 'test';
+    const store: ReduxStore = createStore(
       combineReducers({
         todos: todosReducer,
-        [apolloRootKey]: apolloReducer,
+        [reduxRootKey]: apolloReducer,
       })
     );
 
@@ -282,8 +282,8 @@ describe('client', () => {
     });
 
     const client = new ApolloClient({
-      apolloStore,
-      apolloRootKey,
+      store,
+      reduxRootKey,
       networkInterface,
     });
 

--- a/test/store.ts
+++ b/test/store.ts
@@ -1,0 +1,37 @@
+import * as chai from 'chai';
+const { assert } = chai;
+
+import {
+  createApolloStore,
+} from '../src/store';
+
+describe('createApolloStore', () => {
+  it('does not require any arguments', () => {
+    const store = createApolloStore();
+    assert.isDefined(store);
+  });
+
+  it('has a default root key', () => {
+    const store = createApolloStore();
+    assert.deepEqual(
+      store.getState()['apollo'],
+      {
+        queries: {},
+        mutations: {},
+        data: {},
+      }
+    );
+  });
+
+  it('can take a custom root key', () => {
+    const store = createApolloStore('test');
+    assert.deepEqual(
+      store.getState()['test'],
+      {
+        queries: {},
+        mutations: {},
+        data: {},
+      }
+    );
+  });
+});

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -12,3 +12,4 @@ import './networkInterface';
 import './QueryManager';
 import './client';
 import './middleware';
+import './store';


### PR DESCRIPTION
This brings all of the apollo data in redux under one key. It defaults to `apollo`, but gives the option to supply your own key (with or without an existing store). It also adds some tests and warnings for using an existing store.

With regards to using an existing store, here were my thoughts. We may be on the same page here, but just wanted to get it written down :smile_cat: 

It doesn't seem like best practice, or like redux really wants you to, dynamically add reducers to an existing store unless using the `replaceReducer` function. Using `replaceReducer` requires you to have all of the other reducers in the store handy, then doing a `combineReducers`, and passing that to `existingStore.replaceReducers(newlyCombinedReducers)`.

It feels dirty to have people passing all their reducers to `new ApolloClient` and then getting back a store. So, this PR assumes consumers of apollo-client will take care of `apolloReducer` themselves:

```javascript
import { createStore, combineReducers } from 'redux';
import { ApolloClient, apolloReducer } from 'apollo-client';
import { todoReducer, userReducer } from './reducers';

const store = createStore(
  combineReducers({
    todos: todoReducer,
    users: userReducer,
    apollo: apolloReducer,
  })
});

const client = new ApolloClient({
  apolloStore: store,
});
```

Or, if you wanted to use a different key:

```javascript
const store = createStore(
  combineReducers({
    todos: todoReducer,
    users: userReducer,
    heighliner: apolloReducer,
  })
});

const client = new ApolloClient({
  apolloStore: store,
  apolloRootKey: 'heighliner',
});
```

Thoughts? Thanks!