### PR TITLE
[WIP] Pluggable normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Expect active development and potentially significant breaking changes in the `0
 
 ### vNEXT
 
-- ...
+- Add `dataIdFromObject` option to `ApolloClient` constructor, to allow data normalization. This function should take a GraphQL result object, and return an ID if one can be found. [Issue #204](https://github.com/apollostack/apollo-client/issues/204) [PR #214](https://github.com/apollostack/apollo-client/pull/214)
 
 ### v0.3.6
 

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -41,10 +41,6 @@ import {
   printQueryFromDefinition,
 } from './queryPrinting';
 
-import {
-  IdGetter,
-} from './data/extensions';
-
 import { Observable, Observer, Subscription } from './util/Observable';
 
 export class ObservableQuery extends Observable<GraphQLResult> {
@@ -89,7 +85,6 @@ export class QueryManager {
   private networkInterface: NetworkInterface;
   private store: ApolloStore;
   private reduxRootKey: string;
-  private dataIdFromObject: IdGetter;
   private pollingTimer: NodeJS.Timer | any; // oddity in typescript
 
   private queryListeners: { [queryId: string]: QueryListener };
@@ -100,19 +95,16 @@ export class QueryManager {
     networkInterface,
     store,
     reduxRootKey,
-    dataIdFromObject,
   }: {
     networkInterface: NetworkInterface,
     store: ApolloStore,
     reduxRootKey: string,
-    dataIdFromObject?: IdGetter,
   }) {
     // XXX this might be the place to do introspection for inserting the `id` into the query? or
     // is that the network interface?
     this.networkInterface = networkInterface;
     this.store = store;
     this.reduxRootKey = reduxRootKey;
-    this.dataIdFromObject = dataIdFromObject;
 
     this.queryListeners = {};
 
@@ -290,7 +282,6 @@ export class QueryManager {
         throwOnMissingField: false,
         rootId: querySS.id,
         variables,
-        dataIdFromObject: this.dataIdFromObject,
       });
 
       initialResult = result;

--- a/src/data/diffAgainstStore.ts
+++ b/src/data/diffAgainstStore.ts
@@ -20,10 +20,6 @@ import {
 } from '../queries/store';
 
 import {
-  IdGetter,
-} from './extensions';
-
-import {
   SelectionSet,
   Field,
   Document,
@@ -45,12 +41,10 @@ export function diffQueryAgainstStore({
   store,
   query,
   variables,
-  dataIdFromObject,
 }: {
   store: NormalizedCache,
   query: Document,
   variables?: Object,
-  dataIdFromObject?: IdGetter,
 }): DiffResult {
   const queryDef = getQueryDefinition(query);
 
@@ -60,7 +54,6 @@ export function diffQueryAgainstStore({
     selectionSet: queryDef.selectionSet,
     throwOnMissingField: false,
     variables,
-    dataIdFromObject,
   });
 }
 
@@ -69,13 +62,11 @@ export function diffFragmentAgainstStore({
   fragment,
   rootId,
   variables,
-  dataIdFromObject,
 }: {
   store: NormalizedCache,
   fragment: Document,
   rootId: string,
   variables?: Object,
-  dataIdFromObject?: IdGetter,
 }): DiffResult {
   const fragmentDef = getFragmentDefinition(fragment);
 
@@ -85,7 +76,6 @@ export function diffFragmentAgainstStore({
     selectionSet: fragmentDef.selectionSet,
     throwOnMissingField: false,
     variables,
-    dataIdFromObject,
   });
 }
 
@@ -106,14 +96,12 @@ export function diffSelectionSetAgainstStore({
   rootId,
   throwOnMissingField = false,
   variables,
-  dataIdFromObject,
 }: {
   selectionSet: SelectionSet,
   store: NormalizedCache,
   rootId: string,
   throwOnMissingField: boolean,
   variables: Object,
-  dataIdFromObject?: IdGetter,
 }): DiffResult {
   if (selectionSet.kind !== 'SelectionSet') {
     throw new Error('Must be a selection set.');
@@ -142,7 +130,6 @@ export function diffSelectionSetAgainstStore({
         variables,
         rootId,
         store,
-        dataIdFromObject,
       });
 
       if (fieldIsMissing) {
@@ -162,7 +149,6 @@ export function diffSelectionSetAgainstStore({
         variables,
         rootId,
         store,
-        dataIdFromObject,
       });
 
       if (fieldIsMissing) {
@@ -214,14 +200,12 @@ function diffFieldAgainstStore({
   variables,
   rootId,
   store,
-  dataIdFromObject,
 }: {
   field: Field,
   throwOnMissingField: boolean,
   variables: Object,
   rootId: string,
   store: NormalizedCache,
-  dataIdFromObject: IdGetter,
 }): FieldDiffResult {
   const storeObj = store[rootId] || {};
   const storeFieldKey = storeKeyNameFromField(field, variables);
@@ -269,7 +253,6 @@ function diffFieldAgainstStore({
         rootId: id,
         selectionSet: field.selectionSet,
         variables,
-        dataIdFromObject,
       });
 
       if (itemDiffResult.isMissing) {
@@ -293,7 +276,6 @@ function diffFieldAgainstStore({
       rootId: storeValue,
       selectionSet: field.selectionSet,
       variables,
-      dataIdFromObject,
     });
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
   createApolloStore,
   ApolloStore,
   createApolloReducer,
+  ApolloReducerConfig,
 } from './store';
 
 import {
@@ -24,6 +25,10 @@ import {
   readQueryFromStore,
   readFragmentFromStore,
 } from './data/readFromStore';
+
+import {
+  IdGetter,
+} from './data/extensions';
 
 import isUndefined = require('lodash.isundefined');
 
@@ -41,20 +46,27 @@ export default class ApolloClient {
   public reduxRootKey: string;
   public initialState: any;
   public queryManager: QueryManager;
+  public reducerConfig: ApolloReducerConfig;
 
   constructor({
     networkInterface,
     reduxRootKey,
     initialState,
+    dataIdFromObject,
   }: {
     networkInterface?: NetworkInterface,
     reduxRootKey?: string,
     initialState?: any,
+    dataIdFromObject?: IdGetter,
   } = {}) {
     this.reduxRootKey = reduxRootKey ? reduxRootKey : 'apollo';
     this.initialState = initialState ? initialState : {};
     this.networkInterface = networkInterface ? networkInterface :
       createNetworkInterface('/graphql');
+
+    this.reducerConfig = {
+      dataIdFromObject,
+    };
   }
 
   public watchQuery = (options: WatchQueryOptions): ObservableQuery => {
@@ -78,7 +90,7 @@ export default class ApolloClient {
   };
 
   public reducer(): Function {
-    return createApolloReducer({});
+    return createApolloReducer(this.reducerConfig);
   }
 
   public middleware = () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,6 +115,7 @@ export default class ApolloClient {
     this.setStore(createApolloStore({
       reduxRootKey: this.reduxRootKey,
       initialState: this.initialState,
+      config: this.reducerConfig,
     }));
   };
 

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -1678,7 +1678,6 @@ function testDiffing(
       config: { dataIdFromObject: getIdField },
     }),
     reduxRootKey: 'apollo',
-    dataIdFromObject: config.dataIdFromObject,
   });
 
   const steps = queryArray.map(({ query, fullResponse, variables }) => {


### PR DESCRIPTION
The goal is to allow people to pass their own ID getter functions to pick the key that is used for an object when it is put into the store. This addresses #204, but also makes #180 much easier.

TODO:

- [x] Update CHANGELOG.md with your change
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

Testing strategy:
- [x] Check internal store of apollo client when option is passed to make sure it is used when writing to store; internal functions are already tested