### PR TITLE
allow for rehydrating the store

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,20 +38,20 @@ export default class ApolloClient {
   public networkInterface: NetworkInterface;
   public store: ApolloStore;
   public reduxRootKey: string;
-  public reduxHydration: any;
+  public initialState: any;
   public queryManager: QueryManager;
 
   constructor({
     networkInterface,
     reduxRootKey,
-    reduxHydration,
+    initialState,
   }: {
     networkInterface?: NetworkInterface,
     reduxRootKey?: string,
-    reduxHydration?: any,
+    initialState?: any,
   } = {}) {
     this.reduxRootKey = reduxRootKey ? reduxRootKey : 'apollo';
-    this.reduxHydration = reduxHydration ? reduxHydration : {};
+    this.initialState = initialState ? initialState : {};
     this.networkInterface = networkInterface ? networkInterface :
       createNetworkInterface('/graphql');
   }
@@ -101,7 +101,7 @@ export default class ApolloClient {
     // If we don't have a store already, initialize a default one
     this.setStore(createApolloStore({
       reduxRootKey: this.reduxRootKey,
-      reduxHydration: this.reduxHydration,
+      initialState: this.initialState,
     }));
   };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,17 +38,20 @@ export default class ApolloClient {
   public networkInterface: NetworkInterface;
   public store: ApolloStore;
   public reduxRootKey: string;
+  public reduxHydration: any;
   public queryManager: QueryManager;
 
   constructor({
     networkInterface,
     reduxRootKey,
+    reduxHydration,
   }: {
     networkInterface?: NetworkInterface,
     reduxRootKey?: string,
+    reduxHydration?: any,
   } = {}) {
     this.reduxRootKey = reduxRootKey ? reduxRootKey : 'apollo';
-
+    this.reduxHydration = reduxHydration ? reduxHydration : {};
     this.networkInterface = networkInterface ? networkInterface :
       createNetworkInterface('/graphql');
   }
@@ -98,6 +101,7 @@ export default class ApolloClient {
     // If we don't have a store already, initialize a default one
     this.setStore(createApolloStore({
       reduxRootKey: this.reduxRootKey,
+      reduxHydration: this.reduxHydration,
     }));
   };
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -70,11 +70,11 @@ export function createApolloReducer(config: ApolloReducerConfig): Function {
 
 export function createApolloStore({
   reduxRootKey = 'apollo',
-  reduxHydration,
+  initialState,
   config = {},
 }: {
   reduxRootKey?: string,
-  reduxHydration?: any,
+  initialState?: any,
   config?: ApolloReducerConfig,
 } = {}): ApolloStore {
   const enhancers = [];
@@ -90,7 +90,7 @@ export function createApolloStore({
 
   return createStore(
     combineReducers({ [reduxRootKey]: createApolloReducer(config) }),
-    reduxHydration,
+    initialState,
     compose(...enhancers) as () => any // XXX see why this type fails
   );
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -70,9 +70,11 @@ export function createApolloReducer(config: ApolloReducerConfig): Function {
 
 export function createApolloStore({
   reduxRootKey = 'apollo',
+  reduxHydration,
   config = {},
 }: {
   reduxRootKey?: string,
+  reduxHydration?: any,
   config?: ApolloReducerConfig,
 } = {}): ApolloStore {
   const enhancers = [];
@@ -88,7 +90,8 @@ export function createApolloStore({
 
   return createStore(
     combineReducers({ [reduxRootKey]: createApolloReducer(config) }),
-    compose(...enhancers)
+    reduxHydration,
+    compose(...enhancers) as () => any // XXX see why this type fails
   );
 }
 

--- a/test/client.ts
+++ b/test/client.ts
@@ -297,7 +297,7 @@ describe('client', () => {
       result: { data },
     });
 
-    const reduxHydration = {
+    const initialState = {
       apollo: {
         queries: {
           '0': {
@@ -335,13 +335,13 @@ describe('client', () => {
 
     const client = new ApolloClient({
       networkInterface,
-      reduxHydration,
+      initialState,
     });
 
     return client.query({ query })
       .then((result) => {
         assert.deepEqual(result, { data });
-        assert.deepEqual(reduxHydration, client.store.getState());
+        assert.deepEqual(initialState, client.store.getState());
         done();
        });
   });

--- a/test/store.ts
+++ b/test/store.ts
@@ -37,4 +37,24 @@ describe('createApolloStore', () => {
       }
     );
   });
+
+  it('can be rehydrated from the server', () => {
+    const reduxHydration = {
+      apollo: {
+        queries: {
+          'test.0': true,
+        },
+        mutations: {},
+        data: {
+          'test.0': true,
+        },
+      },
+    };
+
+    const store = createApolloStore({
+      reduxHydration,
+    });
+
+    assert.deepEqual(store.getState(), reduxHydration);
+  });
 });

--- a/test/store.ts
+++ b/test/store.ts
@@ -39,7 +39,7 @@ describe('createApolloStore', () => {
   });
 
   it('can be rehydrated from the server', () => {
-    const reduxHydration = {
+    const initialState = {
       apollo: {
         queries: {
           'test.0': true,
@@ -52,9 +52,9 @@ describe('createApolloStore', () => {
     };
 
     const store = createApolloStore({
-      reduxHydration,
+      initialState,
     });
 
-    assert.deepEqual(store.getState(), reduxHydration);
+    assert.deepEqual(store.getState(), initialState);
   });
 });


### PR DESCRIPTION
Initial discussion here: https://github.com/apollostack/react-apollo/issues/22

When performing server side rendering, the apollo-client populates the store with all of the data the app requested. In order to save subsequent requests on the client side, the PR exposes a way to rehyrdate the internal redux store with the data from the server.

The added api to the client makes it easy to integrate into any SSR methods / stack.

### Included api addition

```js
const client = new ApolloClient({
  initialState,
});
```

### Example use case:

```js
// on server during render
// after application has gotten all of the data it needs
const initialState = client.store.getState()
// inject into template
<script>window.__APOLLO_STORE__ = initialState</script>

// on client
const client = new ApolloClient({
  initialState: __APOLLO_STORE__,
});
```