### PR TITLE
Named fragments within mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 3 to 6 months), to signal the start of a more stable API.
 
 ### vNEXT
-
+- Added name fragment support within mutations [Issue #273](https://github.com/apollostack/apollo-client/issues/273) and [PR #274](https://github.com/apollostack/apollo-client/pull/274)
 
 ### v0.3.13
 - Removed AuthTokenHeaderMiddleware code and related tests from apollo-client [Issue #247](https://github.com/apollostack/apollo-client/issues/247)

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -156,7 +156,9 @@ export class QueryManager {
     if (this.queryTransformer) {
       mutationDef = applyTransformerToOperation(mutationDef, this.queryTransformer);
     }
-    const mutationString = print(mutationDef);
+    mutation = replaceOperationDefinition(mutation, mutationDef);
+    const mutationString = print(mutation);
+    const queryFragmentMap = createFragmentMap(getFragmentDefinitions(mutation));
 
     const request = {
       query: mutationString,
@@ -173,6 +175,7 @@ export class QueryManager {
       },
       variables,
       mutationId,
+      fragmentMap: queryFragmentMap,
     });
 
     return this.networkInterface.query(request)

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -74,6 +74,7 @@ export interface MutationInitAction {
   mutation: SelectionSetWithRoot;
   variables: Object;
   mutationId: string;
+  fragmentMap: FragmentMap;
 }
 
 export function isMutationInitAction(action: ApolloAction): action is MutationInitAction {

--- a/src/data/store.ts
+++ b/src/data/store.ts
@@ -90,6 +90,7 @@ export function data(
         variables: queryStoreValue.variables,
         store: clonedState,
         dataIdFromObject: config.dataIdFromObject,
+        fragmentMap: queryStoreValue.fragmentMap,
       });
 
       return newState;

--- a/src/mutations/store.ts
+++ b/src/mutations/store.ts
@@ -8,6 +8,10 @@ import {
   SelectionSet,
 } from 'graphql';
 
+import {
+  FragmentMap,
+} from '../queries/getFromAST';
+
 import assign = require('lodash.assign');
 
 export interface MutationStore {
@@ -20,6 +24,7 @@ export interface MutationStoreValue {
   variables: Object;
   loading: boolean;
   error: Error;
+  fragmentMap: FragmentMap;
 }
 
 export interface SelectionSetWithRoot {
@@ -41,6 +46,7 @@ export function mutations(
       variables: action.variables,
       loading: true,
       error: null,
+      fragmentMap: action.fragmentMap,
     };
 
     return newState;

--- a/test/client.ts
+++ b/test/client.ts
@@ -572,6 +572,41 @@ describe('client', () => {
 
   });
 
+  it('should handle named fragments on mutations', (done) => {
+    const mutation = gql`
+      mutation {
+        starAuthor(id: 12) {
+          author {
+            ...authorDetails
+          }
+        }
+      }
+      fragment authorDetails on Author {
+        firstName
+        lastName
+      }`;
+    const result = {
+      'starAuthor': {
+        'author': {
+          'firstName': 'John',
+          'lastName': 'Smith',
+        },
+      },
+    };
+    const networkInterface = mockNetworkInterface(
+      {
+        request: { query: mutation },
+        result: { data: result },
+      });
+    const client = new ApolloClient({
+      networkInterface,
+    });
+    client.mutate({ mutation }).then((actualResult) => {
+      assert.deepEqual(actualResult.data, result);
+      done();
+    });
+  });
+
   it('should be able to handle named fragments on forced fetches', (done) => {
     const query = gql`
       fragment authorDetails on Author {


### PR DESCRIPTION
Implements named fragments within mutations.

Solves #273.

TODO:

- [x] Update CHANGELOG.md with your change
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

