### PR TITLE
[0.3.12] Fixed so that queries can be transformed on forceFetch=true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ Expect active development and potentially significant breaking changes in the `0
 
 ### vNEXT
 
-- ...
+### v0.3.12
+
+- Fix query transformation for queries called with `forceFetch`. [PR #240](https://github.com/apollostack/apollo-client/pull/240)
 
 ### v0.3.11
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-client",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "description": "A simple yet functional GraphQL client.",
   "main": "./lib/src/index.js",
   "typings": "./lib/src/index.d.ts",

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -274,7 +274,7 @@ export class QueryManager {
     if (this.queryTransformer) {
       queryDef = applyTransformerToOperation(queryDef, this.queryTransformer);
     }
-    const queryString = print(query);
+    const queryString = print(queryDef);
 
     // Parse the query passed in -- this could also be done by a build plugin or tagged
     // template string

--- a/test/client.ts
+++ b/test/client.ts
@@ -31,6 +31,8 @@ import {
   HTTPNetworkInterface,
 } from '../src/networkInterface';
 
+import { getQueryDefinition } from '../src/queries/getFromAST';
+
 import { addTypenameToSelectionSet } from '../src/queries/queryTransform';
 
 import mockNetworkInterface from './mocks/mockNetworkInterface';
@@ -300,7 +302,7 @@ describe('client', () => {
       apollo: {
         queries: {
           '0': {
-            queryString: print(query),
+            queryString: print(getQueryDefinition(query)),
             query: {
               id: 'ROOT_QUERY',
               typeName: 'Query',
@@ -517,6 +519,58 @@ describe('client', () => {
       assert.deepEqual(actualResult.data, transformedResult);
       done();
     });
+  });
+
+  it('should be able to transform queries on forced fetches', (done) => {
+    const query = gql`
+      query {
+        author {
+          firstName
+          lastName
+        }
+      }`;
+    const transformedQuery = gql`
+      query {
+        author {
+          firstName
+          lastName
+          __typename
+        }
+        __typename
+      }`;
+    const result = {
+      'author': {
+        'firstName': 'John',
+        'lastName': 'Smith',
+      },
+    };
+    const transformedResult = {
+      'author': {
+        'firstName': 'John',
+        'lastName': 'Smith',
+        '__typename': 'Author',
+      },
+      '__typename': 'RootQuery',
+    };
+    const networkInterface = mockNetworkInterface(
+    {
+      request: { query },
+      result: { data: result },
+    },
+    {
+      request: { query: transformedQuery },
+      result: { data: transformedResult },
+    });
+
+    const client = new ApolloClient({
+      networkInterface,
+      queryTransformer: addTypenameToSelectionSet,
+    });
+    client.query({ forceFetch: true, query }).then((actualResult) => {
+      assert.deepEqual(actualResult.data, transformedResult);
+      done();
+    });
+
   });
 
   describe('accepts dataIdFromObject option', () => {

--- a/test/queryTransform.ts
+++ b/test/queryTransform.ts
@@ -145,4 +145,76 @@ describe('query transforms', () => {
     assert.equal(print(expectedQuery), print(modifiedQuery));
 
   });
+
+  it('should add typename fields correctly on this one query' , () => {
+    const testQuery = getQueryDefinition(gql`
+        query Feed($type: FeedType!) {
+          # Eventually move this into a no fetch query right on the entry
+          # since we literally just need this info to determine whether to
+          # show upvote/downvote buttons
+          currentUser {
+            login
+          }
+          feed(type: $type) {
+            createdAt
+            score
+            commentCount
+            id
+            postedBy {
+              login
+              html_url
+            }
+
+            repository {
+              name
+              full_name
+              description
+              html_url
+              stargazers_count
+              open_issues_count
+              created_at
+              owner {
+                avatar_url
+              }
+            }
+          }
+        }`);
+    const expectedQuery = getQueryDefinition(gql`
+      query Feed($type: FeedType!) {
+          currentUser {
+            login
+            __typename
+          }
+          feed(type: $type) {
+            createdAt
+            score
+            commentCount
+            id
+            postedBy {
+              login
+              html_url
+              __typename
+            }
+
+            repository {
+              name
+              full_name
+              description
+              html_url
+              stargazers_count
+              open_issues_count
+              created_at
+              owner {
+                avatar_url
+                __typename
+              }
+              __typename
+            }
+            __typename
+          }
+          __typename
+        }`);
+    const modifiedQuery = applyTransformerToOperation(testQuery, addTypenameToSelectionSet);
+    assert.equal(print(expectedQuery), print(modifiedQuery));
+  });
 });


### PR DESCRIPTION
Fixed the bug where queries weren't getting updated on when forceFetch was set to true.

TODO:

- [x] Update CHANGELOG.md with your change
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
