### PR TITLE
Polling

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,7 @@
     "node_modules": true,
     "test-lib": true,
     "lib": true,
+    "dist": true,
     "coverage": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "pretest": "npm run compile",
     "test": "npm run testonly --",
     "posttest": "npm run lint",
-    "filesize": "npm run compile:browser && ./scripts/filesize.js --file=./dist/index.min.js --maxGzip=30",
+    "filesize": "npm run compile:browser && ./scripts/filesize.js --file=./dist/index.min.js --maxGzip=31",
     "compile": "tsc",
     "compile:browser": "rm -rf ./dist && mkdir ./dist && browserify ./lib/src/index.js -o=./dist/index.js && npm run minify:browser",
     "minify:browser": "uglifyjs --compress --mangle --screw-ie8 -o=./dist/index.min.js -- ./dist/index.js",

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -348,10 +348,10 @@ export class QueryManager {
     this.fetchQuery(queryId, options);
     if (options.pollInterval) {
       this.pollingTimer = setInterval(() => {
-        const copiedOptions = assign({}, options) as WatchQueryOptions;
+        const pollingOptions = assign({}, options) as WatchQueryOptions;
         // subsequent fetches from polling always reqeust new data
-        copiedOptions.forceFetch = true;
-        this.fetchQuery(queryId, copiedOptions);
+        pollingOptions.forceFetch = true;
+        this.fetchQuery(queryId, pollingOptions);
       }, options.pollInterval);
     }
     return queryId;

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -68,6 +68,8 @@ export class ObservableQuery extends Observable<GraphQLResult> {
 
 export interface QuerySubscription extends Subscription {
   refetch(variables?: any): void;
+  stopPolling(): void;
+  startPolling(pollInterval: number): void;
 }
 
 export interface WatchQueryOptions {
@@ -85,7 +87,7 @@ export class QueryManager {
   private store: ApolloStore;
   private reduxRootKey: string;
   private dataIdFromObject: IdGetter;
-  private pollingTimer: NodeJS.Timer;
+  private pollingTimer: NodeJS.Timer | any; // oddity in typescript
 
   private queryListeners: { [queryId: string]: QueryListener };
 
@@ -200,6 +202,13 @@ export class QueryManager {
           this.stopQuery(queryId);
         },
         refetch: (variables: any): void => {
+          // if we are refetching, we clear out the polling interval
+          // if the new refetch passes pollInterval: false, it won't recreate
+          // the timer for subsequent refetches
+          if (this.pollingTimer) {
+            clearInterval(this.pollingTimer);
+          }
+
           // If no new variables passed, use existing variables
           variables = variables || options.variables;
 
@@ -208,6 +217,19 @@ export class QueryManager {
             forceFetch: true,
             variables,
           }) as WatchQueryOptions);
+        },
+        stopPolling: (): void => {
+          if (this.pollingTimer) {
+            clearInterval(this.pollingTimer);
+          }
+        },
+        startPolling: (pollInterval): void => {
+          this.pollingTimer = setInterval(() => {
+            const pollingOptions = assign({}, options) as WatchQueryOptions;
+            // subsequent fetches from polling always reqeust new data
+            pollingOptions.forceFetch = true;
+            this.fetchQuery(queryId, pollingOptions);
+          }, pollInterval);
         },
       };
     });

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -174,7 +174,7 @@ export class QueryManager {
           if (queryStoreValue.graphQLErrors) {
             if (observer.next) {
               observer.next(
-                { errors: queryStoreValue.graphQLErrors},
+                { errors: queryStoreValue.graphQLErrors },
                 () => (this.stopQuery(queryId))
               );
             }

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -173,15 +173,12 @@ export class QueryManager {
           // don't handle partial results
           if (queryStoreValue.graphQLErrors) {
             if (observer.next) {
-              observer.next(
-                { errors: queryStoreValue.graphQLErrors },
-                () => (this.stopQuery(queryId))
-              );
+              observer.next({ errors: queryStoreValue.graphQLErrors });
             }
           } else if (queryStoreValue.networkError) {
             // XXX we might not want to re-broadcast the same error over and over if it didn't change
             if (observer.error) {
-              observer.error(queryStoreValue.networkError, () => (this.stopQuery(queryId)));
+              observer.error(queryStoreValue.networkError);
             }
           } else {
             const resultFromStore = readSelectionSetFromStore({
@@ -192,7 +189,7 @@ export class QueryManager {
             });
 
             if (observer.next) {
-              observer.next({ data: resultFromStore }, () => (this.stopQuery(queryId)));
+              observer.next({ data: resultFromStore });
             }
           }
         }

--- a/src/util/Observable.ts
+++ b/src/util/Observable.ts
@@ -29,8 +29,8 @@ export class Observable<T> {
 }
 
 export interface Observer<T> {
-  next?: (value: T, done: CleanupFunction) => void;
-  error?: (error: Error, done: CleanupFunction) => void;
+  next?: (value: T) => void;
+  error?: (error: Error) => void;
   complete?: () => void;
 }
 

--- a/src/util/Observable.ts
+++ b/src/util/Observable.ts
@@ -29,8 +29,8 @@ export class Observable<T> {
 }
 
 export interface Observer<T> {
-  next?: (value: T) => void;
-  error?: (error: Error) => void;
+  next?: (value: T, done: CleanupFunction) => void;
+  error?: (error: Error, done: CleanupFunction) => void;
   complete?: () => void;
 }
 

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -1088,15 +1088,15 @@ describe('QueryManager', () => {
       pollInterval: 50,
     });
 
-    handle.subscribe({
-      next(result, unsubscribe) {
+    const subscription = handle.subscribe({
+      next(result) {
         handleCount++;
 
         if (handleCount === 1) {
           assert.deepEqual(result.data, data1);
         } else if (handleCount === 2) {
           assert.deepEqual(result.data, data2);
-          unsubscribe();
+          subscription.unsubscribe();
           done();
         }
       },
@@ -1152,15 +1152,15 @@ describe('QueryManager', () => {
       pollInterval: 50,
     });
 
-    handle.subscribe({
-      next(result, unsubscribe) {
+    const subscription = handle.subscribe({
+      next(result) {
         handleCount++;
 
         if (handleCount === 1) {
           assert.deepEqual(result.data, data1);
         } else if (handleCount === 2) {
           assert.deepEqual(result.data, data2);
-          unsubscribe();
+          subscription.unsubscribe();
         }
       },
     });
@@ -1225,7 +1225,7 @@ describe('QueryManager', () => {
       pollInterval: 50,
     });
 
-    handle.subscribe({
+    const subscription = handle.subscribe({
       next(result) {
         handleCount++;
 
@@ -1235,9 +1235,9 @@ describe('QueryManager', () => {
           done(new Error('Should not deliver second result'));
         }
       },
-      error: (error, unsubscribe) => {
+      error: (error) => {
         assert.equal(error.message, 'Network error');
-        unsubscribe();
+        subscription.unsubscribe();
       },
     });
 

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -1279,12 +1279,9 @@ describe('QueryManager', () => {
       },
       {
         request: { query, variables },
-        error: new Error('Network error'),
-      },
-      {
-        request: { query, variables },
         result: { data: data2 },
       }
+
     );
 
     const queryManager = new QueryManager({
@@ -1307,26 +1304,18 @@ describe('QueryManager', () => {
         if (handleCount === 1) {
           assert.deepEqual(result.data, data1);
         } else if (handleCount === 2) {
-          done(new Error('Should not deliver second result'));
+          assert.deepEqual(result.data, data2);
+          done();
         }
-      },
-      error: (error) => {
-        assert.equal(error.message, 'Network error');
-        subscription.unsubscribe();
       },
     });
 
     subscription.startPolling(50);
 
-    setTimeout(() => {
-      assert.equal(handleCount, 1);
-      done();
-    }, 160);
-
   });
   it('exposes a way to stop a polling query', (done) => {
     const query = `
-      query fetchLuke($id: String) {
+      query fetchLeia($id: String) {
         people_one(id: $id) {
           name
         }
@@ -1334,18 +1323,18 @@ describe('QueryManager', () => {
     `;
 
     const variables = {
-      id: '1',
+      id: '2',
     };
 
     const data1 = {
       people_one: {
-        name: 'Luke Skywalker',
+        name: 'Leia Skywalker',
       },
     };
 
     const data2 = {
       people_one: {
-        name: 'Luke Skywalker has a new name',
+        name: 'Leia Skywalker has a new name',
       },
     };
 
@@ -1378,10 +1367,7 @@ describe('QueryManager', () => {
       next(result) {
         handleCount++;
 
-        if (handleCount === 1) {
-          assert.deepEqual(result.data, data1);
-        } else if (handleCount === 2) {
-          assert.deepEqual(result.data, data2);
+        if (handleCount === 2) {
           subscription.stopPolling();
         }
       },

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -1247,6 +1247,152 @@ describe('QueryManager', () => {
     }, 160);
 
   });
+  it('exposes a way to start a polling query', (done) => {
+    const query = `
+      query fetchLuke($id: String) {
+        people_one(id: $id) {
+          name
+        }
+      }
+    `;
+
+    const variables = {
+      id: '1',
+    };
+
+    const data1 = {
+      people_one: {
+        name: 'Luke Skywalker',
+      },
+    };
+
+    const data2 = {
+      people_one: {
+        name: 'Luke Skywalker has a new name',
+      },
+    };
+
+    const networkInterface = mockNetworkInterface(
+      {
+        request: { query, variables },
+        result: { data: data1 },
+      },
+      {
+        request: { query, variables },
+        error: new Error('Network error'),
+      },
+      {
+        request: { query, variables },
+        result: { data: data2 },
+      }
+    );
+
+    const queryManager = new QueryManager({
+      networkInterface,
+      store: createApolloStore(),
+      reduxRootKey: 'apollo',
+    });
+
+    let handleCount = 0;
+
+    const handle = queryManager.watchQuery({
+      query,
+      variables,
+    });
+
+    const subscription = handle.subscribe({
+      next(result) {
+        handleCount++;
+
+        if (handleCount === 1) {
+          assert.deepEqual(result.data, data1);
+        } else if (handleCount === 2) {
+          done(new Error('Should not deliver second result'));
+        }
+      },
+      error: (error) => {
+        assert.equal(error.message, 'Network error');
+        subscription.unsubscribe();
+      },
+    });
+
+    subscription.startPolling(50);
+
+    setTimeout(() => {
+      assert.equal(handleCount, 1);
+      done();
+    }, 160);
+
+  });
+  it('exposes a way to stop a polling query', (done) => {
+    const query = `
+      query fetchLuke($id: String) {
+        people_one(id: $id) {
+          name
+        }
+      }
+    `;
+
+    const variables = {
+      id: '1',
+    };
+
+    const data1 = {
+      people_one: {
+        name: 'Luke Skywalker',
+      },
+    };
+
+    const data2 = {
+      people_one: {
+        name: 'Luke Skywalker has a new name',
+      },
+    };
+
+    const networkInterface = mockNetworkInterface(
+      {
+        request: { query, variables },
+        result: { data: data1 },
+      },
+      {
+        request: { query, variables },
+        result: { data: data2 },
+      }
+    );
+
+    const queryManager = new QueryManager({
+      networkInterface,
+      store: createApolloStore(),
+      reduxRootKey: 'apollo',
+    });
+
+    let handleCount = 0;
+
+    const handle = queryManager.watchQuery({
+      query,
+      variables,
+      pollInterval: 50,
+    });
+
+    const subscription = handle.subscribe({
+      next(result) {
+        handleCount++;
+
+        if (handleCount === 1) {
+          assert.deepEqual(result.data, data1);
+        } else if (handleCount === 2) {
+          assert.deepEqual(result.data, data2);
+          subscription.stopPolling();
+        }
+      },
+    });
+
+    setTimeout(() => {
+      assert.equal(handleCount, 2);
+      done();
+    }, 160);
+
+  });
 });
 
 function testDiffing(


### PR DESCRIPTION
Added ability to poll endpoint on a per query basis

Per #145 

### Docs:

One way to create a reactive-esque query is to use polling. Apollo accepts a `pollInterval` on the `WatchQueryOptions` which is the interval that a forced refetch will be called.

```es6
const handle = client.watchQuery({
  query: `
    query getCategory($categoryId: Int!) {
      category(id: $categoryId) {
        name
        color
      }
    }
  `,
  variables: {
    categoryId: 5,
  },
  forceFetch: false,
  returnPartialData: true,
  pollInterval: 1000, // ms to poll
});
```

Some cases may call for the ability to dynamically stop or start a polling interval on an existing query. The subscription handle returned by `handle.subscribe()` includes `stopPolling` and `startPolling` methods. These can be used like so:

```es6

const handle = client.watchQuery({
  query: `
    query getCategory($categoryId: Int!) {
      category(id: $categoryId) {
        name
        color
      }
    }
  `,
  variables: {
    categoryId: 5,
  },
  forceFetch: false,
  returnPartialData: true,
});

const subscription = handle.subscribe();

subscription.startPolling(50) // 50 ms poll starting
subscription.stopPolling() // stop polling
```

Docs PR: https://github.com/apollostack/docs/pull/53
