### PR TITLE
Pluggable query transforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Expect active development and potentially significant breaking changes in the `0
 
 ### vNEXT
 
-- Add support for basic query transformation before submitting to the server by passing an option to `ApolloClient` constructor. (e.g. adding `__typename` to each SelectionSet)
+- Add support for basic query transformation before submitting to the server by passing an option to `ApolloClient` constructor. (e.g. adding `__typename` to each SelectionSet) [Issue #230](https://github.com/apollostack/apollo-client/issues/230) [PR #233](https://github.com/apollostack/apollo-client/pull/233)
 
 ### v0.3.10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 3 to 6 months), to signal the start of a more stable API.
 
 ### vNEXT
-- Add support for transforming queries before submitting to the server (e.g. adding "__typename" to each SelectionSet)
+
+- Add support for basic query transformation before submitting to the server by passing an option to `ApolloClient` constructor. (e.g. adding `__typename` to each SelectionSet)
 
 ### v0.3.10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 3 to 6 months), to signal the start of a more stable API.
 
 ### vNEXT
+- Add support for transforming queries before submitting to the server (e.g. adding "__typename" to each SelectionSet)
 
 ### v0.3.10
 

--- a/package.json
+++ b/package.json
@@ -51,8 +51,7 @@
     "lodash.isstring": "^4.0.1",
     "lodash.isundefined": "^3.0.1",
     "redux": "^3.3.1",
-    "symbol-observable": "^0.2.4",
-    "to-iso-string": "0.0.2"
+    "symbol-observable": "^0.2.4"
   },
   "devDependencies": {
     "async": "^1.5.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "lodash.isstring": "^4.0.1",
     "lodash.isundefined": "^3.0.1",
     "redux": "^3.3.1",
-    "symbol-observable": "^0.2.4"
+    "symbol-observable": "^0.2.4",
+    "to-iso-string": "0.0.2"
   },
   "devDependencies": {
     "async": "^1.5.2",

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -23,6 +23,11 @@ import {
 } from './queries/getFromAST';
 
 import {
+  QueryTransformer,
+  applyTransformerToQuery,
+} from './queries/queryTransform';
+
+import {
   GraphQLResult,
   Document,
 } from 'graphql';
@@ -88,7 +93,7 @@ export class QueryManager {
   private store: ApolloStore;
   private reduxRootKey: string;
   private pollingTimer: NodeJS.Timer | any; // oddity in typescript
-
+  private queryTransformer: QueryTransformer;
   private queryListeners: { [queryId: string]: QueryListener };
 
   private idCounter = 0;
@@ -97,16 +102,19 @@ export class QueryManager {
     networkInterface,
     store,
     reduxRootKey,
+    queryTransformer,
   }: {
     networkInterface: NetworkInterface,
     store: ApolloStore,
     reduxRootKey: string,
+    queryTransformer?: QueryTransformer,
   }) {
     // XXX this might be the place to do introspection for inserting the `id` into the query? or
     // is that the network interface?
     this.networkInterface = networkInterface;
     this.store = store;
     this.reduxRootKey = reduxRootKey;
+    this.queryTransformer = queryTransformer;
 
     this.queryListeners = {};
 
@@ -257,7 +265,12 @@ export class QueryManager {
       returnPartialData = false,
     } = options;
 
-    const queryDef = getQueryDefinition(query);
+    let queryDef = getQueryDefinition(query);
+    // Apply the query transformer if one has been provided.
+    // TODO make sure this is the right way to check if a nullable variable is present.
+    if (this.queryTransformer) {
+      queryDef = applyTransformerToQuery(queryDef, this.queryTransformer);
+    }
     const queryString = print(query);
 
     // Parse the query passed in -- this could also be done by a build plugin or tagged

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -267,8 +267,7 @@ export class QueryManager {
 
     let queryDef = getQueryDefinition(query);
     // Apply the query transformer if one has been provided.
-    // TODO make sure this is the right way to check if a nullable variable is present.
-    if (this.queryTransformer) {
+    if (this.queryTransformer != null) {
       queryDef = applyTransformerToQuery(queryDef, this.queryTransformer);
     }
     const queryString = print(query);

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -24,7 +24,6 @@ import {
 
 import {
   QueryTransformer,
-  MutationTransformer,
   applyTransformerToOperation,
 } from './queries/queryTransform';
 
@@ -95,7 +94,6 @@ export class QueryManager {
   private reduxRootKey: string;
   private pollingTimer: NodeJS.Timer | any; // oddity in typescript
   private queryTransformer: QueryTransformer;
-  private mutationTransformer: MutationTransformer;
   private queryListeners: { [queryId: string]: QueryListener };
 
   private idCounter = 0;
@@ -105,13 +103,11 @@ export class QueryManager {
     store,
     reduxRootKey,
     queryTransformer,
-    mutationTransformer,
   }: {
     networkInterface: NetworkInterface,
     store: ApolloStore,
     reduxRootKey: string,
     queryTransformer?: QueryTransformer,
-    mutationTransformer?: MutationTransformer,
   }) {
     // XXX this might be the place to do introspection for inserting the `id` into the query? or
     // is that the network interface?
@@ -119,7 +115,6 @@ export class QueryManager {
     this.store = store;
     this.reduxRootKey = reduxRootKey;
     this.queryTransformer = queryTransformer;
-    this.mutationTransformer = mutationTransformer;
 
     this.queryListeners = {};
 
@@ -147,8 +142,8 @@ export class QueryManager {
     const mutationId = this.generateQueryId();
 
     let mutationDef = getMutationDefinition(mutation);
-    if (this.mutationTransformer != null) {
-      mutationDef = applyTransformerToOperation(mutationDef, this.mutationTransformer);
+    if (this.queryTransformer != null) {
+      mutationDef = applyTransformerToOperation(mutationDef, this.queryTransformer);
     }
     const mutationString = print(mutationDef);
 
@@ -178,6 +173,7 @@ export class QueryManager {
         });
 
         return result;
+
       });
   }
 

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -142,7 +142,7 @@ export class QueryManager {
     const mutationId = this.generateQueryId();
 
     let mutationDef = getMutationDefinition(mutation);
-    if (this.queryTransformer != null) {
+    if (this.queryTransformer) {
       mutationDef = applyTransformerToOperation(mutationDef, this.queryTransformer);
     }
     const mutationString = print(mutationDef);
@@ -271,7 +271,7 @@ export class QueryManager {
 
     let queryDef = getQueryDefinition(query);
     // Apply the query transformer if one has been provided.
-    if (this.queryTransformer != null) {
+    if (this.queryTransformer) {
       queryDef = applyTransformerToOperation(queryDef, this.queryTransformer);
     }
     const queryString = print(query);

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,10 @@ import {
   IdGetter,
 } from './data/extensions';
 
+import {
+  QueryTransformer,
+} from './queries/queryTransform';
+
 import isUndefined = require('lodash.isundefined');
 
 export {
@@ -47,22 +51,26 @@ export default class ApolloClient {
   public initialState: any;
   public queryManager: QueryManager;
   public reducerConfig: ApolloReducerConfig;
+  public queryTransformer: QueryTransformer;
 
   constructor({
     networkInterface,
     reduxRootKey,
     initialState,
     dataIdFromObject,
+    queryTransformer,
   }: {
     networkInterface?: NetworkInterface,
     reduxRootKey?: string,
     initialState?: any,
     dataIdFromObject?: IdGetter,
+    queryTransformer?: QueryTransformer,
   } = {}) {
     this.reduxRootKey = reduxRootKey ? reduxRootKey : 'apollo';
     this.initialState = initialState ? initialState : {};
     this.networkInterface = networkInterface ? networkInterface :
       createNetworkInterface('/graphql');
+    this.queryTransformer = queryTransformer;
 
     this.reducerConfig = {
       dataIdFromObject,
@@ -131,6 +139,7 @@ export default class ApolloClient {
       networkInterface: this.networkInterface,
       reduxRootKey: this.reduxRootKey,
       store,
+      queryTransformer: this.queryTransformer,
     });
   };
 }

--- a/src/queries/queryTransform.ts
+++ b/src/queries/queryTransform.ts
@@ -10,9 +10,6 @@ import cloneDeep = require('lodash.clonedeep');
 // A QueryTransformer takes a SelectionSet and transforms it in someway (in place).
 export type QueryTransformer = (queryPiece: SelectionSet) => void
 
-// Pretty much a QueryTransformer but is applied to mutations
-export type MutationTransformer = (queryPiece: SelectionSet) => void
-
 // Adds a field with a given name to every node in the AST recursively.
 // Note: this mutates the AST passed in.
 export function addFieldToSelectionSet(fieldName: string, queryPiece: SelectionSet) {
@@ -60,7 +57,7 @@ export function addTypenameToQuery(queryDef: OperationDefinition): OperationDefi
 // or a mutation.)
 // Returns a new query tree.
 export function applyTransformerToOperation(queryDef: OperationDefinition,
-  queryTransformer: (QueryTransformer | MutationTransformer)): OperationDefinition {
+  queryTransformer: QueryTransformer): OperationDefinition {
     const queryClone = cloneDeep(queryDef);
     queryTransformer(queryClone.selectionSet);
     return queryClone;

--- a/src/queries/queryTransform.ts
+++ b/src/queries/queryTransform.ts
@@ -7,6 +7,10 @@ import {
 
 import cloneDeep = require('lodash.clonedeep');
 
+// A QueryTransformer takes a SelectionSet and transforms it in someway (in place) and
+// then returns the same SelectionSet.
+export type QueryTransformer = (queryPiece: SelectionSet) => SelectionSet
+
 // Adds typename fields to every node in the AST recursively. Returns a copy of the entire
 // AST with the typename fields added.
 // Note: This muates the AST passed in.
@@ -43,4 +47,13 @@ export function addTypenameToQuery(queryDef: OperationDefinition): OperationDefi
   const queryClone = cloneDeep(queryDef);
   this.addTypenameToSelectionSet(queryClone.selectionSet);
   return queryClone;
+}
+
+// Apply a QueryTranformer to an OperationDefinition (extracted from a query)
+// Returns a new query tree.
+export function applyTransformerToQuery(queryDef: OperationDefinition,
+  queryTransformer: QueryTransformer): OperationDefinition {
+    const queryClone = cloneDeep(queryDef);
+    queryTransformer(queryClone.selectionSet);
+    return queryClone;
 }

--- a/src/queries/queryTransform.ts
+++ b/src/queries/queryTransform.ts
@@ -10,6 +10,9 @@ import cloneDeep = require('lodash.clonedeep');
 // A QueryTransformer takes a SelectionSet and transforms it in someway (in place).
 export type QueryTransformer = (queryPiece: SelectionSet) => void
 
+// Pretty much a QueryTransformer but is applied to mutations
+export type MutationTransformer = (queryPiece: SelectionSet) => void
+
 // Adds a field with a given name to every node in the AST recursively.
 // Note: this mutates the AST passed in.
 export function addFieldToSelectionSet(fieldName: string, queryPiece: SelectionSet) {
@@ -53,10 +56,11 @@ export function addTypenameToQuery(queryDef: OperationDefinition): OperationDefi
   return queryClone;
 }
 
-// Apply a QueryTranformer to an OperationDefinition (extracted from a query)
+// Apply a QueryTranformer to an OperationDefinition (extracted from a query
+// or a mutation.)
 // Returns a new query tree.
-export function applyTransformerToQuery(queryDef: OperationDefinition,
-  queryTransformer: QueryTransformer): OperationDefinition {
+export function applyTransformerToOperation(queryDef: OperationDefinition,
+  queryTransformer: (QueryTransformer | MutationTransformer)): OperationDefinition {
     const queryClone = cloneDeep(queryDef);
     queryTransformer(queryClone.selectionSet);
     return queryClone;

--- a/src/queries/queryTransform.ts
+++ b/src/queries/queryTransform.ts
@@ -7,13 +7,12 @@ import {
 
 import cloneDeep = require('lodash.clonedeep');
 
-// A QueryTransformer takes a SelectionSet and transforms it in someway (in place) and
-// then returns the same SelectionSet.
-export type QueryTransformer = (queryPiece: SelectionSet) => SelectionSet
+// A QueryTransformer takes a SelectionSet and transforms it in someway (in place).
+export type QueryTransformer = (queryPiece: SelectionSet) => void
 
-// Adds typename fields to every node in the AST recursively.
-// Note: This muates the AST passed in.
-export function addTypenameToSelectionSet(queryPiece: SelectionSet) {
+// Adds a field with a given name to every node in the AST recursively.
+// Note: this mutates the AST passed in.
+export function addFieldToSelectionSet(fieldName: string, queryPiece: SelectionSet) {
   if (queryPiece == null || queryPiece.selections == null) {
     return queryPiece;
   }
@@ -23,7 +22,7 @@ export function addTypenameToSelectionSet(queryPiece: SelectionSet) {
     alias: null,
     name: {
       kind: 'Name',
-      value: '__typename',
+      value: fieldName,
     },
   };
 
@@ -38,6 +37,12 @@ export function addTypenameToSelectionSet(queryPiece: SelectionSet) {
   // Add the typename to this particular node's children
   queryPiece.selections.push(typenameFieldAST);
   return queryPiece;
+}
+
+// Adds typename fields to every node in the AST recursively.
+// Note: This muates the AST passed in.
+export function addTypenameToSelectionSet(queryPiece: SelectionSet) {
+  return addFieldToSelectionSet('__typename', queryPiece);
 }
 
 // Add typename field to the root query node (i.e. OperationDefinition). Returns a new

--- a/src/queries/queryTransform.ts
+++ b/src/queries/queryTransform.ts
@@ -11,8 +11,7 @@ import cloneDeep = require('lodash.clonedeep');
 // then returns the same SelectionSet.
 export type QueryTransformer = (queryPiece: SelectionSet) => SelectionSet
 
-// Adds typename fields to every node in the AST recursively. Returns a copy of the entire
-// AST with the typename fields added.
+// Adds typename fields to every node in the AST recursively.
 // Note: This muates the AST passed in.
 export function addTypenameToSelectionSet(queryPiece: SelectionSet) {
   if (queryPiece == null || queryPiece.selections == null) {

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -11,6 +11,10 @@ import {
   getIdField,
 } from '../src/data/extensions';
 
+import {
+  addTypenameToSelectionSet,
+} from '../src/queries/queryTransform';
+
 import gql from '../src/gql';
 
 import {
@@ -1685,6 +1689,64 @@ describe('QueryManager', () => {
         query: 'string' as any as Document,
       });
     }, /wrap the query string in a "gql" tag/);
+  });
+
+  it('should transform queries correctly when given a QueryTransformer', (done) => {
+    const query = gql`
+      query {
+        author {
+          firstName
+          lastName
+        }
+      }`;
+    const transformedQuery = gql`
+      query {
+        author {
+          firstName
+          lastName
+          __typename
+        }
+        __typename
+      }`;
+    const unmodifiedQueryResult = {
+      'author': {
+        'firstName': 'John',
+        'lastName': 'Smith',
+      },
+    };
+    const transformedQueryResult = {
+      'author': {
+        'firstName': 'John',
+        'lastName': 'Smith',
+        '__typename': 'Author',
+      },
+      '__typename': 'RootQuery',
+    };
+
+    const networkInterface = mockNetworkInterface(
+    {
+      request: {query},
+      result: {data: unmodifiedQueryResult},
+    },
+    {
+      request: {query: transformedQuery},
+      result: {data: transformedQueryResult},
+    });
+
+    //make sure that the query is transformed within the query
+    //manager
+    const queryManagerWithTransformer = new QueryManager({
+      networkInterface: networkInterface,
+      store: createApolloStore(),
+      reduxRootKey: 'apollo',
+      queryTransformer: addTypenameToSelectionSet,
+    });
+
+
+    queryManagerWithTransformer.query({query: query}).then((result) => {
+      assert.deepEqual(result.data, transformedQueryResult);
+      done();
+    });
   });
 });
 

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -1749,7 +1749,7 @@ describe('QueryManager', () => {
     });
   });
 
-  it('should transform mutations correctly when given a MutationTransformer', (done) => {
+  it('should transform mutations correctly', (done) => {
     const mutation = gql`
       mutation {
         createAuthor(firstName: "John", lastName: "Smith") {
@@ -1795,7 +1795,7 @@ describe('QueryManager', () => {
       networkInterface: networkInterface,
       store: createApolloStore(),
       reduxRootKey: 'apollo',
-      mutationTransformer: addTypenameToSelectionSet,
+      queryTransformer: addTypenameToSelectionSet,
     });
 
     queryManagerWithTransformer.mutate({mutation: mutation}).then((result) => {

--- a/test/queryTransform.ts
+++ b/test/queryTransform.ts
@@ -1,9 +1,12 @@
 import {
   addTypenameToSelectionSet,
   addTypenameToQuery,
-  applyTransformerToQuery,
+  applyTransformerToOperation,
 } from '../src/queries/queryTransform';
-import { getQueryDefinition } from '../src/queries/getFromAST';
+import {
+  getQueryDefinition,
+  getMutationDefinition,
+} from '../src/queries/getFromAST';
 import { print } from 'graphql/language/printer';
 import gql from '../src/gql';
 import { assert } from 'chai';
@@ -117,8 +120,29 @@ describe('query transforms', () => {
     }
     `);
 
-    const modifiedQuery = applyTransformerToQuery(testQuery, addTypenameToSelectionSet);
+    const modifiedQuery = applyTransformerToOperation(testQuery, addTypenameToSelectionSet);
     assert.equal(print(expectedQuery), print(modifiedQuery));
   });
 
+  it('should be able to apply a MutationTransformer correctly', () => {
+    const testQuery = getMutationDefinition(gql`
+      mutation {
+        createAuthor(firstName: "John", lastName: "Smith") {
+          firstName
+          lastName
+        }
+      }`);
+    const expectedQuery = getMutationDefinition(gql`
+      mutation {
+        createAuthor(firstName: "John", lastName: "Smith") {
+          firstName
+          lastName
+          __typename
+        }
+        __typename
+      }`);
+    const modifiedQuery = applyTransformerToOperation(testQuery, addTypenameToSelectionSet);
+    assert.equal(print(expectedQuery), print(modifiedQuery));
+
+  });
 });

--- a/test/queryTransform.ts
+++ b/test/queryTransform.ts
@@ -1,6 +1,7 @@
 import {
   addTypenameToSelectionSet,
   addTypenameToQuery,
+  applyTransformerToQuery,
 } from '../src/queries/queryTransform';
 import { getQueryDefinition } from '../src/queries/getFromAST';
 import { print } from 'graphql/language/printer';
@@ -93,6 +94,30 @@ describe('query transforms', () => {
       __typename
     }`);
     const modifiedQuery = addTypenameToQuery(testQuery);
+    assert.equal(print(expectedQuery), print(modifiedQuery));
+  });
+
+  it('should be able to apply a QueryTransformer correctly', () => {
+    const testQuery = getQueryDefinition(gql`
+    query {
+      author {
+        firstName
+        lastName
+      }
+    }`);
+
+    const expectedQuery = getQueryDefinition(gql`
+    query {
+      author {
+        firstName
+        lastName
+        __typename
+      }
+      __typename
+    }
+    `);
+
+    const modifiedQuery = applyTransformerToQuery(testQuery, addTypenameToSelectionSet);
     assert.equal(print(expectedQuery), print(modifiedQuery));
   });
 


### PR DESCRIPTION
Added a way to plug a query transform function into the QueryManager constructor so that fields other than just `__typename` can be added to the query AST.

#230 

TODO:

- [ ] Update CHANGELOG.md with your change
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
