### PR TITLE
Implement method to add __typename field to queries

### DIFF
--- a/ambient.d.ts
+++ b/ambient.d.ts
@@ -73,6 +73,11 @@ declare module 'lodash.mapvalues' {
   export = main.mapValues;
 }
 
+declare module 'lodash.clonedeep' {
+  import main = require('~lodash/index');
+  export = main.cloneDeep
+}
+
 /*
 
   GRAPHQL

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "es6-promise": "^3.1.2",
     "graphql": "^0.4.18 || ^0.5.0",
     "lodash.assign": "^4.0.8",
+    "lodash.clonedeep": "^4.3.2",
     "lodash.forown": "^4.1.0",
     "lodash.has": "^4.3.1",
     "lodash.includes": "^4.1.2",

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -3,6 +3,7 @@ import {
   Request,
 } from './networkInterface';
 
+
 import forOwn = require('lodash.forown');
 import assign = require('lodash.assign');
 
@@ -47,6 +48,7 @@ export class ObservableQuery extends Observable<GraphQLResult> {
   public subscribe(observer: Observer<GraphQLResult>): QuerySubscription {
     return super.subscribe(observer) as QuerySubscription;
   }
+
 
   public result(): Promise<GraphQLResult> {
     return new Promise((resolve, reject) => {

--- a/src/queries/queryTransform.ts
+++ b/src/queries/queryTransform.ts
@@ -1,0 +1,46 @@
+import {
+  SelectionSet,
+  OperationDefinition,
+  Field,
+  InlineFragment,
+} from 'graphql';
+
+import cloneDeep = require('lodash.clonedeep');
+
+// Adds typename fields to every node in the AST recursively. Returns a copy of the entire
+// AST with the typename fields added.
+// Note: This muates the AST passed in.
+export function addTypenameToSelectionSet(queryPiece: SelectionSet) {
+  if (queryPiece == null || queryPiece.selections == null) {
+    return queryPiece;
+  }
+
+  const typenameFieldAST: Field = {
+    kind: 'Field',
+    alias: null,
+    name: {
+      kind: 'Name',
+      value: '__typename',
+    },
+  };
+
+  queryPiece.selections.map((child) => {
+    // We use type assertions to make sure the child isn't a FragmentSpread because
+    // that can't have a selectionSet.
+    if (child.kind === 'Field' || child.kind === 'InlineFragment') {
+      addTypenameToSelectionSet((child as (Field | InlineFragment)).selectionSet);
+    }
+  });
+
+  // Add the typename to this particular node's children
+  queryPiece.selections.push(typenameFieldAST);
+  return queryPiece;
+}
+
+// Add typename field to the root query node (i.e. OperationDefinition). Returns a new
+// query tree.
+export function addTypenameToQuery(queryDef: OperationDefinition): OperationDefinition {
+  const queryClone = cloneDeep(queryDef);
+  this.addTypenameToSelectionSet(queryClone.selectionSet);
+  return queryClone;
+}

--- a/test/queryTransform.ts
+++ b/test/queryTransform.ts
@@ -1,0 +1,99 @@
+import {
+  addTypenameToSelectionSet,
+  addTypenameToQuery,
+} from '../src/queries/queryTransform';
+import { getQueryDefinition } from '../src/queries/getFromAST';
+import { print } from 'graphql/language/printer';
+import gql from '../src/gql';
+import { assert } from 'chai';
+
+describe('query transforms', () => {
+  it('should correctly add typenames', () => {
+    let testQuery = gql`
+      query {
+        author {
+          name {
+            firstName
+            lastName
+          }
+        }
+      }
+`;
+    const queryDef = getQueryDefinition(testQuery);
+    const queryRes = addTypenameToSelectionSet(queryDef.selectionSet);
+
+    // GraphQL print the parsed, updated query and replace the trailing
+    // newlines.
+    const modifiedQueryStr = print(queryRes);
+    const expectedQuery = getQueryDefinition(gql`
+      query {
+        author {
+          name {
+            firstName
+            lastName
+            __typename
+          }
+          __typename
+        }
+        __typename}`);
+    const expectedQueryStr = print(expectedQuery);
+
+    assert.equal(expectedQueryStr, modifiedQueryStr);
+  });
+
+  it('should correctly alter a query from the root', () => {
+    const testQuery = gql`
+      query {
+        testString
+      }`;
+    const expectedQuery = getQueryDefinition(gql`
+      query {
+        testString
+        __typename
+      }`);
+    const modifiedQuery = addTypenameToQuery(getQueryDefinition(testQuery));
+    const modifiedQueryStr = print(modifiedQuery);
+    const expectedQueryStr = print(expectedQuery);
+    assert.equal(expectedQueryStr, modifiedQueryStr);
+  });
+
+  it('should not alter the original query AST', () => {
+    const testQuery = gql`
+      query {
+        user {
+          firstName
+          lastName
+        }
+      }`;
+    const expectedQueryStr = print(testQuery);
+    addTypenameToQuery(getQueryDefinition(testQuery));
+
+    //make sure that producing the modified query has not changed the original query
+    assert.equal(expectedQueryStr, print(testQuery));
+  });
+
+  it('should not screw up on a FragmentSpread within the query AST', () => {
+    const testQuery = getQueryDefinition(gql`
+    query withFragments {
+      user(id: 4) {
+        friends(first: 10) {
+          ...friendFields
+        }
+      }
+    }`);
+    const expectedQuery = getQueryDefinition(gql`
+    query withFragments {
+      user(id: 4) {
+        friends(first: 10) {
+          ...friendFields
+          __typename
+        }
+        __typename
+      }
+      __typename
+    }`);
+    const modifiedQuery = addTypenameToQuery(testQuery);
+    assert.equal(print(expectedQuery), print(modifiedQuery));
+  });
+
+});

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -18,3 +18,4 @@ import './client';
 import './middleware';
 import './store';
 import './gql';
+import './queryTransform';

--- a/typings.json
+++ b/typings.json
@@ -14,5 +14,9 @@
     "promises-a-plus": "registry:dt/promises-a-plus#0.0.0+20160317120654",
     "redux": "registry:dt/redux#1.0.0+20160317120654",
     "apollo-client": "file:./ambient.d.ts"
+  },
+  "resolution": {
+    "main": "typings/main",
+    "browser": "typings/browser"
   }
 }

--- a/typings/browser/ambient/apollo-client/index.d.ts
+++ b/typings/browser/ambient/apollo-client/index.d.ts
@@ -75,6 +75,11 @@ declare module 'lodash.mapvalues' {
   export = main.mapValues;
 }
 
+declare module 'lodash.clonedeep' {
+  import main = require('~lodash/index');
+  export = main.cloneDeep
+}
+
 /*
 
   GRAPHQL

--- a/typings/main/ambient/apollo-client/index.d.ts
+++ b/typings/main/ambient/apollo-client/index.d.ts
@@ -75,6 +75,11 @@ declare module 'lodash.mapvalues' {
   export = main.mapValues;
 }
 
+declare module 'lodash.clonedeep' {
+  import main = require('~lodash/index');
+  export = main.cloneDeep
+}
+
 /*
 
   GRAPHQL


### PR DESCRIPTION
Added the __typename addition logic with unit tests. Haven't integrated with QueryManager yet - will do that as the next step. #27 

TODO:

- [ ] Update CHANGELOG.md with your change
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
