### PR TITLE
Send operation name to the server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Expect active development and potentially significant breaking changes in the `0
 
 ### vNEXT
 - Added name fragment support within mutations [Issue #273](https://github.com/apollostack/apollo-client/issues/273) and [PR #274](https://github.com/apollostack/apollo-client/pull/274)
+- Now sending the operation name along with the query to the server [Issue #259](https://github.com/apollostack/apollo-client/issues/259) and [PR #282](https://github.com/apollostack/apollo-client/pull/282)
 
 ### v0.3.13
 - Removed AuthTokenHeaderMiddleware code and related tests from apollo-client [Issue #247](https://github.com/apollostack/apollo-client/issues/247)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ Expect active development and potentially significant breaking changes in the `0
 
 ### vNEXT
 - Added name fragment support within mutations [Issue #273](https://github.com/apollostack/apollo-client/issues/273) and [PR #274](https://github.com/apollostack/apollo-client/pull/274)
-- Now sending the operation name along with the query to the server [Issue #259](https://github.com/apollostack/apollo-client/issues/259) and [PR #282](https://github.com/apollostack/apollo-client/pull/282)
 
 ### v0.3.13
 - Removed AuthTokenHeaderMiddleware code and related tests from apollo-client [Issue #247](https://github.com/apollostack/apollo-client/issues/247)

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -24,6 +24,7 @@ import {
   replaceOperationDefinition,
   getFragmentDefinitions,
   createFragmentMap,
+  getOperationName,
 } from './queries/getFromAST';
 
 import {
@@ -163,6 +164,7 @@ export class QueryManager {
     const request = {
       query: mutation,
       variables,
+      operationName: getOperationName(mutation),
     } as Request;
 
     this.store.dispatch({
@@ -378,6 +380,7 @@ export class QueryManager {
       const request: Request = {
         query: minimizedQueryDoc,
         variables,
+        operationName: getOperationName(minimizedQueryDoc),
       };
 
       return this.networkInterface.query(request)

--- a/src/networkInterface.ts
+++ b/src/networkInterface.ts
@@ -20,6 +20,7 @@ export interface Request {
   debugName?: string;
   query?: Document;
   variables?: Object;
+  operationName?: String;
 }
 
 // The request representation just before it is converted to JSON
@@ -28,6 +29,7 @@ export interface PrintedRequest {
   debugName?: string;
   query?: string;
   variables?: Object;
+  operationName?: String;
 }
 
 export interface NetworkInterface {
@@ -73,6 +75,7 @@ export function printRequest(request: Request): PrintedRequest {
     debugName: request.debugName,
     query: print(request.query),
     variables: request.variables,
+    operationName: request.operationName,
   };
   return printedRequest;
 }

--- a/src/networkInterface.ts
+++ b/src/networkInterface.ts
@@ -20,7 +20,7 @@ export interface Request {
   debugName?: string;
   query?: Document;
   variables?: Object;
-  operationName?: String;
+  operationName?: string;
 }
 
 // The request representation just before it is converted to JSON
@@ -29,7 +29,7 @@ export interface PrintedRequest {
   debugName?: string;
   query?: string;
   variables?: Object;
-  operationName?: String;
+  operationName?: string;
 }
 
 export interface NetworkInterface {

--- a/src/queries/getFromAST.ts
+++ b/src/queries/getFromAST.ts
@@ -44,6 +44,17 @@ string in a "gql" tag? http://docs.apollostack.com/apollo-client/core.html#gql`)
   }
 }
 
+export function getOperationName(doc: Document): string {
+  let res: string = '';
+  doc.definitions.forEach((definition) => {
+    if (definition.kind === 'OperationDefinition'
+        && (definition as OperationDefinition).name) {
+      res = (definition as OperationDefinition).name.value;
+    }
+  });
+  return res;
+}
+
 // Returns the FragmentDefinitions from a particular document as an array
 export function getFragmentDefinitions(doc: Document): FragmentDefinition[] {
   checkDocument(doc);

--- a/test/client.ts
+++ b/test/client.ts
@@ -734,7 +734,7 @@ describe('client', () => {
   });
 
   it('should send operationName along with the mutation to the server', (done) => {
-    const query = gql`
+    const mutation = gql`
       mutation myMutationName {
         fortuneCookie
       }`;
@@ -750,7 +750,7 @@ describe('client', () => {
     const client = new ApolloClient({
       networkInterface,
     });
-    client.query({ query }).then((actualResult) => {
+    client.mutate({ mutation }).then((actualResult) => {
       assert.deepEqual(actualResult.data, data);
       done();
     });

--- a/test/client.ts
+++ b/test/client.ts
@@ -7,6 +7,7 @@ import {
   GraphQLError,
   OperationDefinition,
   print,
+  GraphQLResult,
 } from 'graphql';
 
 import {
@@ -29,6 +30,8 @@ import {
 import {
   createNetworkInterface,
   HTTPNetworkInterface,
+  Request,
+  NetworkInterface,
 } from '../src/networkInterface';
 
 import { addTypenameToSelectionSet } from '../src/queries/queryTransform';
@@ -703,6 +706,52 @@ describe('client', () => {
     });
     client.query({ query }).then((actualResult) => {
       assert.deepEqual(actualResult.data, result);
+      done();
+    });
+  });
+
+  it('should send operationName along with the query to the server', (done) => {
+    const query = gql`
+      query myQueryName {
+        fortuneCookie
+      }`;
+    const data = {
+      'fortuneCookie': 'The waiter spit in your food',
+    };
+    const networkInterface: NetworkInterface = {
+      query(request: Request): Promise<GraphQLResult> {
+        assert.equal(request.operationName, 'myQueryName');
+        return Promise.resolve({ data });
+      },
+    };
+    const client = new ApolloClient({
+      networkInterface,
+    });
+    client.query({ query }).then((actualResult) => {
+      assert.deepEqual(actualResult.data, data);
+      done();
+    });
+  });
+
+  it('should send operationName along with the mutation to the server', (done) => {
+    const query = gql`
+      mutation myMutationName {
+        fortuneCookie
+      }`;
+    const data = {
+      'fortuneCookie': 'The waiter spit in your food',
+    };
+    const networkInterface: NetworkInterface = {
+      query(request: Request): Promise<GraphQLResult> {
+        assert.equal(request.operationName, 'myMutationName');
+        return Promise.resolve({ data });
+      },
+    };
+    const client = new ApolloClient({
+      networkInterface,
+    });
+    client.query({ query }).then((actualResult) => {
+      assert.deepEqual(actualResult.data, data);
       done();
     });
   });

--- a/test/getFromAST.ts
+++ b/test/getFromAST.ts
@@ -6,6 +6,7 @@ import {
   replaceOperationDefinition,
   createFragmentMap,
   FragmentMap,
+  getOperationName,
 } from '../src/queries/getFromAST';
 
 import {
@@ -218,5 +219,23 @@ describe('AST utility functions', () => {
       'moreAuthorDetails': fragments[1],
     };
     assert.deepEqual(fragmentMap, expectedTable);
+  });
+
+  it('should get the operation name out of a query', () => {
+    const query = gql`
+      query nameOfQuery {
+        fortuneCookie
+      }`;
+    const operationName = getOperationName(query);
+    assert.equal(operationName, 'nameOfQuery');
+  });
+
+  it('should get the operation name out of a mutation', () => {
+    const query = gql`
+      mutation nameOfMutation {
+        fortuneCookie
+      }`;
+    const operationName = getOperationName(query);
+    assert.equal(operationName, 'nameOfMutation');
   });
 });


### PR DESCRIPTION
Sending the operation name of the query down the server (probably helpful for logging, etc.).

TODO:

- [x] Update CHANGELOG.md with your change
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
