### PR TITLE
[WIP] Allow objects parameters in mutations

### DIFF
--- a/src/data/storeUtils.ts
+++ b/src/data/storeUtils.ts
@@ -4,46 +4,79 @@ import {
   FloatValue,
   StringValue,
   BooleanValue,
+  ObjectValue,
+  ListValue,
   Variable,
   InlineFragment,
   Value,
   Selection,
   GraphQLResult,
+  Name,
 } from 'graphql';
 
 import includes = require('lodash.includes');
 
-type ScalarValue = IntValue | FloatValue | StringValue | BooleanValue;
+type ScalarValue = StringValue | BooleanValue;
 
 function isScalarValue(value: Value): value is ScalarValue {
-  const SCALAR_TYPES = ['IntValue', 'FloatValue', 'StringValue', 'BooleanValue'];
+  const SCALAR_TYPES = ['StringValue', 'BooleanValue'];
   return includes(SCALAR_TYPES, value.kind);
+}
+
+type NumberValue = IntValue | FloatValue;
+
+function isNumberValue(value: Value): value is NumberValue {
+  const NUMBER_TYPES = ['IntValue', 'FloatValue'];
+  return includes(NUMBER_TYPES, value.kind);
 }
 
 function isVariable(value: Value): value is Variable {
   return value.kind === 'Variable';
 }
 
+function isObject(value: Value): value is ObjectValue {
+  return value.kind === 'ObjectValue';
+}
+
+function isList(value: Value): value is ListValue {
+  return value.kind === 'ListValue';
+}
+
+function valueToObjectRepresentation(argObj: Object, name: Name, value: Value, variables?: Object) {
+  if (isNumberValue(value)) {
+    argObj[name.value] = Number(value.value);
+  } else if (isScalarValue(value)) {
+    argObj[name.value] = value.value;
+  } else if (isObject(value)) {
+    const nestedArgObj = {};
+    value.fields.map((obj) => valueToObjectRepresentation(nestedArgObj, obj.name, obj.value, variables));
+    argObj[name.value] = nestedArgObj;
+  } else if (isVariable(value)) {
+    if (! variables || !(value.name.value in variables)) {
+      throw new Error(`The inline argument "${value.name.value}" is expected as a variable but was not provided.`);
+    }
+    const variableValue = variables[value.name.value];
+    argObj[name.value] = variableValue;
+  } else if (isList(value)) {
+    argObj[name.value] = value.values.map((listValue) => {
+      const nestedArgArrayObj = {};
+      valueToObjectRepresentation(nestedArgArrayObj, name, listValue, variables);
+      return nestedArgArrayObj[name.value];
+    });
+  } else {
+    throw new Error(`The inline argument "${name.value}" of kind "${value.kind}" is not supported.
+                    Use variables instead of inline arguments to overcome this limitation.`);
+  }
+}
+
 export function storeKeyNameFromField(field: Field, variables?: Object): string {
   if (field.arguments && field.arguments.length) {
     const argObj: Object = {};
 
-    field.arguments.forEach(({name, value}) => {
-      if (isScalarValue(value)) {
-        argObj[name.value] = value.value;
-      } else if (isVariable(value)) {
-        if (! variables) {
-          throw new Error('Internal err: Field has a variable argument but variables not passed.');
-        }
-        const variableValue = variables[value.name.value];
-        argObj[name.value] = variableValue;
-      } else {
-        throw new Error(`For inline arguments, only scalar types are supported. To use Enum or \
-Object types, please pass them as variables.`);
-      }
-    });
+    field.arguments.forEach(({name, value}) => valueToObjectRepresentation(argObj, name, value, variables));
 
     const stringifiedArgs: string = JSON.stringify(argObj);
+
     return `${field.name.value}(${stringifiedArgs})`;
   }
 

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -1009,10 +1009,10 @@ describe('QueryManager', () => {
     });
   });
 
-  it('runs a mutation and puts the result in the store', () => {
+  it('runs a mutation with object parameters and puts the result in the store', () => {
     const mutation = gql`
       mutation makeListPrivate {
-        makeListPrivate(id: "5") {
+        makeListPrivate(input: {id: "5"}) {
           id,
           isPrivate,
         }

--- a/test/client.ts
+++ b/test/client.ts
@@ -323,11 +323,11 @@ describe('client', () => {
           'ROOT_QUERY.allPeople({"first":"1"}).people.0': {
             name: 'Luke Skywalker',
           },
-          'ROOT_QUERY.allPeople({"first":"1"})': {
+          'ROOT_QUERY.allPeople({"first":1})': {
             people: [ 'ROOT_QUERY.allPeople({"first":"1"}).people.0' ],
           },
           ROOT_QUERY: {
-            'allPeople({"first":"1"})': 'ROOT_QUERY.allPeople({"first":"1"})',
+            'allPeople({"first":1})': 'ROOT_QUERY.allPeople({"first":1})',
           },
         },
       },

--- a/typings/browser/globals/graphql/index.d.ts
+++ b/typings/browser/globals/graphql/index.d.ts
@@ -936,4 +936,7 @@ declare module "graphql" {
         directives?: Array<GraphQLDirective>;
     }
 
+// utilities/valueFromAST.js
+
+    function valueFromAST(valueAST: Value, type: GraphQLInputType, variables?: Object): any
 }

--- a/typings/main/globals/graphql/index.d.ts
+++ b/typings/main/globals/graphql/index.d.ts
@@ -936,4 +936,7 @@ declare module "graphql" {
         directives?: Array<GraphQLDirective>;
     }
 
+// utilities/valueFromAST.js
+
+    function valueFromAST(valueAST: Value, type: GraphQLInputType, variables?: Object): any
 }


### PR DESCRIPTION
This is a work in progress to add support for object parameters in mutations and thus support reindex.io default mutation format.

I did succeed in making all tests pass BUT the fix is obviously wrong so I reach out here to get feedback on which other part of the project should be breaking so I can add some tests there and create a proper fix.

I also reused a duplicated test.