### PR TITLE
[WIP] Turn off forceFetch by default, preserve query name and variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,14 +5,15 @@
   "main": "./lib/src/index.js",
   "scripts": {
     "pretest": "npm run compile",
-    "test": "mocha --reporter spec --full-trace lib/test/tests.js",
+    "test": "npm run testonly",
     "posttest": "npm run lint",
     "compile": "tsc",
     "watch": "tsc -w",
     "prepublish": "npm run compile",
     "lint": "tslint src/*.ts && tslint test/*.ts",
     "coverage": "istanbul cover ./node_modules/mocha/bin/_mocha -- --reporter dot --full-trace lib/test/tests.js",
-    "postcoverage": "remap-istanbul --input coverage/coverage.json --type lcovonly --output coverage/lcov.info"
+    "postcoverage": "remap-istanbul --input coverage/coverage.json --type lcovonly --output coverage/lcov.info",
+    "testonly": "mocha --reporter spec --full-trace lib/test/tests.js"
   },
   "repository": {
     "type": "git",

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -39,10 +39,15 @@ import {
   printQueryFromDefinition,
 } from './queryPrinting';
 
+import {
+  IdGetter,
+} from './data/extensions';
+
 export class QueryManager {
   private networkInterface: NetworkInterface;
   private store: ApolloStore;
   private reduxRootKey: string;
+  private dataIdFromObject: IdGetter;
 
   private resultCallbacks: { [queryId: number]: QueryResultCallback[] };
 
@@ -52,16 +57,19 @@ export class QueryManager {
     networkInterface,
     store,
     reduxRootKey,
+    dataIdFromObject,
   }: {
     networkInterface: NetworkInterface,
     store: ApolloStore,
     reduxRootKey: string,
+    dataIdFromObject?: IdGetter,
   }) {
     // XXX this might be the place to do introspection for inserting the `id` into the query? or
     // is that the network interface?
     this.networkInterface = networkInterface;
     this.store = store;
     this.reduxRootKey = reduxRootKey;
+    this.dataIdFromObject = dataIdFromObject;
 
     this.resultCallbacks = {};
 
@@ -156,6 +164,7 @@ export class QueryManager {
         throwOnMissingField: false,
         rootId: querySS.id,
         variables,
+        dataIdFromObject: this.dataIdFromObject,
       });
 
       initialResult = result;

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -119,7 +119,7 @@ export class QueryManager {
   public watchQuery({
     query,
     variables,
-    forceFetch = true,
+    forceFetch = false,
     returnPartialData = false,
   }: WatchQueryOptions): WatchedQueryHandle {
     // Generate a query ID
@@ -130,13 +130,14 @@ export class QueryManager {
     this.resultCallbacks[queryId] = [];
 
     const queryString = query;
+    const queryDef = parseQuery(query);
 
     // Parse the query passed in -- this could also be done by a build plugin or tagged
     // template string
     const querySS = {
       id: 'ROOT_QUERY',
       typeName: 'Query',
-      selectionSet: parseQuery(query).selectionSet,
+      selectionSet: queryDef.selectionSet,
     } as SelectionSetWithRoot;
 
     // If we don't use diffing, then these will be the same as the original query
@@ -160,7 +161,11 @@ export class QueryManager {
       initialResult = result;
 
       if (missingSelectionSets.length) {
-        const diffedQueryDef = queryDefinition(missingSelectionSets);
+        const diffedQueryDef = queryDefinition({
+          missingSelectionSets,
+          variableDefinitions: queryDef.variableDefinitions,
+          name: queryDef.name,
+        });
 
         minimizedQuery = {
           id: 'ROOT_QUERY',

--- a/src/data/diffAgainstStore.ts
+++ b/src/data/diffAgainstStore.ts
@@ -24,6 +24,10 @@ import {
 } from '../queries/store';
 
 import {
+  IdGetter,
+} from './extensions';
+
+import {
   SelectionSet,
   Field,
 } from 'graphql';
@@ -31,16 +35,19 @@ import {
 export interface QueryDiffResult {
   result: any;
   missingSelectionSets: SelectionSetWithRoot[];
+  mergeUp: boolean;
 }
 
 export function diffQueryAgainstStore({
   store,
   query,
   variables,
+  dataIdFromObject,
 }: {
   store: NormalizedCache,
   query: string
   variables?: Object,
+  dataIdFromObject?: IdGetter,
 }): QueryDiffResult {
   const queryDef = parseQuery(query);
 
@@ -50,6 +57,7 @@ export function diffQueryAgainstStore({
     selectionSet: queryDef.selectionSet,
     throwOnMissingField: false,
     variables,
+    dataIdFromObject,
   });
 }
 
@@ -58,11 +66,13 @@ export function diffFragmentAgainstStore({
   fragment,
   rootId,
   variables,
+  dataIdFromObject,
 }: {
   store: NormalizedCache,
   fragment: string,
   rootId: string,
   variables?: Object,
+  dataIdFromObject?: IdGetter,
 }): QueryDiffResult {
   const fragmentDef = parseFragment(fragment);
 
@@ -72,6 +82,7 @@ export function diffFragmentAgainstStore({
     selectionSet: fragmentDef.selectionSet,
     throwOnMissingField: false,
     variables,
+    dataIdFromObject,
   });
 }
 
@@ -92,23 +103,22 @@ export function diffSelectionSetAgainstStore({
   rootId,
   throwOnMissingField = false,
   variables,
+  dataIdFromObject,
 }: {
   selectionSet: SelectionSet,
   store: NormalizedCache,
   rootId: string,
   throwOnMissingField: Boolean,
   variables: Object,
+  dataIdFromObject?: IdGetter,
 }): QueryDiffResult {
   if (selectionSet.kind !== 'SelectionSet') {
     throw new Error('Must be a selection set.');
   }
 
   const result = {};
-
   const missingSelectionSets: SelectionSetWithRoot[] = [];
-
   const missingSelections: Field[] = [];
-
   const storeObj = store[rootId] || {};
 
   selectionSet.selections.forEach((selection) => {
@@ -120,6 +130,15 @@ export function diffSelectionSetAgainstStore({
 
     const storeFieldKey = storeKeyNameFromField(field, variables);
     const resultFieldKey = resultKeyNameFromField(field);
+
+    // Don't push more than one missing field per field in the query
+    let missingFieldPushed = false;
+    function pushMissingField(field: Field) {
+      if (!missingFieldPushed) {
+        missingSelections.push(field);
+        missingFieldPushed = true;
+      }
+    }
 
     if (! has(storeObj, storeFieldKey)) {
       if (throwOnMissingField) {
@@ -157,10 +176,17 @@ export function diffSelectionSetAgainstStore({
           rootId: id,
           selectionSet: field.selectionSet,
           variables,
+          dataIdFromObject,
         });
 
-        itemDiffResult.missingSelectionSets.forEach(
-          itemSelectionSet => missingSelectionSets.push(itemSelectionSet));
+        if (! itemDiffResult.mergeUp) {
+          itemDiffResult.missingSelectionSets.forEach(
+            itemSelectionSet => missingSelectionSets.push(itemSelectionSet));
+        } else {
+          // XXX merge all of the missing selections from the children to get a more minimal result
+          pushMissingField(field);
+        }
+
         return itemDiffResult.result;
       });
       return;
@@ -173,11 +199,16 @@ export function diffSelectionSetAgainstStore({
         rootId: storeValue,
         selectionSet: field.selectionSet,
         variables,
+        dataIdFromObject,
       });
 
-      // This is a nested query
-      subObjDiffResult.missingSelectionSets.forEach(
-        subObjSelectionSet => missingSelectionSets.push(subObjSelectionSet));
+      if (! subObjDiffResult.mergeUp) {
+        subObjDiffResult.missingSelectionSets.forEach(
+          subObjSelectionSet => missingSelectionSets.push(subObjSelectionSet));
+      } else {
+        // XXX merge all of the missing selections from the children to get a more minimal result
+        pushMissingField(field);
+      }
 
       result[resultFieldKey] = subObjDiffResult.result;
       return;
@@ -186,39 +217,71 @@ export function diffSelectionSetAgainstStore({
     throw new Error('Unexpected number value in the store where the query had a subselection.');
   });
 
+  // Set this to true if we don't have enough information at this level to generate a refetch
+  // query, so we need to merge the selection set with the parent, rather than appending
+  let mergeUp = false;
+
   // If we weren't able to resolve some selections from the store, construct them into
   // a query we can fetch from the server
   if (missingSelections.length) {
-    const id = storeObj['id'];
-    if (typeof id !== 'string' && rootId !== 'ROOT_QUERY') {
-      throw new Error(
-        `Can't generate query to refetch object ${rootId}, since it doesn't have a string id.`);
-    }
+    if (dataIdFromObject) {
+      // We have a semantic understanding of IDs
+      const id = dataIdFromObject(storeObj);
 
-    let typeName: string;
+      if (typeof id !== 'string' && rootId !== 'ROOT_QUERY') {
+        throw new Error(
+          `Can't generate query to refetch object ${rootId}, since it doesn't have a string id.`);
+      }
 
-    if (rootId === 'ROOT_QUERY') {
-      // We don't need to do anything interesting to fetch root queries, like have an ID
-      typeName = 'Query';
-    } else if (! storeObj.__typename) {
-      throw new Error(
-        `Can't generate query to refetch object ${rootId}, since __typename wasn't in the store.`);
+      let typeName: string;
+
+      if (rootId === 'ROOT_QUERY') {
+        // We don't need to do anything interesting to fetch root queries, like have an ID
+        typeName = 'Query';
+      } else if (! storeObj.__typename) {
+        throw new Error(
+          `Can't generate query to refetch object ${rootId}, since __typename wasn't in the store.`);
+      } else {
+        typeName = storeObj.__typename;
+      }
+
+      missingSelectionSets.push({
+        id: rootId,
+        typeName,
+        selectionSet: {
+          kind: 'SelectionSet',
+          selections: missingSelections,
+        },
+      });
+    } else if (rootId === 'ROOT_QUERY') {
+      const typeName = 'Query';
+
+      missingSelectionSets.push({
+        id: rootId,
+        typeName,
+        selectionSet: {
+          kind: 'SelectionSet',
+          selections: missingSelections,
+        },
+      });
     } else {
-      typeName = storeObj.__typename;
-    }
+      mergeUp = true;
 
-    missingSelectionSets.push({
-      id: rootId,
-      typeName,
-      selectionSet: {
-        kind: 'SelectionSet',
-        selections: missingSelections,
-      },
-    });
+      missingSelectionSets.push({
+        // Sentinel values, all we need is the selection set
+        id: 'CANNOT_REFETCH',
+        typeName: 'CANNOT_REFETCH',
+        selectionSet: {
+          kind: 'SelectionSet',
+          selections: missingSelections,
+        },
+      });
+    }
   }
 
   return {
     result,
     missingSelectionSets,
+    mergeUp,
   };
 }

--- a/src/data/diffAgainstStore.ts
+++ b/src/data/diffAgainstStore.ts
@@ -118,7 +118,7 @@ export function diffSelectionSetAgainstStore({
 
   const result = {};
   const missingSelectionSets: SelectionSetWithRoot[] = [];
-  const missingSelections: Field[] = [];
+  const missingFields: Field[] = [];
   const storeObj = store[rootId] || {};
 
   selectionSet.selections.forEach((selection) => {
@@ -133,9 +133,9 @@ export function diffSelectionSetAgainstStore({
 
     // Don't push more than one missing field per field in the query
     let missingFieldPushed = false;
-    function pushMissingField(field: Field) {
+    function pushMissingField(missingField: Field) {
       if (!missingFieldPushed) {
-        missingSelections.push(field);
+        missingFields.push(missingField);
         missingFieldPushed = true;
       }
     }
@@ -145,7 +145,7 @@ export function diffSelectionSetAgainstStore({
         throw new Error(`Can't find field ${storeFieldKey} on object ${storeObj}.`);
       }
 
-      missingSelections.push(field);
+      missingFields.push(field);
 
       return;
     }
@@ -223,7 +223,7 @@ export function diffSelectionSetAgainstStore({
 
   // If we weren't able to resolve some selections from the store, construct them into
   // a query we can fetch from the server
-  if (missingSelections.length) {
+  if (missingFields.length) {
     if (dataIdFromObject) {
       // We have a semantic understanding of IDs
       const id = dataIdFromObject(storeObj);
@@ -250,7 +250,7 @@ export function diffSelectionSetAgainstStore({
         typeName,
         selectionSet: {
           kind: 'SelectionSet',
-          selections: missingSelections,
+          selections: missingFields,
         },
       });
     } else if (rootId === 'ROOT_QUERY') {
@@ -261,7 +261,7 @@ export function diffSelectionSetAgainstStore({
         typeName,
         selectionSet: {
           kind: 'SelectionSet',
-          selections: missingSelections,
+          selections: missingFields,
         },
       });
     } else {
@@ -273,7 +273,7 @@ export function diffSelectionSetAgainstStore({
         typeName: 'CANNOT_REFETCH',
         selectionSet: {
           kind: 'SelectionSet',
-          selections: missingSelections,
+          selections: missingFields,
         },
       });
     }

--- a/src/queryPrinting.ts
+++ b/src/queryPrinting.ts
@@ -2,14 +2,16 @@ import {
   print,
   SelectionSet,
   OperationDefinition,
+  VariableDefinition,
+  Name,
 } from 'graphql';
 
 import {
   SelectionSetWithRoot,
 } from './queries/store';
 
-export function printQueryForMissingData(missingSelectionSets: SelectionSetWithRoot[]) {
-  return printQueryFromDefinition(queryDefinition(missingSelectionSets));
+export function printQueryForMissingData(options: QueryDefinitionOptions) {
+  return printQueryFromDefinition(queryDefinition(options));
 }
 
 const idField = {
@@ -32,8 +34,11 @@ export function printQueryFromDefinition(queryDef: OperationDefinition) {
   return print(queryDocumentAst);
 }
 
-export function queryDefinition(
-    missingSelectionSets: SelectionSetWithRoot[]): OperationDefinition {
+export function queryDefinition({
+    missingSelectionSets,
+    variableDefinitions = null,
+    name = null,
+}: QueryDefinitionOptions): OperationDefinition {
   const selections = missingSelectionSets.map((missingSelectionSet: SelectionSetWithRoot, ii) => {
     if (missingSelectionSet.id === 'ROOT_QUERY') {
       if (missingSelectionSet.selectionSet.selections.length > 1) {
@@ -54,8 +59,8 @@ export function queryDefinition(
   return {
     kind: 'OperationDefinition',
     operation: 'query',
-    name: null,
-    variableDefinitions: null,
+    name,
+    variableDefinitions,
     directives: [],
     selectionSet: {
       kind: 'SelectionSet',
@@ -130,4 +135,10 @@ function inlineFragmentSelection({
     directives: [],
     selectionSet,
   };
+}
+
+export type QueryDefinitionOptions = {
+  missingSelectionSets: SelectionSetWithRoot[];
+  variableDefinitions?: VariableDefinition[];
+  name?: Name;
 }

--- a/src/queryPrinting.ts
+++ b/src/queryPrinting.ts
@@ -40,6 +40,10 @@ export function queryDefinition({
     name = null,
 }: QueryDefinitionOptions): OperationDefinition {
   const selections = missingSelectionSets.map((missingSelectionSet: SelectionSetWithRoot, ii) => {
+    if (missingSelectionSet.id === 'CANNOT_REFETCH') {
+      throw new Error('diffAgainstStore did not merge selection sets correctly');
+    }
+
     if (missingSelectionSet.id === 'ROOT_QUERY') {
       if (missingSelectionSet.selectionSet.selections.length > 1) {
         throw new Error('Multiple root queries, cannot print that yet.');

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -708,6 +708,7 @@ function testDiffing(
       config: { dataIdFromObject: getIdField },
     }),
     reduxRootKey: 'apollo',
+    dataIdFromObject: getIdField,
   });
 
   const steps = queryArray.map(({ query, fullResponse, variables }) => {

--- a/test/diffAgainstStore.ts
+++ b/test/diffAgainstStore.ts
@@ -243,6 +243,7 @@ describe('diffing queries against the store', () => {
     const { missingSelectionSets } = diffQueryAgainstStore({
       store,
       query: secondQuery,
+      dataIdFromObject: getIdField,
     });
 
     assert.equal(printQueryForMissingData({

--- a/test/diffAgainstStore.ts
+++ b/test/diffAgainstStore.ts
@@ -136,7 +136,9 @@ describe('diffing queries against the store', () => {
       query: secondQuery,
     });
 
-    assert.equal(printQueryForMissingData(missingSelectionSets), `{
+    assert.equal(printQueryForMissingData({
+      missingSelectionSets,
+    }), `{
   __node_0: node(id: "lukeId") {
     id
     ... on Person {
@@ -190,7 +192,9 @@ describe('diffing queries against the store', () => {
       query: secondQuery,
     });
 
-    assert.equal(printQueryForMissingData(missingSelectionSets), `{
+    assert.equal(printQueryForMissingData({
+      missingSelectionSets,
+    }), `{
   __node_0: node(id: "lukeId") {
     id
     ... on Person {
@@ -294,7 +298,9 @@ describe('diffing queries against the store', () => {
       query: secondQuery,
     });
 
-    assert.equal(printQueryForMissingData(missingSelectionSets), `{
+    assert.equal(printQueryForMissingData({
+      missingSelectionSets,
+    }), `{
   people_one(id: "2") {
     __typename
     id

--- a/test/diffAgainstStore.ts
+++ b/test/diffAgainstStore.ts
@@ -36,7 +36,7 @@ describe('diffing queries against the store', () => {
     }).missingSelectionSets, []);
   });
 
-  it('returns correct selection set when the store is missing one field', () => {
+  it('when the store is missing one field and knows about IDs', () => {
     const firstQuery = `
       {
         people_one(id: "1") {
@@ -73,6 +73,7 @@ describe('diffing queries against the store', () => {
     assert.deepEqual(stripLoc(diffQueryAgainstStore({
       store,
       query: secondQuery,
+      dataIdFromObject: getIdField,
     }).missingSelectionSets), [
       {
         id: 'lukeId',
@@ -97,7 +98,7 @@ describe('diffing queries against the store', () => {
     ]);
   });
 
-  it('generates the right query when the store is missing one field', () => {
+  it('when the store is missing one field and knows about IDs', () => {
     const firstQuery = `
       {
         people_one(id: "1") {
@@ -134,6 +135,7 @@ describe('diffing queries against the store', () => {
     const { missingSelectionSets } = diffQueryAgainstStore({
       store,
       query: secondQuery,
+      dataIdFromObject: getIdField,
     });
 
     assert.equal(printQueryForMissingData({
@@ -149,7 +151,58 @@ describe('diffing queries against the store', () => {
 `);
   });
 
-  it('generates the right queries when the store is missing multiple nodes', () => {
+  it('when the store is missing one field and doesn\'t know IDs', () => {
+    const firstQuery = `
+      {
+        people_one(id: "1") {
+          __typename
+          id
+          name
+        }
+      }
+    `;
+
+    const result = {
+      people_one: {
+        __typename: 'Person',
+        id: 'lukeId',
+        name: 'Luke Skywalker',
+      },
+    };
+
+    const store = writeQueryToStore({
+      result,
+      query: firstQuery,
+    });
+
+    const secondQuery = `
+      {
+        people_one(id: "1") {
+          name
+          age
+        }
+      }
+    `;
+
+    const { missingSelectionSets } = diffQueryAgainstStore({
+      store,
+      query: secondQuery,
+    });
+
+    // XXX a more efficient diffing algorithm would actually only fetch `age` here. Something to
+    // implement next
+    assert.equal(printQueryForMissingData({
+      missingSelectionSets,
+    }), `{
+  people_one(id: "1") {
+    name
+    age
+  }
+}
+`);
+  });
+
+  it('when the store is missing multiple nodes', () => {
     const firstQuery = `
       {
         people_one(id: "1") {

--- a/test/queryPrinting.ts
+++ b/test/queryPrinting.ts
@@ -23,13 +23,15 @@ describe('printing queries', () => {
     };
 
     // Note - the indentation inside template strings is meaningful!
-    assert.equal(printQueryForMissingData([
-      {
-        id,
-        typeName,
-        selectionSet,
-      },
-    ]), `{
+    assert.equal(printQueryForMissingData({
+      missingSelectionSets: [
+        {
+          id,
+          typeName,
+          selectionSet,
+        },
+      ],
+    }), `{
   __node_0: node(id: "lukeId") {
     id
     ... on Person {


### PR DESCRIPTION
Fixes #109 and #85 

✅  Still need to write a test for variable definition and query name preservation in QueryManager.

Also, we can do query diffing in a smarter way, going to file an issue about that soon.