### PR TITLE
Query merging fix

### DIFF
--- a/src/batching/queryMerging.ts
+++ b/src/batching/queryMerging.ts
@@ -97,7 +97,12 @@ export function unpackMergedResult(result: GraphQLResult,
     const fieldMap = fieldMaps[childRequestIndex];
     const field = fieldMap[mergeInfo.fieldIndex];
     data[field.name.value] = result.data[dataKey];
-    resultArray[childRequestIndex] = { data };
+
+    if (resultArray[childRequestIndex]) {
+      assign(resultArray[childRequestIndex].data, data);
+    } else {
+      resultArray[childRequestIndex] = { data };
+    }
   });
 
   return resultArray;

--- a/test/queryMerging.ts
+++ b/test/queryMerging.ts
@@ -742,7 +742,7 @@ describe('Query merging', () => {
           firstName: 'John',
           lastName: 'Smith',
         },
-        ___authorStuff___requestIndex_0___fieldIndex_1: "RootQuery",
+        ___authorStuff___requestIndex_0___fieldIndex_1: 'RootQuery',
         ___personStuff___requestIndex_1___fieldIndex_0: {
           name: 'John Smith',
         },


### PR DESCRIPTION
A small fix for an issue that came up when testing query merging with GitHunt. Basically, consider a a query with two top level fields:

```
query {
  fortuneCookie
  __typename
}
```

Then, suppose this query is composed with other queries. It used to be that only the last field would get written to the decomposed data - this PR fixes that. No update to CHANGELOG because this is not a user-facing change (yet) since batching has not been exposed (yet).

TODO:

- [x] Update CHANGELOG.md with your change
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
