### PR TITLE
rename action types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Expect active development and potentially significant breaking changes in the `0
 
 ### vNEXT
 
+- Namespace Apollo action types to prevent collision with user's own Redux action types. [Issue #210](https://github.com/apollostack/apollo-client/issues/210) [PR #222](https://github.com/apollostack/apollo-client/pull/222) 
+
 ### v0.3.8
 
 - Add support for [GraphQLJSON](https://github.com/taion/graphql-type-json) scalar type by changing the way we identify scalar types when writing to the store. [Issue #217](https://github.com/apollostack/apollo-client/issues/217) [PR #219](https://github.com/apollostack/apollo-client/pull/219)

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -140,7 +140,7 @@ export class QueryManager {
     } as Request;
 
     this.store.dispatch({
-      type: 'MUTATION_INIT',
+      type: 'APOLLO_MUTATION_INIT',
       mutationString,
       mutation: {
         id: 'ROOT_MUTATION',
@@ -154,7 +154,7 @@ export class QueryManager {
     return this.networkInterface.query(request)
       .then((result) => {
         this.store.dispatch({
-          type: 'MUTATION_RESULT',
+          type: 'APOLLO_MUTATION_RESULT',
           result,
           mutationId,
         });
@@ -310,7 +310,7 @@ export class QueryManager {
 
     // Initialize query in store with unique requestId
     this.store.dispatch({
-      type: 'QUERY_INIT',
+      type: 'APOLLO_QUERY_INIT',
       queryString,
       query: querySS,
       minimizedQueryString,
@@ -332,14 +332,14 @@ export class QueryManager {
         .then((result: GraphQLResult) => {
           // XXX handle multiple GraphQLResults
           this.store.dispatch({
-            type: 'QUERY_RESULT',
+            type: 'APOLLO_QUERY_RESULT',
             result,
             queryId,
             requestId,
           });
         }).catch((error: Error) => {
           this.store.dispatch({
-            type: 'QUERY_ERROR',
+            type: 'APOLLO_QUERY_ERROR',
             error,
             queryId,
             requestId,
@@ -349,7 +349,7 @@ export class QueryManager {
 
     if (! minimizedQuery || returnPartialData) {
       this.store.dispatch({
-        type: 'QUERY_RESULT_CLIENT',
+        type: 'APOLLO_QUERY_RESULT_CLIENT',
         result: {
           data: initialResult,
         },
@@ -391,7 +391,7 @@ export class QueryManager {
     }
 
     this.store.dispatch({
-      type: 'QUERY_STOP',
+      type: 'APOLLO_QUERY_STOP',
       queryId,
     });
   }

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -7,29 +7,29 @@ import {
 } from './queries/store';
 
 export interface QueryResultAction {
-  type: 'QUERY_RESULT';
+  type: 'APOLLO_QUERY_RESULT';
   result: GraphQLResult;
   queryId: string;
   requestId: number;
 }
 
 export function isQueryResultAction(action: ApolloAction): action is QueryResultAction {
-  return action.type === 'QUERY_RESULT';
+  return action.type === 'APOLLO_QUERY_RESULT';
 }
 
 export interface QueryErrorAction {
-  type: 'QUERY_ERROR';
+  type: 'APOLLO_QUERY_ERROR';
   error: Error;
   queryId: string;
   requestId: number;
 }
 
 export function isQueryErrorAction(action: ApolloAction): action is QueryErrorAction {
-  return action.type === 'QUERY_ERROR';
+  return action.type === 'APOLLO_QUERY_ERROR';
 }
 
 export interface QueryInitAction {
-  type: 'QUERY_INIT';
+  type: 'APOLLO_QUERY_INIT';
   queryString: string;
   query: SelectionSetWithRoot;
   minimizedQueryString: string;
@@ -42,31 +42,31 @@ export interface QueryInitAction {
 }
 
 export function isQueryInitAction(action: ApolloAction): action is QueryInitAction {
-  return action.type === 'QUERY_INIT';
+  return action.type === 'APOLLO_QUERY_INIT';
 }
 
 export interface QueryResultClientAction {
-  type: 'QUERY_RESULT_CLIENT';
+  type: 'APOLLO_QUERY_RESULT_CLIENT';
   result: GraphQLResult;
   complete: boolean;
   queryId: string;
 }
 
 export function isQueryResultClientAction(action: ApolloAction): action is QueryResultClientAction {
-  return action.type === 'QUERY_RESULT_CLIENT';
+  return action.type === 'APOLLO_QUERY_RESULT_CLIENT';
 }
 
 export interface QueryStopAction {
-  type: 'QUERY_STOP';
+  type: 'APOLLO_QUERY_STOP';
   queryId: string;
 }
 
 export function isQueryStopAction(action: ApolloAction): action is QueryStopAction {
-  return action.type === 'QUERY_STOP';
+  return action.type === 'APOLLO_QUERY_STOP';
 }
 
 export interface MutationInitAction {
-  type: 'MUTATION_INIT';
+  type: 'APOLLO_MUTATION_INIT';
   mutationString: string;
   mutation: SelectionSetWithRoot;
   variables: Object;
@@ -74,17 +74,17 @@ export interface MutationInitAction {
 }
 
 export function isMutationInitAction(action: ApolloAction): action is MutationInitAction {
-  return action.type === 'MUTATION_INIT';
+  return action.type === 'APOLLO_MUTATION_INIT';
 }
 
 export interface MutationResultAction {
-  type: 'MUTATION_RESULT';
+  type: 'APOLLO_MUTATION_RESULT';
   result: GraphQLResult;
   mutationId: string;
 }
 
 export function isMutationResultAction(action: ApolloAction): action is MutationResultAction {
-  return action.type === 'MUTATION_RESULT';
+  return action.type === 'APOLLO_MUTATION_RESULT';
 }
 
 export type ApolloAction =


### PR DESCRIPTION
Prefix Action Types with `APOLLO_`

[#210](https://github.com/apollostack/apollo-client/issues/210)

TODO:

- [x] Update CHANGELOG.md with your change
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass