### PR TITLE
[WIP] reroute npm publish to deploy scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "compile:browser": "rm -rf ./dist && mkdir ./dist && browserify ./lib/src/index.js -o=./dist/index.js && npm run minify:browser",
     "minify:browser": "uglifyjs --compress --mangle --screw-ie8 -o=./dist/index.min.js -- ./dist/index.js",
     "watch": "tsc -w",
-    "prepublish": "npm run compile",
+    "prepublish": "npm run deploy",
     "lint": "grunt tslint",
     "coverage": "istanbul cover ./node_modules/mocha/bin/_mocha -- --reporter dot --full-trace lib/test/tests.js",
     "postcoverage": "remap-istanbul --input coverage/coverage.json --type lcovonly --output coverage/lcov.info",

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,5 +1,10 @@
 #!/bin/sh -e
-
+# Because of a long-running npm issue (https://github.com/npm/npm/issues/3059)
+# prepublish runs after `npm install` and `npm pack`.
+# In order to only run prepublish before `npm publish`, we have to check argv.
+if node -e "process.exit(($npm_config_argv).original[0].indexOf('pu') === 0)"; then
+  exit 0;
+fi
 
 # When we publish to npm, the published files are available in the root
 # directory, which allows for a clean include or require of sub-modules.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -6,12 +6,16 @@ if node -e "process.exit(($npm_config_argv).original[0].indexOf('pu') === 0)"; t
   exit 0;
 fi
 
+
+if node -e "process.exit(process.platform.indexOf('win32') === 0)"; then
+  exit 0;
+fi
+
 # When we publish to npm, the published files are available in the root
 # directory, which allows for a clean include or require of sub-modules.
 #
 #    var language = require('apollo-client/parser');
 #
-
 npm run compile
 
 rm -rf ./npm


### PR DESCRIPTION
Now `npm publish` is the way to publish instead of `npm run deploy`

Locally running `npm i` will print out `npm run deploy`. This won't actually deploy but is required in order to route `npm publish` to our custom script.

On the npm shipped version, we remove all of the scripts so `npm run deploy` won't happen on anyone else's machine.

Fixes #188 
.