### PR TITLE
Add optional returnPartialData argument.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Expect active development and potentially significant breaking changes in the `0
 ### vNEXT
 
 - Exported `writeQueryToStore` and `writeFragmentToStore` directly from `apollo-client` to match `readQueryFromStore` and `readFragmentFromStore`.
+- Add (optional) `returnPartialData` to `readFragmentFromStore` and `readQueryFromStore`.
 
 ### v0.3.19
 

--- a/src/data/readFromStore.ts
+++ b/src/data/readFromStore.ts
@@ -25,10 +25,12 @@ export function readQueryFromStore({
   store,
   query,
   variables,
+  returnPartialData,
 }: {
   store: NormalizedCache,
   query: Document,
   variables?: Object,
+  returnPartialData?: boolean,
 }): Object {
   const queryDef = getQueryDefinition(query);
 
@@ -37,6 +39,7 @@ export function readQueryFromStore({
     rootId: 'ROOT_QUERY',
     selectionSet: queryDef.selectionSet,
     variables,
+    returnPartialData,
   });
 }
 
@@ -45,11 +48,13 @@ export function readFragmentFromStore({
   fragment,
   rootId,
   variables,
+  returnPartialData,
 }: {
   store: NormalizedCache,
   fragment: Document,
   rootId: string,
   variables?: Object,
+  returnPartialData?: boolean,
 }): Object {
   const fragmentDef = getFragmentDefinition(fragment);
 
@@ -58,6 +63,7 @@ export function readFragmentFromStore({
     rootId,
     selectionSet: fragmentDef.selectionSet,
     variables,
+    returnPartialData,
   });
 }
 

--- a/test/readFromStore.ts
+++ b/test/readFromStore.ts
@@ -351,6 +351,31 @@ describe('reading from the store', () => {
     }, /field missingField on object/);
   });
 
+  it('does not throw on a missing field if returnPartialData is true', () => {
+    const result = {
+      id: 'abcd',
+      stringField: 'This is a string!',
+      numberField: 5,
+      nullField: null,
+    } as StoreObject;
+
+    const store = { abcd: result } as NormalizedCache;
+
+    assert.doesNotThrow(() => {
+      readFragmentFromStore({
+        store,
+        fragment: gql`
+          fragment FragmentName on Item {
+            stringField,
+            missingField
+          }
+        `,
+        rootId: 'abcd',
+        returnPartialData: true,
+      });
+    }, /field missingField on object/);
+  });
+
   it('runs a nested fragment where the reference is null', () => {
     const result = {
       id: 'abcd',


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Update CHANGELOG.md with your change
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

Adds optional `returnPartialData` argument to `readQueryFromStore` and `readFragmentFromStore`.

While implementing updates from a CouchDB `_changes` feed, I found that I sometimes had information from the feed that wasn't yet in the store. While I could use `readSelectionSetFromStore` and pass `returnPartialData: true`, it seems that having the option to `returnPartialData` from both `readQueryFromStore` and `readFragmentFromStore` would be useful.