### PR TITLE
Update 1.0 goal in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log
 
-Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 1 or 2 months), so that we can take advantage of SemVer to signify breaking changes from that point on.
+Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 3 to 6 months), to signal the start of a more stable API.
 
 ### vNEXT
 


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

I didn't realize that NPM actually treats minor version bumps as breaking changes in the `0.x.y` series of versions, so users still get warned about breaking changes even when Apollo Client is not 1.0. This means we should only bump to the 1.0 version once it's important to have a stable API and we consider breaking changes a lot more carefully than we do now.