### PR TITLE
Export writeQueryToStore and writeFragmentToStore.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Expect active development and potentially significant breaking changes in the `0
 
 ### vNEXT
 
+- Exported `writeQueryToStore` and `writeFragmentToStore` directly from `apollo-client` to match `readQueryFromStore` and `readFragmentFromStore`.
+
 ### v0.3.19
 
 - Exported `addTypename` query transform directly from `apollo-client` so that it doesn't need to be imported from a submodule. [PR #303](https://github.com/apollostack/apollo-client/pull/303)

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,11 @@ import {
 } from './data/readFromStore';
 
 import {
+  writeQueryToStore,
+  writeFragmentToStore,
+} from './data/writeToStore';
+
+import {
   IdGetter,
 } from './data/extensions';
 
@@ -44,6 +49,8 @@ export {
   readQueryFromStore,
   readFragmentFromStore,
   addTypenameToSelectionSet as addTypename,
+  writeQueryToStore,
+  writeFragmentToStore,
 };
 
 export default class ApolloClient {


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Update CHANGELOG.md with your change
- [ ] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

It'd be nice to import `writeQueryToStore` and `writeFragmentToStore` directly.