### PR TITLE
[Discussion] Fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   "author": "Sashko Stubailo <sashko@stubailo.com>",
   "license": "MIT",
   "dependencies": {
-    "es6-promise": "^3.1.2",
     "graphql": "^0.4.18 || ^0.5.0",
     "lodash.assign": "^4.0.8",
     "lodash.forown": "^4.1.0",
@@ -48,7 +47,8 @@
     "lodash.isobject": "^3.0.2",
     "lodash.isstring": "^4.0.1",
     "lodash.isundefined": "^3.0.1",
-    "redux": "^3.3.1"
+    "redux": "^3.3.1",
+    "whatwg-fetch": "^0.11.0"
   },
   "devDependencies": {
     "async": "^1.5.2",

--- a/src/networkInterface.ts
+++ b/src/networkInterface.ts
@@ -1,3 +1,5 @@
+import 'whatwg-fetch';
+
 import isString = require('lodash.isstring');
 import assign = require('lodash.assign');
 


### PR DESCRIPTION
Most modern browsers support fetch natively: [link](http://caniuse.com/#feat=promises). However, a few of them don't and we want this to be easy for people.

Since fetch is a [standard](https://fetch.spec.whatwg.org/) and the polyfill for browsers is pretty [small](https://github.com/github/fetch/blob/master/fetch.js), I think sticking with fetch is the right call.

The issue comes into play when running on the server. Since the primary target of this client is the browser, I'm fine with requiring the developer to add fetch on the server (e.g node-fetch or isomorphic-fetch).

Adding in `whatwg-fetch` adds 2kb to the compiled output but should make for a uniform usage in browsers and make it easy with one line `import 'isomorphic-fetch'` to add server support with no changes to the library.  

Thoughts?