### PR TITLE
	Export ApolloClient class with name and not as default

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,15 +28,8 @@ import {
   isUndefined,
 } from 'lodash';
 
-export {
-  createNetworkInterface,
-  createApolloStore,
-  createApolloReducer,
-  readQueryFromStore,
-  readFragmentFromStore,
-};
 
-export default class ApolloClient {
+export class ApolloClient {
   public networkInterface: NetworkInterface;
   public store: ApolloStore;
   public reduxRootKey: string;
@@ -135,3 +128,12 @@ export default class ApolloClient {
     });
   };
 }
+
+export {
+  createNetworkInterface,
+  createApolloStore,
+  createApolloReducer,
+  readQueryFromStore,
+  readFragmentFromStore,
+  ApolloClient
+};


### PR DESCRIPTION
When exporting it as default and without it's name, it is not possible to import it with TypeScript application.

The following line did no work before:
```ts
import {ApolloClient} from "apollo-client";
```

And returned `undefined` value.

Now it is possible to import it with it's name using TypeScript. 