### PR TITLE
Expose printAST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Expect active development and potentially significant breaking changes in the `0
 - Added support for resetting the store [Issue #158](https://github.com/apollostack/apollo-client/issues/158) and [PR #314](https://github.com/apollostack/apollo-client/pull/314).
 - Deprecate `apollo-client/gql` for `graphql-tag` and show a meaningful warning when importing
   `apollo-client/gql`
+- Exposed a `printAST` method that is just `graphql-js`'s `print` method underneath.
 
 ### v0.3.22 + v0.3.23 + v0.3.24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 3 to 6 months), to signal the start of a more stable API.
 
 ### vNEXT
+- Exposed a `printAST` method that is just `graphql-js`'s `print` method underneath [PR #337](https://github.com/apollostack/apollo-client/pull/337). With [PR #277](https://github.com/apollostack/apollo-client/pull/277), we moved to using the query AST as the representation of the query passed to the network interface. Unfortunately, this broke implementations of network interfaces. By exposing `printAST`, custom network interface implementations will be able to convert the query AST to a string easily.
 
 ### v0.3.25
 
@@ -18,7 +19,6 @@ Expect active development and potentially significant breaking changes in the `0
 - Added support for resetting the store [Issue #158](https://github.com/apollostack/apollo-client/issues/158) and [PR #314](https://github.com/apollostack/apollo-client/pull/314).
 - Deprecate `apollo-client/gql` for `graphql-tag` and show a meaningful warning when importing
   `apollo-client/gql`
-- Exposed a `printAST` method that is just `graphql-js`'s `print` method underneath [PR #337](https://github.com/apollostack/apollo-client/pull/337). With [PR #277](https://github.com/apollostack/apollo-client/pull/277), we moved to using the query AST as the representation of the query passed to the network interface. Unfortunately, this broke implementations of network interfaces. By exposing `printAST`, custom network interface implementations will be able to convert the query AST to a string easily.
 
 ### v0.3.22 + v0.3.23 + v0.3.24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Expect active development and potentially significant breaking changes in the `0
 - Added support for resetting the store [Issue #158](https://github.com/apollostack/apollo-client/issues/158) and [PR #314](https://github.com/apollostack/apollo-client/pull/314).
 - Deprecate `apollo-client/gql` for `graphql-tag` and show a meaningful warning when importing
   `apollo-client/gql`
-- Exposed a `printAST` method that is just `graphql-js`'s `print` method underneath.
+- Exposed a `printAST` method that is just `graphql-js`'s `print` method underneath [PR #337](https://github.com/apollostack/apollo-client/pull/337). With [PR #277](https://github.com/apollostack/apollo-client/pull/277), we moved to using the query AST as the representation of the query passed to the network interface. Unfortunately, this broke implementations of network interfaces. By exposing `printAST`, custom network interface implementations will be able to convert the query AST to a string easily.
 
 ### v0.3.22 + v0.3.23 + v0.3.24
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,6 @@ import assign = require('lodash.assign');
 
 // We expose the print method from GraphQL so that people that implement
 // custom network interfaces can turn query ASTs into query strings as needed.
-const printAST = print;
 export {
   createNetworkInterface,
   createApolloStore,
@@ -68,7 +67,7 @@ export {
   addTypenameToSelectionSet as addTypename,
   writeQueryToStore,
   writeFragmentToStore,
-  printAST,
+  printAST: print,
 };
 
 export default class ApolloClient {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,10 @@ import {
 } from 'graphql';
 
 import {
+  print,
+} from 'graphql/language/printer';
+
+import {
   createApolloStore,
   ApolloStore,
   createApolloReducer,
@@ -52,6 +56,9 @@ import {
 import isUndefined = require('lodash.isundefined');
 import assign = require('lodash.assign');
 
+// We expose the print method from GraphQL so that people that implement
+// custom network interfaces can turn query ASTs into query strings as needed.
+const printAST = print;
 export {
   createNetworkInterface,
   createApolloStore,
@@ -61,6 +68,7 @@ export {
   addTypenameToSelectionSet as addTypename,
   writeQueryToStore,
   writeFragmentToStore,
+  printAST,
 };
 
 export default class ApolloClient {

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,7 @@ export {
   addTypenameToSelectionSet as addTypename,
   writeQueryToStore,
   writeFragmentToStore,
-  printAST: print,
+  print as printAST,
 };
 
 export default class ApolloClient {

--- a/test/client.ts
+++ b/test/client.ts
@@ -2,7 +2,7 @@ import * as chai from 'chai';
 const { assert } = chai;
 import * as sinon from 'sinon';
 
-import ApolloClient from '../src';
+import ApolloClient, { printAST } from '../src';
 
 import {
   GraphQLError,
@@ -983,5 +983,14 @@ describe('client', () => {
       clock.tick(0);
       return outerPromise;
     });
+  });
+
+  it('should expose a method called printAST that is prints graphql queries', () => {
+    const query = gql`
+      query {
+        fortuneCookie
+      }`;
+
+    assert.equal(printAST(query), print(query));
   });
 });


### PR DESCRIPTION
Exposed a `printAST` method that can be used to turn query ASTs into query strings.

TODO:

- [x] Update CHANGELOG.md with your change
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
