### PR TITLE
Adds failing test for query merging bug #296

### DIFF
--- a/test/queryMerging.ts
+++ b/test/queryMerging.ts
@@ -353,6 +353,24 @@ describe('Query merging', () => {
     assert.equal(print(mergedQuery), print(exp));
   });
 
+  it('should be able to merge the same query with different variables correctly', () => {
+    const query1 = gql`
+      query authorById($id: Int) {
+        author(id: $id)
+      }`;
+    const query2 = gql`
+      query authorById($id: Int) {
+        author(id: $id)
+      }`;
+    const exp = gql`
+      query ___composed($___authorById___requestIndex_0___id: Int, $___authorById___requestIndex_1___id: Int) {
+        ___authorById___requestIndex_0___fieldIndex_0: author(id: $___authorById___requestIndex_0___id)
+        ___authorById___requestIndex_1___fieldIndex_0: author(id: $___authorById___requestIndex_1___id)
+      }`;
+    const mergedQuery = mergeQueryDocuments([query1, query2]);
+    assert.equal(print(mergedQuery), print(exp));
+  });
+
   it('should be able to merge queries with inline fragments', () => {
     const query1 = gql`
       query nameOfQuery {


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

I assume this is a valid use-case for query merging.  Since this test results in a thrown exception before the equal check, I might not have the expected `composed` query formatted correctly, so help with that requested.

TODO:

- [ ] Update CHANGELOG.md with your change
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

