### PR TITLE
Get rid of hardcoded 'id'

### DIFF
--- a/src/data/extensions.ts
+++ b/src/data/extensions.ts
@@ -1,0 +1,3 @@
+export type IdGetter = (value: Object) => string;
+
+export const getIdField = ({ id }) => id;

--- a/src/data/store.ts
+++ b/src/data/store.ts
@@ -51,6 +51,7 @@ export function data(
         selectionSet: queryStoreValue.minimizedQuery.selectionSet,
         variables: queryStoreValue.variables,
         store: clonedState,
+        dataIdFromObject: null,
       });
 
       return newState;
@@ -69,6 +70,7 @@ export function data(
         selectionSet: queryStoreValue.mutation.selectionSet,
         variables: queryStoreValue.variables,
         store: clonedState,
+        dataIdFromObject: null,
       });
 
       return newState;

--- a/src/data/store.ts
+++ b/src/data/store.ts
@@ -20,6 +20,10 @@ import {
   MutationStore,
 } from '../mutations/store';
 
+import {
+  ApolloReducerConfig,
+} from '../store';
+
 export interface NormalizedCache {
   [dataId: string]: StoreObject;
 }
@@ -35,7 +39,8 @@ export function data(
   previousState: NormalizedCache = {},
   action: ApolloAction,
   queries: QueryStore,
-  mutations: MutationStore
+  mutations: MutationStore,
+  config: ApolloReducerConfig
 ): NormalizedCache {
   if (isQueryResultAction(action)) {
     // XXX handle partial result due to errors
@@ -51,7 +56,7 @@ export function data(
         selectionSet: queryStoreValue.minimizedQuery.selectionSet,
         variables: queryStoreValue.variables,
         store: clonedState,
-        dataIdFromObject: null,
+        dataIdFromObject: config.dataIdFromObject,
       });
 
       return newState;
@@ -70,7 +75,7 @@ export function data(
         selectionSet: queryStoreValue.mutation.selectionSet,
         variables: queryStoreValue.variables,
         store: clonedState,
-        dataIdFromObject: null,
+        dataIdFromObject: config.dataIdFromObject,
       });
 
       return newState;

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import {
 import {
   createApolloStore,
   ApolloStore,
-  apolloReducer,
+  createApolloReducer,
 } from './store';
 
 import {
@@ -26,7 +26,7 @@ import {
 export {
   createNetworkInterface,
   createApolloStore,
-  apolloReducer,
+  createApolloReducer,
 };
 
 export default class ApolloClient {
@@ -80,8 +80,8 @@ export default class ApolloClient {
     return this.queryManager.mutate(options);
   }
 
-  public reducer() {
-    return apolloReducer;
+  public reducer(): Function {
+    return createApolloReducer({});
   }
 
   public middleware() {
@@ -103,7 +103,9 @@ export default class ApolloClient {
     }
 
     // If we don't have a store already, initialize a default one
-    this.setStore(createApolloStore(this.reduxRootKey));
+    this.setStore(createApolloStore({
+      reduxRootKey: this.reduxRootKey,
+    }));
   }
 
   private setStore(store: ApolloStore) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -24,6 +24,10 @@ import {
   ApolloAction,
 } from './actions';
 
+import {
+  IdGetter,
+} from './data/extensions';
+
 export interface Store {
   data: NormalizedCache;
   queries: QueryStore;
@@ -49,20 +53,28 @@ const crashReporter = store => next => action => {
   }
 };
 
-export function apolloReducer(state = {} as Store, action: ApolloAction) {
-  const newState = {
-    queries: queries(state.queries, action),
-    mutations: mutations(state.mutations, action),
+export function createApolloReducer(config: ApolloReducerConfig): Function {
+  return function apolloReducer(state = {} as Store, action: ApolloAction) {
+    const newState = {
+      queries: queries(state.queries, action),
+      mutations: mutations(state.mutations, action),
 
-    // Note that we are passing the queries into this, because it reads them to associate
-    // the query ID in the result with the actual query
-    data: data(state.data, action, state.queries, state.mutations),
+      // Note that we are passing the queries into this, because it reads them to associate
+      // the query ID in the result with the actual query
+      data: data(state.data, action, state.queries, state.mutations, config),
+    };
+
+    return newState;
   };
-
-  return newState;
 }
 
-export function createApolloStore(reduxRootKey: string = 'apollo'): ApolloStore {
+export function createApolloStore({
+  reduxRootKey = 'apollo',
+  config = {},
+}: {
+  reduxRootKey?: string,
+  config?: ApolloReducerConfig,
+} = {}): ApolloStore {
   const enhancers = [];
 
   if (typeof window !== 'undefined') {
@@ -75,7 +87,11 @@ export function createApolloStore(reduxRootKey: string = 'apollo'): ApolloStore 
   enhancers.push(applyMiddleware(crashReporter));
 
   return createStore(
-    combineReducers({ [reduxRootKey]: apolloReducer }),
+    combineReducers({ [reduxRootKey]: createApolloReducer(config) }),
     compose(...enhancers)
   );
+}
+
+export interface ApolloReducerConfig {
+  dataIdFromObject?: IdGetter;
 }

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -12,6 +12,10 @@ import {
 } from '../src/store';
 
 import {
+  getIdField,
+} from '../src/data/extensions';
+
+import {
   assert,
 } from 'chai';
 
@@ -251,7 +255,9 @@ describe('QueryManager', () => {
       },
     ]);
 
-    const store = createApolloStore();
+    const store = createApolloStore({
+      config: { dataIdFromObject: getIdField },
+    });
 
     const queryManager = new QueryManager({
       networkInterface,
@@ -293,7 +299,9 @@ describe('QueryManager', () => {
       },
     ]);
 
-    const store = createApolloStore();
+    const store = createApolloStore({
+      config: { dataIdFromObject: getIdField },
+    });
 
     const queryManager = new QueryManager({
       networkInterface,
@@ -336,7 +344,10 @@ describe('QueryManager', () => {
     ]);
 
     const reduxRootKey = 'test';
-    const store = createApolloStore(reduxRootKey);
+    const store = createApolloStore({
+      reduxRootKey,
+      config: { dataIdFromObject: getIdField },
+    });
 
     const queryManager = new QueryManager({
       networkInterface,
@@ -693,7 +704,9 @@ function testDiffing(
 
   const queryManager = new QueryManager({
     networkInterface,
-    store: createApolloStore(),
+    store: createApolloStore({
+      config: { dataIdFromObject: getIdField },
+    }),
     reduxRootKey: 'apollo',
   });
 

--- a/test/diffAgainstStore.ts
+++ b/test/diffAgainstStore.ts
@@ -248,4 +248,60 @@ describe('diffing queries against the store', () => {
     assert.deepEqual(missingSelectionSets, []);
     assert.deepEqual(store['1'], result.people_one);
   });
+
+  it('diffs root queries even when IDs are turned off', () => {
+    const firstQuery = `
+      {
+        people_one(id: "1") {
+          __typename,
+          id,
+          name
+        }
+      }
+    `;
+
+    const result = {
+      people_one: {
+        __typename: 'Person',
+        id: '1',
+        name: 'Luke Skywalker',
+      },
+    };
+
+    const store = writeQueryToStore({
+      result,
+      query: firstQuery,
+      dataIdFromObject: getIdField,
+    });
+
+    const secondQuery = `
+      {
+        people_one(id: "1") {
+          __typename
+          id
+          name
+        }
+        people_one(id: "2") {
+          __typename
+          id
+          name
+        }
+      }
+    `;
+
+    const { missingSelectionSets } = diffQueryAgainstStore({
+      store,
+      query: secondQuery,
+    });
+
+    assert.equal(printQueryForMissingData(missingSelectionSets), `{
+  people_one(id: "2") {
+    __typename
+    id
+    name
+  }
+}
+`);
+    assert.deepEqual(store['1'], result.people_one);
+  });
 });

--- a/test/diffAgainstStore.ts
+++ b/test/diffAgainstStore.ts
@@ -5,6 +5,10 @@ import { writeQueryToStore } from '../src/data/writeToStore';
 import { stripLoc } from '../src/data/debug';
 import { printQueryForMissingData } from '../src/queryPrinting';
 
+import {
+  getIdField,
+} from '../src/data/extensions';
+
 describe('diffing queries against the store', () => {
   it('returns nothing when the store is enough', () => {
     const query = `
@@ -54,6 +58,7 @@ describe('diffing queries against the store', () => {
     const store = writeQueryToStore({
       result,
       query: firstQuery,
+      dataIdFromObject: getIdField,
     });
 
     const secondQuery = `
@@ -114,6 +119,7 @@ describe('diffing queries against the store', () => {
     const store = writeQueryToStore({
       result,
       query: firstQuery,
+      dataIdFromObject: getIdField,
     });
 
     const secondQuery = `
@@ -163,6 +169,7 @@ describe('diffing queries against the store', () => {
     const store = writeQueryToStore({
       result,
       query: firstQuery,
+      dataIdFromObject: getIdField,
     });
 
     const secondQuery = `
@@ -220,6 +227,7 @@ describe('diffing queries against the store', () => {
     const store = writeQueryToStore({
       result,
       query: firstQuery,
+      dataIdFromObject: getIdField,
     });
 
     const secondQuery = `

--- a/test/store.ts
+++ b/test/store.ts
@@ -24,7 +24,10 @@ describe('createApolloStore', () => {
   });
 
   it('can take a custom root key', () => {
-    const store = createApolloStore('test');
+    const store = createApolloStore({
+      reduxRootKey: 'test',
+    });
+
     assert.deepEqual(
       store.getState()['test'],
       {

--- a/test/writeToStore.ts
+++ b/test/writeToStore.ts
@@ -5,6 +5,10 @@ import {
   writeFragmentToStore,
 } from '../src/data/writeToStore';
 
+import {
+  getIdField,
+} from '../src/data/extensions';
+
 describe('writing to the store', () => {
   it('properly normalizes a trivial item', () => {
     const fragment = `
@@ -23,7 +27,7 @@ describe('writing to the store', () => {
       nullField: null,
     };
 
-    assertEqualSansDataId(writeFragmentToStore({
+    assert.deepEqual(writeFragmentToStore({
       fragment,
       result: _.cloneDeep(result),
     }), {
@@ -53,7 +57,7 @@ describe('writing to the store', () => {
       fragment,
     });
 
-    assertEqualSansDataId(normalized, {
+    assert.deepEqual(normalized, {
       [result.id]: {
         id: 'abcd',
         stringField: 'This is a string!',
@@ -87,7 +91,7 @@ describe('writing to the store', () => {
       fragment,
     });
 
-    assertEqualSansDataId(normalized, {
+    assert.deepEqual(normalized, {
       [result.id]: {
         id: 'abcd',
         'stringField({"arg":"1"})': 'The arg was 1!',
@@ -127,7 +131,7 @@ describe('writing to the store', () => {
       variables,
     });
 
-    assertEqualSansDataId(normalized, {
+    assert.deepEqual(normalized, {
       [result.id]: {
         id: 'abcd',
         nullField: null,
@@ -166,9 +170,10 @@ describe('writing to the store', () => {
       },
     };
 
-    assertEqualSansDataId(writeFragmentToStore({
+    assert.deepEqual(writeFragmentToStore({
       fragment,
       result: _.cloneDeep(result),
+      dataIdFromObject: getIdField,
     }), {
       [result.id]: _.assign({}, _.assign({}, _.omit(result, 'nestedObj')), {
         nestedObj: result.nestedObj.id,
@@ -204,7 +209,7 @@ describe('writing to the store', () => {
       },
     };
 
-    assertEqualSansDataId(writeFragmentToStore({
+    assert.deepEqual(writeFragmentToStore({
       fragment,
       result: _.cloneDeep(result),
     }), {
@@ -242,7 +247,7 @@ describe('writing to the store', () => {
       },
     };
 
-    assertEqualSansDataId(writeFragmentToStore({
+    assert.deepEqual(writeFragmentToStore({
       fragment,
       result: _.cloneDeep(result),
     }), {
@@ -290,9 +295,10 @@ describe('writing to the store', () => {
       ],
     };
 
-    assertEqualSansDataId(writeFragmentToStore({
+    assert.deepEqual(writeFragmentToStore({
       fragment,
       result: _.cloneDeep(result),
+      dataIdFromObject: getIdField,
     }), {
       [result.id]: _.assign({}, _.assign({}, _.omit(result, 'nestedArray')), {
         nestedArray: result.nestedArray.map(_.property('id')),
@@ -334,9 +340,10 @@ describe('writing to the store', () => {
       ],
     };
 
-    assertEqualSansDataId(writeFragmentToStore({
+    assert.deepEqual(writeFragmentToStore({
       fragment,
       result: _.cloneDeep(result),
+      dataIdFromObject: getIdField,
     }), {
       [result.id]: _.assign({}, _.assign({}, _.omit(result, 'nestedArray')), {
         nestedArray: [
@@ -387,7 +394,7 @@ describe('writing to the store', () => {
       result: _.cloneDeep(result),
     });
 
-    assertEqualSansDataId(normalized, {
+    assert.deepEqual(normalized, {
       [result.id]: _.assign({}, _.assign({}, _.omit(result, 'nestedArray')), {
         nestedArray: [
           `${result.id}.nestedArray.0`,
@@ -434,7 +441,7 @@ describe('writing to the store', () => {
       result: _.cloneDeep(result),
     });
 
-    assertEqualSansDataId(normalized, {
+    assert.deepEqual(normalized, {
       [result.id]: _.assign({}, _.assign({}, _.omit(result, 'nestedArray')), {
         nestedArray: [
           null,
@@ -467,9 +474,10 @@ describe('writing to the store', () => {
     const normalized = writeFragmentToStore({
       fragment,
       result: _.cloneDeep(result),
+      dataIdFromObject: getIdField,
     });
 
-    assertEqualSansDataId(normalized, {
+    assert.deepEqual(normalized, {
       [result.id]: _.assign({}, _.assign({}, _.omit(result, 'simpleArray')), {
         simpleArray: [
           result.simpleArray[0],
@@ -504,7 +512,7 @@ describe('writing to the store', () => {
       result: _.cloneDeep(result),
     });
 
-    assertEqualSansDataId(normalized, {
+    assert.deepEqual(normalized, {
       [result.id]: _.assign({}, _.assign({}, _.omit(result, 'simpleArray')), {
         simpleArray: [
           result.simpleArray[0],
@@ -533,6 +541,7 @@ describe('writing to the store', () => {
     const store = writeFragmentToStore({
       fragment,
       result: _.cloneDeep(result),
+      dataIdFromObject: getIdField,
     });
 
     const fragment2 = `
@@ -553,6 +562,7 @@ describe('writing to the store', () => {
       store,
       fragment: fragment2,
       result: result2,
+      dataIdFromObject: getIdField,
     });
 
     assert.deepEqual(store2, {
@@ -584,7 +594,7 @@ describe('writing to the store', () => {
       nestedObj: null,
     };
 
-    assertEqualSansDataId(writeFragmentToStore({
+    assert.deepEqual(writeFragmentToStore({
       fragment,
       result: _.cloneDeep(result),
     }), {
@@ -594,22 +604,3 @@ describe('writing to the store', () => {
     });
   });
 });
-
-function assertEqualSansDataId(a, b) {
-  const filteredA = omitDataIdFields(a);
-  const filteredB = omitDataIdFields(b);
-
-  assert.deepEqual(filteredA, filteredB);
-}
-
-function omitDataIdFields(obj) {
-  if (! _.isObject(obj)) {
-    return obj;
-  }
-
-  const omitted = _.omit(obj, ['__data_id']);
-
-  return _.mapValues(omitted, (value) => {
-    return omitDataIdFields(value);
-  });
-}

--- a/test/writeToStore.ts
+++ b/test/writeToStore.ts
@@ -3,6 +3,7 @@ import * as _ from 'lodash';
 
 import {
   writeFragmentToStore,
+  writeQueryToStore,
 } from '../src/data/writeToStore';
 
 import {
@@ -601,6 +602,37 @@ describe('writing to the store', () => {
       [result.id]: _.assign({}, _.assign({}, _.omit(result, 'nestedObj')), {
         nestedObj: null,
       }),
+    });
+  });
+
+  it('properly normalizes an object with an ID when no extension is passed', () => {
+    const query = `
+      {
+        people_one(id: "5") {
+          id
+          stringField
+        }
+      }
+    `;
+
+    const result = {
+      people_one: {
+        id: 'abcd',
+        stringField: 'This is a string!',
+      },
+    };
+
+    assert.deepEqual(writeQueryToStore({
+      query,
+      result: _.cloneDeep(result),
+    }), {
+      'ROOT_QUERY': {
+        'people_one({"id":"5"})': 'ROOT_QUERY.people_one({"id":"5"})',
+      },
+      'ROOT_QUERY.people_one({"id":"5"})': {
+        'id': 'abcd',
+        'stringField': 'This is a string!',
+      },
     });
   });
 });


### PR DESCRIPTION
Fixes #93 - "don't treat ID as special unless told to do so"

Still needs new tests for querying for data with `id`, but without the extension.

Also, changes internal APIs for `createApolloStore` and `apolloReducer` - no external API changes though.