### PR TITLE
Minor bug fixes and exporting of readFromStore utils for manual cache reads

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.5",
   "description": "A simple yet functional GraphQL client.",
   "main": "./lib/src/index.js",
+  "typings": "./lib/src/index.d.ts",
   "scripts": {
     "pretest": "npm run compile",
     "test": "npm run testonly",

--- a/src/data/extensions.ts
+++ b/src/data/extensions.ts
@@ -1,3 +1,3 @@
 export type IdGetter = (value: Object) => string;
 
-export const getIdField = ({ id }) => id;
+export const getIdField = (data: { id: any }) => data.id;

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,11 @@ import {
 } from './QueryManager';
 
 import {
+  readQueryFromStore,
+  readFragmentFromStore,
+} from './data/readFromStore';
+
+import {
   isUndefined,
 } from 'lodash';
 
@@ -27,6 +32,8 @@ export {
   createNetworkInterface,
   createApolloStore,
   createApolloReducer,
+  readQueryFromStore,
+  readFragmentFromStore,
 };
 
 export default class ApolloClient {

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,13 +48,13 @@ export default class ApolloClient {
       createNetworkInterface('/graphql');
   }
 
-  public watchQuery(options: WatchQueryOptions): WatchedQueryHandle {
+  public watchQuery = (options: WatchQueryOptions): WatchedQueryHandle => {
     this.initStore();
 
     return this.queryManager.watchQuery(options);
   }
 
-  public query(options: WatchQueryOptions): Promise<GraphQLResult | Error> {
+  public query = (options: WatchQueryOptions): Promise<GraphQLResult | Error> => {
 
     if (options.returnPartialData) {
       throw new Error('returnPartialData option only supported on watchQuery.');
@@ -77,10 +77,10 @@ export default class ApolloClient {
     });
   }
 
-  public mutate(options: {
+  public mutate = (options: {
     mutation: string,
     variables?: Object,
-  }): Promise<GraphQLResult> {
+  }): Promise<GraphQLResult> => {
     this.initStore();
     return this.queryManager.mutate(options);
   }
@@ -89,7 +89,7 @@ export default class ApolloClient {
     return createApolloReducer({});
   }
 
-  public middleware() {
+  public middleware = () => {
     return (store: ApolloStore) => {
       this.setStore(store);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ export default class ApolloClient {
     this.initStore();
 
     return this.queryManager.watchQuery(options);
-  }
+  };
 
   public query = (options: WatchQueryOptions): Promise<GraphQLResult | Error> => {
 
@@ -75,7 +75,7 @@ export default class ApolloClient {
         },
       });
     });
-  }
+  };
 
   public mutate = (options: {
     mutation: string,
@@ -83,7 +83,7 @@ export default class ApolloClient {
   }): Promise<GraphQLResult> => {
     this.initStore();
     return this.queryManager.mutate(options);
-  }
+  };
 
   public reducer(): Function {
     return createApolloReducer({});
@@ -99,7 +99,7 @@ export default class ApolloClient {
         return returnValue;
       };
     };
-  }
+  };
 
   public initStore() {
     if (this.store) {
@@ -111,9 +111,9 @@ export default class ApolloClient {
     this.setStore(createApolloStore({
       reduxRootKey: this.reduxRootKey,
     }));
-  }
+  };
 
-  private setStore(store: ApolloStore) {
+  private setStore = (store: ApolloStore) => {
     // ensure existing store has apolloReducer
     if (isUndefined(store.getState()[this.reduxRootKey])) {
       throw new Error(`Existing store does not use apolloReducer for ${this.reduxRootKey}`);
@@ -126,5 +126,5 @@ export default class ApolloClient {
       reduxRootKey: this.reduxRootKey,
       store,
     });
-  }
+  };
 }


### PR DESCRIPTION
A few minor bugs I ran across when building apollo-react.

- Change binding methods of client (`this` was undefined on the client methods)
- Fix oddity in typescript definitions

I also exported a couple of the readFromStore utils to setup a manual cache read for now until a sync way to get existing data is in place 