### PR TITLE
Refetch promise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Expect active development and potentially significant breaking changes in the `0
 ### vNEXT
 
 - Namespace Apollo action types to prevent collision with user's own Redux action types. [Issue #210](https://github.com/apollostack/apollo-client/issues/210) [PR #222](https://github.com/apollostack/apollo-client/pull/222) 
+- Queries on refetch return promises. [PR #178](https://github.com/apollostack/apollo-client/pull/178)
 
 ### v0.3.8
 

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -352,7 +352,7 @@ export class QueryManager {
           });
 
           return result;
-        }).then((result: GraphQLResult) => {
+        }).then(() => {
 
           let resultFromStore;
           try {

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -66,7 +66,7 @@ export class ObservableQuery extends Observable<GraphQLResult> {
 }
 
 export interface QuerySubscription extends Subscription {
-  refetch(variables?: any): void;
+  refetch(variables?: any): Promise<GraphQLResult>;
   stopPolling(): void;
   startPolling(pollInterval: number): void;
 }
@@ -365,7 +365,7 @@ export class QueryManager {
 
       // return a chainable promise
       return new Promise((resolve) => {
-        resolve();
+        resolve({ data: initialResult });
       });
     }
   }

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -383,12 +383,11 @@ export class QueryManager {
 
           return error;
         });
-    } else {
-      // return a chainable promise
-      return new Promise((resolve) => {
-        resolve({ data: initialResult });
-      });
     }
+    // return a chainable promise
+    return new Promise((resolve) => {
+      resolve({ data: initialResult });
+    });
   }
 
   private getApolloState(): Store {

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -324,7 +324,7 @@ export class QueryManager {
 
     if (! minimizedQuery || returnPartialData) {
       this.store.dispatch({
-        type: 'QUERY_RESULT_CLIENT',
+        type: 'APOLLO_QUERY_RESULT_CLIENT',
         result: {
           data: initialResult,
         },

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -557,6 +557,56 @@ describe('QueryManager', () => {
     });
   });
 
+  it('allows you to refetch queries with promises', (done) => {
+    const query = gql`
+      {
+        people_one(id: 1) {
+          name
+        }
+      }
+    `;
+
+    const data1 = {
+      people_one: {
+        name: 'Luke Skywalker',
+      },
+    };
+
+    const data2 = {
+      people_one: {
+        name: 'Luke Skywalker has a new name',
+      },
+    };
+
+    const networkInterface = mockNetworkInterface(
+      {
+        request: { query },
+        result: { data: data1 },
+      },
+      {
+        request: { query },
+        result: { data: data2 },
+      }
+    );
+
+    const queryManager = new QueryManager({
+      networkInterface,
+      store: createApolloStore(),
+      reduxRootKey: 'apollo',
+    });
+
+    const handle = queryManager.watchQuery({
+      query,
+    });
+
+    const subscription = handle.subscribe({});
+
+    subscription.refetch().then((result) => {
+      assert.deepEqual(result.data, data2);
+      done();
+    });
+  });
+
   it('allows you to refetch queries with new variables', (done) => {
     const query = gql`
       {


### PR DESCRIPTION
This is for a change to the QueryManager on refetch to return a Promise instead of void. By returning a promise you eliminate the need to wrap any requests for updating data. So instead of:

```js
refreshFeed = (resolve, reject) => {
  this.props.data.refetch();
  resolve();
}

<ReactPullToRefresh
  onRefresh={ this.refreshFeed }>
</ReactPullToRefresh>
```

You can call `refetch` directly from the Compontent: 

```js
<ReactPullToRefresh
  onRefresh={ this.props.data.refetch }
</ReactPullToRefresh>
```

TODO:

- [ ] Update CHANGELOG.md with your change
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
