### PR TITLE
[WIP] Error handling and Observable support

### DIFF
--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -44,7 +44,7 @@ export class QueryManager {
   private store: ApolloStore;
   private reduxRootKey: string;
 
-  private resultCallbacks: { [queryId: number]: QueryResultCallback[] };
+  private observers: { [queryId: number]: QueryObserver[] };
 
   private idCounter = 0;
 
@@ -63,7 +63,7 @@ export class QueryManager {
     this.store = store;
     this.reduxRootKey = reduxRootKey;
 
-    this.resultCallbacks = {};
+    this.observers = {};
 
     this.store.subscribe(() => {
       this.broadcastNewStore(this.store.getState()[this.reduxRootKey]);
@@ -123,7 +123,7 @@ export class QueryManager {
     this.idCounter++;
 
 
-    this.resultCallbacks[queryId] = [];
+    this.observers[queryId] = [];
 
     const queryString = query;
 
@@ -199,7 +199,7 @@ export class QueryManager {
             queryId,
           });
         }).catch((error: Error) => {
-           // XXX handle errors
+          this.broadcastQueryError(queryId, error);
         });
     }
 
@@ -259,10 +259,20 @@ export class QueryManager {
       stop: () => {
         this.stopQuery(queryId);
       },
+      subscribe: (observer: QueryObserver) => {
+        if (isStopped()) { throw new Error('Query was stopped. Please create a new one.'); }
+
+        this.registerObserver(queryId, observer);
+      },
       onResult: (callback) => {
         if (isStopped()) { throw new Error('Query was stopped. Please create a new one.'); }
 
-        this.registerResultCallback(queryId, callback);
+        const observer = {
+          onResult: callback,
+          onError: () => { return; },
+        };
+
+        this.registerObserver(queryId, observer);
       },
     };
   }
@@ -273,17 +283,23 @@ export class QueryManager {
       queryId,
     });
 
-    delete this.resultCallbacks[queryId];
+    delete this.observers[queryId];
   }
 
   private broadcastQueryChange(queryId: string, result: GraphQLResult) {
-    this.resultCallbacks[queryId].forEach((callback) => {
-      callback(result);
+    this.observers[queryId].forEach((observer) => {
+      observer.onResult(result);
     });
   }
 
-  private registerResultCallback(queryId: string, callback: QueryResultCallback): void {
-    this.resultCallbacks[queryId].push(callback);
+  private broadcastQueryError(queryId: string, error: Error) {
+    this.observers[queryId].forEach((observer) => {
+      observer.onError(error);
+    });
+  }
+
+  private registerObserver(queryId: string, observer: QueryObserver): void {
+    this.observers[queryId].push(observer);
   }
 }
 
@@ -291,10 +307,17 @@ export interface WatchedQueryHandle {
   id: string;
   isStopped: () => boolean;
   stop();
+  subscribe(observer: QueryObserver);
   onResult(callback: QueryResultCallback);
 }
 
 export type QueryResultCallback = (result: GraphQLResult) => void;
+
+export interface QueryObserver {
+  onResult: (result: GraphQLResult) => void;
+  onError: (error: Error) => void;
+  onStop?: () => void;
+}
 
 export interface WatchQueryOptions {
   query: string;

--- a/src/data/store.ts
+++ b/src/data/store.ts
@@ -45,6 +45,8 @@ export function data(
       // XXX use immutablejs instead of cloning
       const clonedState = assign({}, previousState) as NormalizedCache;
 
+      // XXX A query result will only be from minimizedQuery on the first fetch,
+      // but we'll want to fetch the complete query on a refetch
       const newState = writeSelectionSetToStore({
         result: action.result.data,
         dataId: queryStoreValue.minimizedQuery.id,

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,9 +14,10 @@ import {
 
 import {
   QueryManager,
-  WatchedQueryHandle,
   WatchQueryOptions,
 } from './QueryManager';
+
+import ObservableQuery from './queries/ObservableQuery';
 
 import {
   isUndefined,
@@ -62,23 +63,12 @@ export default class ApolloClient {
     });
   }
 
-  public watchQuery(options: WatchQueryOptions): WatchedQueryHandle {
+  public watchQuery(options: WatchQueryOptions): ObservableQuery {
     return this.queryManager.watchQuery(options);
   }
 
-  public query(options: WatchQueryOptions): Promise<GraphQLResult | Error> {
-    if (options.returnPartialData) {
-      throw new Error('returnPartialData option only supported on watchQuery.');
-    }
-
-    return new Promise((resolve, reject) => {
-      const handle = this.queryManager.watchQuery(options);
-      handle.onResult((result) => {
-        resolve(result);
-        // remove the listeners
-        handle.stop();
-      });
-    });
+  public query(options: WatchQueryOptions): Promise<GraphQLResult> {
+    return this.queryManager.query(options);
   }
 
   public mutate(options: {

--- a/src/queries/ObservableQuery.ts
+++ b/src/queries/ObservableQuery.ts
@@ -1,0 +1,105 @@
+import {
+  GraphQLResult,
+  GraphQLError,
+} from 'graphql';
+
+import {
+  pull,
+} from 'lodash';
+
+import {
+  Observable,
+  Observer,
+  Subscription
+} from './observable';
+
+import {
+  SelectionSetWithRoot,
+} from './store';
+
+import {
+  QueryManager,
+  WatchQueryOptions
+} from '../QueryManager';
+
+export type QueryObserver = Observer<GraphQLResult>;
+
+export default class ObservableQuery implements Observable<GraphQLResult> {
+  public queryManager: QueryManager;
+  public queryId: string;
+  public selectionSetWithRoot: SelectionSetWithRoot;
+  public options: WatchQueryOptions;
+  public isLoading: boolean = true;
+  public lastResult: GraphQLResult
+
+  private observers: QueryObserver[];
+
+  constructor(queryManager: QueryManager, queryId: string, options: WatchQueryOptions) {
+    this.queryManager = queryManager;
+    this.queryId = queryId;
+    this.options = options;
+    this.observers = [];
+  }
+
+  subscribe(observer: QueryObserver): Subscription {
+    this.observers.push(observer);
+
+    if (this.observers.length == 1) {
+      this.queryManager.registerObservedQuery(this);
+    }
+
+    /// XXX Don't refetch for every new subscriber
+    this.refetch();
+
+    return {
+      unsubscribe: () => {
+        pull(this.observers, observer);
+
+        if (this.observers.length < 1) {
+          this.queryManager.deregisterObservedQuery(this);
+        }
+      },
+    };
+  }
+
+  result(): Promise<GraphQLResult> {
+    return new Promise((resolve, reject) => {
+      const subscription = this.subscribe({
+        next(result) {
+          resolve(result);
+          setTimeout(() => {
+            subscription.unsubscribe();
+          }, 0);
+        },
+        error(error) {
+          reject(error);
+        },
+      });
+    });
+  }
+
+  // Temporary workaround for backwards compatibility
+  onResult(callback: (result: GraphQLResult) => void) {
+    const observer = {
+      next: callback,
+      error: () => { return; },
+    };
+    this.subscribe(observer);
+  }
+
+  refetch() {
+    this.queryManager.fetchQuery(this);
+  }
+
+  didReceiveResult(result: GraphQLResult) {
+    this.observers.forEach((observer) => {
+      observer.next(result);
+    });
+  }
+
+  didReceiveError(error: Error) {
+    this.observers.forEach((observer) => {
+      observer.error(error);
+    });
+  }
+}

--- a/src/queries/observable.ts
+++ b/src/queries/observable.ts
@@ -1,0 +1,16 @@
+// Observable<T> and Observer<T> follow the current version of the ECMAScript proposal.
+// See https://github.com/zenparsing/es-observable
+
+export interface Observable<T> {
+  subscribe(observer: Observer<T>): Subscription
+}
+
+export interface Observer<T> {
+  next?: (value: T) => void;
+  error?: (error: Error) => void;
+  complete?: () => void;
+}
+
+export interface Subscription {
+  unsubscribe: () => void
+}

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -175,15 +175,15 @@ describe('QueryManager', () => {
       reduxRootKey: 'apollo',
     });
 
-    const handle = queryManager.watchQuery({
+    const observableQuery = queryManager.watchQuery({
       query,
     });
 
-    handle.subscribe({
-      onResult: (result) => {
+    observableQuery.subscribe({
+      next(result) {
         done(new Error('Should not deliver result'));
       },
-      onError: (error) => {
+      error(error) {
         assert.equal(error.message, 'Network error');
         done();
       },
@@ -681,15 +681,12 @@ function testDiffing(
 
   const steps = queryArray.map(({ query, fullResponse, variables }) => {
     return (cb) => {
-      const handle = queryManager.watchQuery({
+      queryManager.query({
         query,
         variables,
         forceFetch: false,
-      });
-
-      handle.onResult((result) => {
+      }).then(result => {
         assert.deepEqual(result.data, fullResponse);
-        handle.stop();
         cb();
       });
     };

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -151,6 +151,45 @@ describe('QueryManager', () => {
     });
   });
 
+  it('handles network errors', (done) => {
+    const query = `
+      query people {
+        allPeople(first: 1) {
+          people {
+            name
+          }
+        }
+      }
+    `;
+
+    const networkInterface = mockNetworkInterface(
+      {
+        request: { query },
+        error: new Error('Network error'),
+      }
+    );
+
+    const queryManager = new QueryManager({
+      networkInterface,
+      store: createApolloStore(),
+      reduxRootKey: 'apollo',
+    });
+
+    const handle = queryManager.watchQuery({
+      query,
+    });
+
+    handle.subscribe({
+      onResult: (result) => {
+        done(new Error('Should not deliver result'));
+      },
+      onError: (error) => {
+        assert.equal(error.message, 'Network error');
+        done();
+      },
+    });
+  });
+
   it('runs a mutation', () => {
     const mutation = `
       mutation makeListPrivate {

--- a/test/client.ts
+++ b/test/client.ts
@@ -4,10 +4,7 @@ const { assert } = chai;
 import ApolloClient from '../src';
 
 import {
-  GraphQLResult,
   GraphQLError,
-  parse,
-  print,
 } from 'graphql';
 
 import {
@@ -28,8 +25,9 @@ import {
 import {
   createNetworkInterface,
   NetworkInterface,
-  Request,
 } from '../src/networkInterface';
+
+import mockNetworkInterface from './mocks/mockNetworkInterface';
 
 import * as chaiAsPromised from 'chai-as-promised';
 
@@ -364,43 +362,4 @@ describe('client', () => {
       done();
     });
   });
-
 });
-
-function mockNetworkInterface(
-  mockedRequest: {
-    request: Request,
-    result: GraphQLResult,
-  }
-) {
-  const requestToResultMap: any = {};
-  const { request, result } = mockedRequest;
-
-  // Populate set of mocked requests
-  requestToResultMap[requestToKey(request)] = result as GraphQLResult;
-
-  // A mock for the query method
-  const queryMock = (req: Request) => {
-    return new Promise((resolve, reject) => {
-      const resultData = requestToResultMap[requestToKey(req)];
-      if (!resultData) {
-        throw new Error(`Passed request that wasn't mocked: ${requestToKey(req)}`);
-      }
-      resolve(resultData);
-    });
-  };
-
-  return {
-    query: queryMock,
-  } as NetworkInterface;
-}
-
-
-function requestToKey(request: Request): string {
-  const query = request.query && print(parse(request.query));
-
-  return JSON.stringify({
-    variables: request.variables,
-    query,
-  });
-}

--- a/test/mocks/mockNetworkInterface.ts
+++ b/test/mocks/mockNetworkInterface.ts
@@ -9,31 +9,34 @@ import {
   print
 } from 'graphql';
 
+// Pass in multiple mocked responses, so that you can test flows that end up
+// making multiple queries to the server
+export default function mockNetworkInterface(
+  ...mockedResponses: MockedResponse[]
+): NetworkInterface { return new MockNetworkInterface(...mockedResponses) as any }
+
 export interface MockedResponse {
   request: Request
   result: GraphQLResult
   delay?: number
 }
 
-// Pass in an array of requests and responses, so that you can test flows that end up making
-// multiple queries to the server
-export default function mockNetworkInterface(
-  ...mockedResponses: MockedResponse[]
-) {
-  const requestToResultMap: any = {};
-  const requestToDelayMap: any = {};
+class MockNetworkInterface {
+  private requestToResultMap: any = {};
+  private requestToDelayMap: any = {};
 
-  // Populate set of mocked requests
-  mockedResponses.forEach(({ request, result, delay }) => {
-    requestToResultMap[requestToKey(request)] = result as GraphQLResult;
-    requestToDelayMap[requestToKey(request)] = delay;
-  });
+  constructor(...mockedResponses: MockedResponse[]) {
+    // Populate set of mocked requests
+    mockedResponses.forEach(({ request, result, delay }) => {
+      this.requestToResultMap[requestToKey(request)] = result as GraphQLResult;
+      this.requestToDelayMap[requestToKey(request)] = delay;
+    });
+  }
 
-  // A mock for the query method
-  const queryMock = (request: Request) => {
+  query(request: Request) {
     return new Promise((resolve, reject) => {
-      const resultData = requestToResultMap[requestToKey(request)];
-      const delay = requestToDelayMap[requestToKey(request)];
+      const resultData = this.requestToResultMap[requestToKey(request)];
+      const delay = this.requestToDelayMap[requestToKey(request)];
 
       if (! resultData) {
         throw new Error(`Passed request that wasn't mocked: ${requestToKey(request)}`);
@@ -43,11 +46,7 @@ export default function mockNetworkInterface(
         resolve(resultData);
       }, delay ? delay : 0);
     });
-  };
-
-  return {
-    query: queryMock,
-  } as NetworkInterface;
+  }
 }
 
 function requestToKey(request: Request): string {

--- a/test/mocks/mockNetworkInterface.ts
+++ b/test/mocks/mockNetworkInterface.ts
@@ -22,28 +22,26 @@ export interface MockedResponse {
 }
 
 class MockNetworkInterface {
-  private requestToResultMap: any = {};
-  private requestToDelayMap: any = {};
+  private mockedResponsesByKey: { [key:string]: MockedResponse } = {};
 
   constructor(...mockedResponses: MockedResponse[]) {
-    // Populate set of mocked requests
-    mockedResponses.forEach(({ request, result, delay }) => {
-      this.requestToResultMap[requestToKey(request)] = result as GraphQLResult;
-      this.requestToDelayMap[requestToKey(request)] = delay;
+    mockedResponses.forEach((mockedResponse) => {
+      const key = requestToKey(mockedResponse.request);
+      this.mockedResponsesByKey[key] = mockedResponse;
     });
   }
 
   query(request: Request) {
     return new Promise((resolve, reject) => {
-      const resultData = this.requestToResultMap[requestToKey(request)];
-      const delay = this.requestToDelayMap[requestToKey(request)];
+      const key = requestToKey(request);
+      const { result, delay } = this.mockedResponsesByKey[key];
 
-      if (! resultData) {
-        throw new Error(`Passed request that wasn't mocked: ${requestToKey(request)}`);
+      if (!result) {
+        throw new Error(`Passed request that wasn't mocked: ${key}`);
       }
 
       setTimeout(() => {
-        resolve(resultData);
+        resolve(result);
       }, delay ? delay : 0);
     });
   }

--- a/test/mocks/mockNetworkInterface.ts
+++ b/test/mocks/mockNetworkInterface.ts
@@ -17,7 +17,8 @@ export default function mockNetworkInterface(
 
 export interface MockedResponse {
   request: Request
-  result: GraphQLResult
+  result?: GraphQLResult
+  error?: Error
   delay?: number
 }
 
@@ -34,14 +35,18 @@ class MockNetworkInterface {
   query(request: Request) {
     return new Promise((resolve, reject) => {
       const key = requestToKey(request);
-      const { result, delay } = this.mockedResponsesByKey[key];
+      const { result, error, delay } = this.mockedResponsesByKey[key];
 
-      if (!result) {
-        throw new Error(`Passed request that wasn't mocked: ${key}`);
+      if (!result && !error) {
+        throw new Error(`Mocked response should contain either result or error: ${key}`);
       }
 
       setTimeout(() => {
-        resolve(result);
+        if (error) {
+          reject(error);
+        } else {
+          resolve(result);
+        }
       }, delay ? delay : 0);
     });
   }

--- a/test/mocks/mockNetworkInterface.ts
+++ b/test/mocks/mockNetworkInterface.ts
@@ -1,0 +1,61 @@
+import {
+  NetworkInterface,
+  Request,
+} from '../../src/networkInterface';
+
+import {
+  GraphQLResult,
+  parse,
+  print
+} from 'graphql';
+
+export interface MockedResponse {
+  request: Request
+  result: GraphQLResult
+  delay?: number
+}
+
+// Pass in an array of requests and responses, so that you can test flows that end up making
+// multiple queries to the server
+export default function mockNetworkInterface(
+  ...mockedResponses: MockedResponse[]
+) {
+  const requestToResultMap: any = {};
+  const requestToDelayMap: any = {};
+
+  // Populate set of mocked requests
+  mockedResponses.forEach(({ request, result, delay }) => {
+    requestToResultMap[requestToKey(request)] = result as GraphQLResult;
+    requestToDelayMap[requestToKey(request)] = delay;
+  });
+
+  // A mock for the query method
+  const queryMock = (request: Request) => {
+    return new Promise((resolve, reject) => {
+      const resultData = requestToResultMap[requestToKey(request)];
+      const delay = requestToDelayMap[requestToKey(request)];
+
+      if (! resultData) {
+        throw new Error(`Passed request that wasn't mocked: ${requestToKey(request)}`);
+      }
+
+      setTimeout(() => {
+        resolve(resultData);
+      }, delay ? delay : 0);
+    });
+  };
+
+  return {
+    query: queryMock,
+  } as NetworkInterface;
+}
+
+function requestToKey(request: Request): string {
+  const query = request.query && print(parse(request.query));
+
+  return JSON.stringify({
+    variables: request.variables,
+    debugName: request.debugName,
+    query,
+  });
+}


### PR DESCRIPTION
To continue the discussion in https://github.com/apollostack/apollo-client/issues/88:

I'm not sure I like having a separate `onError` callback. It also forces us to keep maps of `queryId` to both result and error callbacks, and possibly more. The design that makes the most sense to me is something like:

```
export interface QueryObserver {
  onResult: (result: GraphQLResult) => void;
  onError: (error: Error) => void;
  onStop?: () => void;
}

handle.subscribe({
  onResult: (result) => {
  },
  onError: (error) => {
  },
});
```

We could also allow passing in an observer to `watchQuery()` for convenience:

```
const handle = queryManager.watchQuery({
  query,
  {
    onResult: (result) => {
    },
    onError: (error) => {
    },
  }
});
```

This looks a lot like `Observable<GraphQLResult>`, apart from the callback names. So we could decide to make `QueryObserver` compatible.

(I've kept `handle.onResult()` for now to avoid rewriting all test code, but the idea is that we would remove it.)