### PR TITLE
Resolve stopQuery/broadcastQueries race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Expect active development and potentially significant breaking changes in the `0
 
 ### vNEXT
 
+- Resolve a race condition between `QueryManager` `stopQuery()` and `broadcastQueries()`. [Issue #231](https://github.com/apollostack/apollo-client/issues/231) [PR #232](https://github.com/apollostack/apollo-client/pull/232)
+
 ### v0.3.9
 
 - Namespace Apollo action types to prevent collision with user's own Redux action types. [Issue #210](https://github.com/apollostack/apollo-client/issues/210) [PR #222](https://github.com/apollostack/apollo-client/pull/222)

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -430,8 +430,11 @@ export class QueryManager {
   private broadcastQueries() {
     const queries = this.getApolloState().queries;
     forOwn(this.queryListeners, (listener: QueryListener, queryId: string) => {
-      const queryStoreValue = queries[queryId];
-      listener(queryStoreValue);
+      // it's possible for the listener to be undefined if the query is being stopped
+      if (listener) {
+        const queryStoreValue = queries[queryId];
+        listener(queryStoreValue);
+      }
     });
   }
 


### PR DESCRIPTION
- [x] Update CHANGELOG.md with your change
- [x] ~~Make sure all of the significant new logic is covered by tests~~ (Small change to avoid race condition, hard to effectively reproduce in tests.)
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass (There are pre-existing middleware tests in master that currently fail for me intermittently due to timeouts, but this change has no effect on test failures.)

Fix for #231.

* Add check for `listener` in QueryManager's `broadcastQueries()`

It is possible the deletion of a query listener in `stopQuery()`
and the `forOwn` iteration of query listeners in `broadcastQueries()` to
overlap, causing a race condition. This explicitly checks that
the listener exists before attempting to invoke it.