### PR TITLE
Fix query merging with the same query with diff. variable values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 3 to 6 months), to signal the start of a more stable API.
 
 ### vNEXT
+- Solved an issue that occurred when merging two queries with exactly the same query document [Issue #296](https://github.com/apollostack/apollo-client/issues/296) and [PR #299](https://github.com/apollostack/apollo-client/pull/299)
 
 ### v0.3.16
 

--- a/src/batching/queryMerging.ts
+++ b/src/batching/queryMerging.ts
@@ -54,16 +54,16 @@ import cloneDeep = require('lodash.clonedeep');
 
 // Merges requests together.
 // NOTE: This is pretty much the only function from this file that should be
-// called from a network interface. It guarantees that the requests you pass in
+// called from outside of this file. It guarantees that the requests you pass in
 // will remain unchanged.
 export function mergeRequests(requests: Request[]): Request {
   // NOTE: subsequent calls actually modify the request object and/or GQL document.
   // So, to avoid changing the request passed in, we clone the whole request tree.
-  requests = cloneDeep(requests);
   let rootQueryDoc: Document = createEmptyRootQueryDoc();
   let rootVariables: { [key: string]: any };
 
   requests.forEach((request, requestIndex) => {
+    request = cloneDeep(request);
     rootQueryDoc = addQueryToRoot(rootQueryDoc, request.query, requestIndex);
     if (request.variables) {
       rootVariables = addVariablesToRoot(

--- a/src/batching/queryMerging.ts
+++ b/src/batching/queryMerging.ts
@@ -168,6 +168,8 @@ export function parseMergedKey(key: string): { requestIndex: number, fieldIndex:
 
 // Merges multiple queries into a single document. Starts out with an empty root
 // query. Used primarily to unit test addQueryToRoot.
+// Note: this method does NOT guarantee that the child query documents will remain
+// unchanged.
 export function mergeQueryDocuments(childQueryDocs: Document[]): Document {
   let rootQueryDoc: Document = createEmptyRootQueryDoc();
 

--- a/test/queryMerging.ts
+++ b/test/queryMerging.ts
@@ -758,4 +758,31 @@ describe('Query merging', () => {
     assert.deepEqual(unpackedResults[0], result1);
     assert.deepEqual(unpackedResults[1], result2);
   });
+
+  it('should correctly merge two queries that are the same other than variable values', () => {
+    const query1 = gql`
+      query authorStuff($id: Int) {
+        author(id: $id) {
+          name
+        }
+      }`;
+    const query2 = gql`
+      query authorStuff($id: Int) {
+        author(id: $id) {
+          name
+        }
+      }`;
+    const expQuery = gql`
+      query ___composed($___authorStuff___requestIndex_0___id: Int, $___authorStuff___requestIndex_1___id: Int) {
+        ___authorStuff___requestIndex_0___fieldIndex_0: author(id: $___authorStuff___requestIndex_0___id) {
+          name
+        }
+
+        ___authorStuff___requestIndex_1___fieldIndex_0: author(id: $___authorStuff___requestIndex_1___id) {
+          name
+        }
+      }`;
+    const mergedRequest = mergeRequests([{query: query1}, {query: query2}]);
+    assert.equal(print(mergedRequest.query), print(expQuery));
+  });
 });


### PR DESCRIPTION
This PR fixes the issue #296 and incorporates the test provided in #297.

It seems that if `gql` is passed exactly the same query document twice, it will return a reference to the same object. This can be problematic when we want to merge the two queries. This PR changes how the requests array is cloned so that this isn't an issue.

TODO:

- [x] Update CHANGELOG.md with your change
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass