### PR TITLE
Put back mocked SWAPI once it's fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "remap-istanbul": "^0.5.1",
     "request-promise": "^2.0.1",
     "source-map-support": "^0.4.0",
-    "swapi-graphql": "^0.0.4",
+    "swapi-graphql": "^0.0.6",
     "tslint": "^3.6.0",
     "typescript": "^1.8.9",
     "typescript-require": "^0.2.9-1",

--- a/test/networkInterface.ts
+++ b/test/networkInterface.ts
@@ -17,12 +17,12 @@ import {
   MiddlewareRequest,
 } from '../src/middleware';
 
-// import {
-//   graphql,
-// } from 'graphql';
+import {
+  graphql,
+} from 'graphql';
 
 /* tslint:disable */
-// const swapiSchema = require('swapi-graphql').schema;
+const swapiSchema = require('swapi-graphql').schema;
 /* tslint:enable */
 
 describe('network interface', () => {
@@ -33,26 +33,19 @@ describe('network interface', () => {
       this.lastFetchOpts = opts;
       if (url === 'http://does-not-exist.test/') {
         return Promise.reject('Network error');
+      } else if (url === 'http://graphql-swapi.test/') {
+        return new Promise((resolve, reject) => {
+          const request = JSON.parse(opts.body);
+          graphql(swapiSchema, request.query, undefined, request.variables).then(result => {
+            const response = new global['Response'](JSON.stringify(result));
+            resolve(response);
+          }).catch(error => {
+            reject(error);
+          });
+        });
+      } else {
+        return this.realFetch(url, opts);
       }
-
-      if (url === 'http://graphql-swapi.test/') {
-        url = 'http://graphql-swapi.parseapp.com/';
-      }
-
-      // XXX swapi graphql NPM package is broken now
-      // else if (url === 'http://graphql-swapi.test/') {
-      //   return new Promise((resolve, reject) => {
-      //     const request = JSON.parse(opts.body);
-      //     graphql(swapiSchema, request.query, undefined, request.variables).then(result => {
-      //       const response = new global['Response'](JSON.stringify(result));
-      //       resolve(response);
-      //     }).catch(error => {
-      //       reject(error);
-      //     });
-      //   });
-      // }
-
-      return this.realFetch(url, opts);
     });
   });
 
@@ -317,12 +310,6 @@ describe('network interface', () => {
           errors: [
             {
               message: 'Syntax Error GraphQL request (8:9) Expected Name, found EOF\n\n7:           }\n8:         \n           ^\n',
-              locations: [
-                {
-                  column: 9,
-                  line: 8,
-                },
-              ],
             },
           ],
         }

--- a/test/networkInterface.ts
+++ b/test/networkInterface.ts
@@ -17,12 +17,8 @@ import {
   MiddlewareRequest,
 } from '../src/middleware';
 
-import {
-  graphql,
-} from 'graphql';
-
 /* tslint:disable */
-const swapiSchema = require('swapi-graphql').schema;
+const { schema: swapiSchema, graphql: swapiGraphql } = require('swapi-graphql');
 /* tslint:enable */
 
 describe('network interface', () => {
@@ -36,7 +32,7 @@ describe('network interface', () => {
       } else if (url === 'http://graphql-swapi.test/') {
         return new Promise((resolve, reject) => {
           const request = JSON.parse(opts.body);
-          graphql(swapiSchema, request.query, undefined, request.variables).then(result => {
+          swapiGraphql(swapiSchema, request.query, undefined, request.variables).then(result => {
             const response = new global['Response'](JSON.stringify(result));
             resolve(response);
           }).catch(error => {


### PR DESCRIPTION
Something about NPM deps ended up breaking the `swapi-graphql` package, so I've removed it from the build for now, and pointed back at the real server.