### PR TITLE
Fragment referencing/Query composition support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 3 to 6 months), to signal the start of a more stable API.
 
 ### vNEXT
+- Added support for query composition through fragments [Issue #338](https://github.com/apollostack/apollo-client/issues/338) and [PR #343](https://github.com/apollostack/apollo-client/pull/343)
 
 ### v0.3.26
 

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -258,8 +258,10 @@ export class QueryManager {
 
   // Returns a query listener that will update the given observer based on the
   // results (or lack thereof) for a particular query.
-  public queryListenerForObserver(options: WatchQueryOptions,
-                                  observer: Observer<GraphQLResult>): QueryListener {
+  public queryListenerForObserver(
+    options: WatchQueryOptions,
+    observer: Observer<GraphQLResult>
+  ): QueryListener {
     return (queryStoreValue: QueryStoreValue) => {
       if (!queryStoreValue.loading || queryStoreValue.returnPartialData) {
         // XXX Currently, returning errors and data is exclusive because we
@@ -418,7 +420,7 @@ export class QueryManager {
   }
 
   public fetchQuery(queryId: string, options: WatchQueryOptions): Promise<GraphQLResult> {
-      return this.fetchQueryOverInterface(queryId, options, this.networkInterface);
+    return this.fetchQueryOverInterface(queryId, options, this.networkInterface);
   }
 
   public generateQueryId() {
@@ -510,9 +512,11 @@ export class QueryManager {
     });
   }
 
-  private fetchQueryOverInterface(queryId: string,
-  options: WatchQueryOptions,
-  network: NetworkInterface): Promise<GraphQLResult> {
+  private fetchQueryOverInterface(
+    queryId: string,
+    options: WatchQueryOptions,
+    network: NetworkInterface
+  ): Promise<GraphQLResult> {
     const {
       query,
       variables,

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -214,7 +214,7 @@ export class QueryManager {
     }
     mutation = replaceOperationDefinition(mutation, mutationDef);
 
-    // add the fragments that were passed in to the mutation document and then
+    // Add the fragments that were passed in to the mutation document and then
     // construct the fragment map.
     mutation = addFragmentsToDocument(mutation, fragments);
 

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -25,7 +25,6 @@ import {
   getFragmentDefinitions,
   createFragmentMap,
   getOperationName,
-  FragmentMap,
   addFragmentsToDocument,
 } from './queries/getFromAST';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,7 +100,9 @@ export function createFragment(doc: Document, fragments: FragmentDefinition[] = 
       // this is a problem because the app developer is trying to register another fragment with
       // the same name as one previously registered. So, we tell them about it.
       if (printFragmentWarnings) {
-        console.warn(`Warning: fragment with name ${fragmentDefinition.name.value} already exists.`);
+        console.warn(`Warning: fragment with name ${fragmentDefinition.name.value} already exists.
+Apollo Client enforces all fragment names across your application to be unique; read more about
+this in the docs: http://docs.apollostack.com/`);
       }
 
       fragmentDefinitionsMap[fragmentName].push(fragmentDefinition);
@@ -113,10 +115,14 @@ export function createFragment(doc: Document, fragments: FragmentDefinition[] = 
 }
 
 // This function disables the warnings printed about fragment names. One place where this chould be
-// is called when writing unit tests that depend on Apollo Client and use named fragments that may
-// have the Nsame name across different unit tests.
+// called is within writing unit tests that depend on Apollo Client and use named fragments that may
+// have the same name across different unit tests.
 export function disableFragmentWarnings() {
   printFragmentWarnings = false;
+}
+
+export function enableFragmentWarnings() {
+  printFragmentWarnings = true;
 }
 
 // This function is used to be empty the namespace of fragment definitions. Used for unit tests.

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,56 @@ export {
   print as printAST,
 };
 
+
+// A map going from the name of a fragment to that fragment's definition.
+// The point is to keep track of fragments that exist and print a warning if we encounter two
+// fragments that have the same name, i.e. the values *should* be of arrays of length 1.
+// Note: this variable is exported solely for unit testing purposes. It should not be touched
+// directly by application code.
+export let fragmentDefinitionsMap: { [fragmentName: string]: FragmentDefinition[] } = {};
+
+// Specifies whether or not we should print warnings about conflicting fragment names.
+let printFragmentWarnings = true;
+
+// Takes a document, extracts the FragmentDefinitions from it and puts
+// them in this.fragmentDefinitions. The second argument specifies the fragments
+// that the fragment in the document depends on. The fragment definition array from the document
+// is concatenated with the fragment definition array passed as the second argument and this
+// concatenated array is returned.
+export function createFragment(doc: Document, fragments: FragmentDefinition[] = []): FragmentDefinition[] {
+  const fragmentDefinitions = getFragmentDefinitions(doc);
+  fragmentDefinitions.forEach((fragmentDefinition) => {
+    const fragmentName = fragmentDefinition.name.value;
+    if (fragmentDefinitionsMap.hasOwnProperty(fragmentName) &&
+        fragmentDefinitionsMap[fragmentName].indexOf(fragmentDefinition) === -1) {
+      // this is a problem because the app developer is trying to register another fragment with
+      // the same name as one previously registered. So, we tell them about it.
+      if (printFragmentWarnings) {
+        console.warn(`Warning: fragment with name ${fragmentDefinition.name.value} already exists.`);
+      }
+
+      fragmentDefinitionsMap[fragmentName].push(fragmentDefinition);
+    } else if (!fragmentDefinitionsMap.hasOwnProperty(fragmentName)) {
+      fragmentDefinitionsMap[fragmentName] = [fragmentDefinition];
+    }
+  });
+
+  return fragments.concat(fragmentDefinitions);
+}
+
+// This function disables the warnings printed about fragment names. One place where this chould be
+// is called when writing unit tests that depend on Apollo Client and use named fragments that may
+// have the Nsame name across different unit tests.
+export function disableFragmentWarnings() {
+  printFragmentWarnings = false;
+}
+
+// This function is used to be empty the namespace of fragment definitions. Used for unit tests.
+export function clearFragmentDefinitions() {
+  fragmentDefinitionsMap = {};
+}
+
+
 export default class ApolloClient {
   public networkInterface: NetworkInterface;
   public store: ApolloStore;
@@ -87,11 +137,6 @@ export default class ApolloClient {
   public shouldForceFetch: boolean;
   public dataId: IdGetter;
   public fieldWithArgs: (fieldName: string, args?: Object) => string;
-
-  // A map going from the name of a fragment to that fragment's definition.
-  // The point is to keep track of fragments that exist and print a warning if we encounter two
-  // fragments that have the same name, i.e. the values *should* be of length 1.
-  public fragmentDefinitionsMap: { [fragmentName: string]: FragmentDefinition[] };
 
   constructor({
     networkInterface,
@@ -132,8 +177,6 @@ export default class ApolloClient {
       dataIdFromObject,
       mutationBehaviorReducers,
     };
-
-    this.fragmentDefinitionsMap = {};
   }
 
   public watchQuery = (options: WatchQueryOptions): ObservableQuery => {
@@ -148,7 +191,7 @@ export default class ApolloClient {
     // Register each of the fragments present in the query document. The point
     // is to prevent fragment name collisions with fragments that are in the query
     // document itself.
-    this.fragment(options.query);
+    createFragment(options.query);
 
     return this.queryManager.watchQuery(options);
   };
@@ -165,7 +208,7 @@ export default class ApolloClient {
     // Register each of the fragments present in the query document. The point
     // is to prevent fragment name collisions with fragments that are in the query
     // document itself.
-    this.fragment(options.query);
+    createFragment(options.query);
 
     return this.queryManager.query(options);
   };
@@ -209,28 +252,6 @@ export default class ApolloClient {
       config: this.reducerConfig,
     }));
   };
-
-  // Takes a document, extracts the FragmentDefinitions from it and puts
-  // them in this.fragmentDefinitions. The second argument specifies the fragments
-  // that the fragment in the document depends on. The fragment definition array from the document
-  // is concatenated with the fragment definition array passed as the second argument and this
-  // concatenated array is returned.
-  public fragment(doc: Document, fragments: FragmentDefinition[] = []): FragmentDefinition[] {
-    const fragmentDefinitions = getFragmentDefinitions(doc);
-    fragmentDefinitions.forEach((fragmentDefinition) => {
-      const fragmentName = fragmentDefinition.name.value;
-      if (this.fragmentDefinitionsMap.hasOwnProperty(fragmentName)) {
-        // this is a problem because the app developer is trying to register another fragment with
-        // the same name as one previously registered. So, we tell them about it.
-        console.warn(`Warning: fragment with name ${fragmentDefinition.name.value} already exists.`);
-        this.fragmentDefinitionsMap[fragmentName].push(fragmentDefinition);
-      } else {
-        this.fragmentDefinitionsMap[fragmentName] = [fragmentDefinition];
-      }
-    });
-
-    return fragments.concat(fragmentDefinitions);
-  }
 
   private setStore = (store: ApolloStore) => {
     // ensure existing store has apolloReducer

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,7 +136,7 @@ export default class ApolloClient {
     this.fragmentDefinitionsMap = {};
   }
 
-  public watchQuery = (options: WatchQueryOptions, fragments: FragmentDefinition[] = []): ObservableQuery => {
+  public watchQuery = (options: WatchQueryOptions): ObservableQuery => {
     this.initStore();
 
     if (!this.shouldForceFetch && options.forceFetch) {
@@ -148,12 +148,12 @@ export default class ApolloClient {
     // Register each of the fragments present in the query document. The point
     // is to prevent fragment name collisions with fragments that are in the query
     // document itself.
-    this.fragment(options.query, []);
+    this.fragment(options.query);
 
-    return this.queryManager.watchQuery(options, fragments);
+    return this.queryManager.watchQuery(options);
   };
 
-  public query = (options: WatchQueryOptions, fragments: FragmentDefinition[] = []): Promise<GraphQLResult> => {
+  public query = (options: WatchQueryOptions): Promise<GraphQLResult> => {
     this.initStore();
 
     if (!this.shouldForceFetch && options.forceFetch) {
@@ -165,18 +165,19 @@ export default class ApolloClient {
     // Register each of the fragments present in the query document. The point
     // is to prevent fragment name collisions with fragments that are in the query
     // document itself.
-    this.fragment(options.query, []);
+    this.fragment(options.query);
 
-    return this.queryManager.query(options, fragments);
+    return this.queryManager.query(options);
   };
 
   public mutate = (options: {
     mutation: Document,
     resultBehaviors?: MutationBehavior[],
     variables?: Object,
-  }, fragments: FragmentDefinition[] = []): Promise<GraphQLResult> => {
+    fragments?: FragmentDefinition[],
+  }): Promise<GraphQLResult> => {
     this.initStore();
-    return this.queryManager.mutate(options, fragments);
+    return this.queryManager.mutate(options);
   };
 
   public reducer(): Function {

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,7 @@ export default class ApolloClient {
   // The method fragment adds fragments to this map. The point is to keep track
   // of fragments that exist and print a warning if we encounter two fragments
   // that have the same name, i.e. the values *should* be of length 1.
-  public fragmentDefinitionsMap: { [fragmentName: string]: FragmentDefinition[] }
+  public fragmentDefinitionsMap: { [fragmentName: string]: FragmentDefinition[] };
 
   constructor({
     networkInterface,
@@ -171,9 +171,9 @@ export default class ApolloClient {
     mutation: Document,
     resultBehaviors?: MutationBehavior[],
     variables?: Object,
-  }): Promise<GraphQLResult> => {
+  }, fragments: FragmentDefinition[] = []): Promise<GraphQLResult> => {
     this.initStore();
-    return this.queryManager.mutate(options);
+    return this.queryManager.mutate(options, fragments);
   };
 
   public reducer(): Function {
@@ -214,7 +214,7 @@ export default class ApolloClient {
     const fragmentDefinitions = getFragmentDefinitions(doc);
     fragmentDefinitions.forEach((fragmentDefinition) => {
       const fragmentName = fragmentDefinition.name.value;
-      if(this.fragmentDefinitionsMap.hasOwnProperty(fragmentName)) {
+      if (this.fragmentDefinitionsMap.hasOwnProperty(fragmentName)) {
         // this is a problem because the app developer is trying to register another fragment with
         // the same name as one previously registered. So, we tell them about it.
         console.warn(`Warning: fragment with name ${fragmentDefinition.name.value} already exists.`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,9 +89,8 @@ export default class ApolloClient {
   public fieldWithArgs: (fieldName: string, args?: Object) => string;
 
   // A map going from the name of a fragment to that fragment's definition.
-  // The method fragment adds fragments to this map. The point is to keep track
-  // of fragments that exist and print a warning if we encounter two fragments
-  // that have the same name, i.e. the values *should* be of length 1.
+  // The point is to keep track of fragments that exist and print a warning if we encounter two
+  // fragments that have the same name, i.e. the values *should* be of length 1.
   public fragmentDefinitionsMap: { [fragmentName: string]: FragmentDefinition[] };
 
   constructor({
@@ -146,7 +145,9 @@ export default class ApolloClient {
       }) as WatchQueryOptions;
     }
 
-    // register each of the fragments present in the query document
+    // Register each of the fragments present in the query document. The point
+    // is to prevent fragment name collisions with fragments that are in the query
+    // document itself.
     this.fragment(options.query, []);
 
     return this.queryManager.watchQuery(options, fragments);
@@ -161,7 +162,9 @@ export default class ApolloClient {
       }) as WatchQueryOptions;
     }
 
-    // register each of the fragments in the query document
+    // Register each of the fragments present in the query document. The point
+    // is to prevent fragment name collisions with fragments that are in the query
+    // document itself.
     this.fragment(options.query, []);
 
     return this.queryManager.query(options, fragments);
@@ -209,7 +212,8 @@ export default class ApolloClient {
   // Takes a document, extracts the FragmentDefinitions from it and puts
   // them in this.fragmentDefinitions. The second argument specifies the fragments
   // that the fragment in the document depends on. The fragment definition array from the document
-  // are concatenated with the fragment definition array passed as the second argument and returned.
+  // is concatenated with the fragment definition array passed as the second argument and this
+  // concatenated array is returned.
   public fragment(doc: Document, fragments: FragmentDefinition[] = []): FragmentDefinition[] {
     const fragmentDefinitions = getFragmentDefinitions(doc);
     fragmentDefinitions.forEach((fragmentDefinition) => {

--- a/src/queries/getFromAST.ts
+++ b/src/queries/getFromAST.ts
@@ -57,8 +57,6 @@ export function getOperationName(doc: Document): string {
 
 // Returns the FragmentDefinitions from a particular document as an array
 export function getFragmentDefinitions(doc: Document): FragmentDefinition[] {
-  checkDocument(doc);
-
   let fragmentDefinitions: FragmentDefinition[] = doc.definitions.filter((definition) => {
     if (definition.kind === 'FragmentDefinition') {
       return true;

--- a/src/queries/getFromAST.ts
+++ b/src/queries/getFromAST.ts
@@ -139,21 +139,7 @@ export function createFragmentMap(fragments: FragmentDefinition[]): FragmentMap 
   return symTable;
 }
 
-// Take a list of fragment query documents and return a fragment map
-// (i.e. a map that goes from the name of the fragment to the fragment itself).
-export function createFragmentMapFromDocuments(fragmentDocs: Document[]): FragmentMap {
-  let definitions: FragmentDefinition[] = [];
-  fragmentDocs.forEach((fragmentDoc) => {
-    definitions = definitions.concat(getFragmentDefinitions(fragmentDoc));
-  });
-
-  return createFragmentMap(definitions);
-}
-
-// Takes a list of fragments (stored as documents) and tacks them onto the end of the query
-// document.
-// Note: this function does not do any uniqueness-of-name checking.
-export function addFragmentsToDocument(queryDoc: Document, fragmentDocs: Document[]): Document {
-  const fragmentMap = createFragmentMapFromDocuments(fragmentDocs);
-  queryDoc.definitions = queryDoc.definitions.concat(Object.values(fragmentMap));
+export function addFragmentsToDocument(queryDoc: Document, fragments: FragmentDefinition[]): Document {
+  queryDoc.definitions = queryDoc.definitions.concat(fragments);
+  return queryDoc;
 }

--- a/src/queries/getFromAST.ts
+++ b/src/queries/getFromAST.ts
@@ -139,7 +139,10 @@ export function createFragmentMap(fragments: FragmentDefinition[]): FragmentMap 
   return symTable;
 }
 
-export function addFragmentsToDocument(queryDoc: Document, fragments: FragmentDefinition[]): Document {
+// Utility function that takes a list of fragment definitions and adds them to a particular
+// document.
+export function addFragmentsToDocument(queryDoc: Document,
+  fragments: FragmentDefinition[]): Document {
   queryDoc.definitions = queryDoc.definitions.concat(fragments);
   return queryDoc;
 }

--- a/src/queries/getFromAST.ts
+++ b/src/queries/getFromAST.ts
@@ -138,3 +138,22 @@ export function createFragmentMap(fragments: FragmentDefinition[]): FragmentMap 
 
   return symTable;
 }
+
+// Take a list of fragment query documents and return a fragment map
+// (i.e. a map that goes from the name of the fragment to the fragment itself).
+export function createFragmentMapFromDocuments(fragmentDocs: Document[]): FragmentMap {
+  let definitions: FragmentDefinition[] = [];
+  fragmentDocs.forEach((fragmentDoc) => {
+    definitions = definitions.concat(getFragmentDefinitions(fragmentDoc));
+  });
+
+  return createFragmentMap(definitions);
+}
+
+// Takes a list of fragments (stored as documents) and tacks them onto the end of the query
+// document.
+// Note: this function does not do any uniqueness-of-name checking.
+export function addFragmentsToDocument(queryDoc: Document, fragmentDocs: Document[]): Document {
+  const fragmentMap = createFragmentMapFromDocuments(fragmentDocs);
+  queryDoc.definitions = queryDoc.definitions.concat(Object.values(fragmentMap));
+}

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -11,6 +11,7 @@
 import {
   GraphQLResult,
   Document,
+  FragmentDefinition,
 } from 'graphql';
 
 import {
@@ -47,7 +48,7 @@ export class QueryScheduler {
     return this.inFlightQueries.hasOwnProperty(queryId);
   }
 
-  public fetchQuery(queryId: string, options: WatchQueryOptions, fragments: Document[]) {
+  public fetchQuery(queryId: string, options: WatchQueryOptions, fragments: FragmentDefinition[]) {
     return new Promise((resolve, reject) => {
       this.queryManager.fetchQuery(queryId, options, fragments).then((result) => {
         this.removeInFlight(queryId);
@@ -61,7 +62,7 @@ export class QueryScheduler {
   }
 
   public startPollingQuery(options: WatchQueryOptions, listener: QueryListener,
-    fragments: Document[] = [],
+    fragments: FragmentDefinition[] = [],
     queryId?: string): string {
     if (!queryId) {
       queryId = this.queryManager.generateQueryId();
@@ -99,7 +100,7 @@ export class QueryScheduler {
 
   // Tell the QueryScheduler to schedule the queries fired by a polling query.
   public registerPollingQuery(options: WatchQueryOptions,
-    fragments: Document[] = []): ObservableQuery {
+    fragments: FragmentDefinition[] = []): ObservableQuery {
     if (!options.pollInterval) {
       throw new Error('Tried to register a non-polling query with the scheduler.');
     }

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -10,7 +10,6 @@
 
 import {
   GraphQLResult,
-  Document,
   FragmentDefinition,
 } from 'graphql';
 

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -47,7 +47,7 @@ import {
 } from '../src/networkInterface';
 
 import {
-  getFragmentDefinitions,
+  getFragmentDefinition,
 } from '../src/queries/getFromAST';
 
 describe('QueryManager', () => {
@@ -2414,15 +2414,15 @@ describe('QueryManager', () => {
 
   describe('fragment referencing', () => {
     it('should accept a list of fragments and let us reference them through fetchQuery', (done) => {
-      const fragment1 = getFragmentDefinitions(gql`
+      const fragment1 = getFragmentDefinition(gql`
         fragment authorDetails on Author {
           firstName
           lastName
-        }`)[0];
-      const fragment2 = getFragmentDefinitions(gql`
+        }`);
+      const fragment2 = getFragmentDefinition(gql`
         fragment personDetails on Person {
           name
-        }`)[0];
+        }`);
       const fragments = [fragment1, fragment2];
       const query = gql`
         query {
@@ -2474,15 +2474,15 @@ describe('QueryManager', () => {
       });
     });
     it('should accept a list of fragments and let us reference them from mutate', (done) => {
-      const fragment1 = getFragmentDefinitions(gql`
+      const fragment1 = getFragmentDefinition(gql`
         fragment authorDetails on Author {
           firstName
           lastName
-        }`)[0];
-      const fragment2 = getFragmentDefinitions(gql`
+        }`);
+      const fragment2 = getFragmentDefinition(gql`
         fragment personDetails on Person {
           name
-        }`)[0];
+        }`);
       const fragments = [fragment1, fragment2];
       const mutation = gql`
         mutation changeStuff {

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -2460,7 +2460,7 @@ describe('QueryManager', () => {
       };
       const networkInterface = mockNetworkInterface({
         request: { query: composedQuery },
-        result: { data }
+        result: { data },
       });
       const queryManager = new QueryManager({
         networkInterface: networkInterface,

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -2468,7 +2468,7 @@ describe('QueryManager', () => {
         reduxRootKey: 'apollo',
       });
 
-      queryManager.fetchQuery('bad-id', { query }, fragments).then((result) => {
+      queryManager.fetchQuery('bad-id', { query, fragments }).then((result) => {
         assert.deepEqual(result, { data });
         done();
       });
@@ -2536,7 +2536,7 @@ describe('QueryManager', () => {
         reduxRootKey: 'apollo',
       });
 
-      queryManager.mutate({ mutation }, fragments).then((result) => {
+      queryManager.mutate({ mutation, fragments }).then((result) => {
         assert.deepEqual(result, { data });
         done();
       });

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -2407,6 +2407,67 @@ describe('QueryManager', () => {
       }, 100);
     });
   });
+
+  describe('fragment referencing', () => {
+    it('should accept a list of fragments and let us reference them through fetchQuery', (done) => {
+      const fragment1 = gql`
+        fragment authorDetails on Author {
+          firstName
+          lastName
+        }`;
+      const fragment2 = gql`
+        fragment personDetails on Person {
+          name
+        }`;
+      const query = gql`
+        query {
+          author {
+            ...authorDetails
+          }
+          person {
+            ...personDetails
+          }
+        }`;
+      const composedQuery = gql`
+        query {
+          author {
+            ...authorDetails
+          }
+          person {
+            ...personDetails
+          }
+        }
+        fragment authorDetails on Author {
+          firstName
+          lastName
+        }
+        fragment personDetails on Person {
+          name
+        }`;
+      const data = {
+        'author': {
+          'firstName': 'John',
+          'lastName': 'Smith',
+        },
+        'person': {
+          'name': 'John Smith',
+        },
+      };
+      const networkInterface = mockNetworkInterface({
+        request: { query: composedQuery },
+        result: { data }
+      });
+      const queryManager = new QueryManager({
+        networkInterface: mockNetworkInterface(),
+        store: createApolloStore(),
+        reduxRootKey: 'apollo',
+      });
+      queryManager.fetchQuery('bad-id', { query }).then((result) => {
+        assert.deepEqual(result, { data });
+        done();
+      });
+    });
+  });
 });
 
 function testDiffing(

--- a/test/client.ts
+++ b/test/client.ts
@@ -8,6 +8,7 @@ import ApolloClient, {
   clearFragmentDefinitions,
   disableFragmentWarnings,
   printAST,
+  enableFragmentWarnings,
 } from '../src';
 
 import {
@@ -59,6 +60,9 @@ import * as chaiAsPromised from 'chai-as-promised';
 
 // make it easy to assert with promises
 chai.use(chaiAsPromised);
+
+// Turn off warnings for repeated fragment names
+disableFragmentWarnings();
 
 describe('client', () => {
   it('does not require any arguments and creates store lazily', () => {
@@ -1107,7 +1111,7 @@ describe('client', () => {
 
       // hacky solution that allows us to test whether the warning is printed
       const oldWarn = console.warn;
-      console.warn = (str) => {
+      console.warn = (str, vals) => {
         assert.include(str, 'Warning: fragment with name');
       };
 
@@ -1118,6 +1122,8 @@ describe('client', () => {
     });
 
     it('should issue a warning if we try query with a conflicting fragment name', (done) => {
+      enableFragmentWarnings();
+
       const client = new ApolloClient({
         networkInterface: mockNetworkInterface(),
       });
@@ -1146,9 +1152,13 @@ describe('client', () => {
         done();
       };
       client.query({ query: queryDoc });
+
+      disableFragmentWarnings();
     });
 
     it('should issue a warning if we try to watchQuery with a conflicting fragment name', (done) => {
+      enableFragmentWarnings();
+
       const client = new ApolloClient({
         networkInterface: mockNetworkInterface(),
       });
@@ -1177,6 +1187,8 @@ describe('client', () => {
         done();
       };
       client.watchQuery({ query: queryDoc });
+
+      disableFragmentWarnings();
     });
 
     it('should allow passing fragments to query', (done) => {

--- a/test/client.ts
+++ b/test/client.ts
@@ -996,7 +996,7 @@ describe('client', () => {
     assert.equal(printAST(query), print(query));
   });
 
-  describe('fragments', () => {
+  describe('fragment referencing', () => {
     it('should return a fragment def with a unique name', () => {
       const client = new ApolloClient({
         networkInterface: mockNetworkInterface(),
@@ -1010,7 +1010,7 @@ describe('client', () => {
           }
         }
       `;
-      const fragmentDefs = client.fragment(fragment, []);
+      const fragmentDefs = client.fragment(fragment);
       assert.equal(fragmentDefs.length, 1);
       assert.equal(print(fragmentDefs[0]), print(getFragmentDefinitions(fragment)[0]));
     });
@@ -1028,7 +1028,7 @@ describe('client', () => {
           name
         }
         `;
-      const fragmentDefs = client.fragment(fragmentDoc, []);
+      const fragmentDefs = client.fragment(fragmentDoc);
       assert.equal(fragmentDefs.length, 2);
       const expFragmentDefs = getFragmentDefinitions(fragmentDoc);
       assert.equal(print(fragmentDefs[0]), print(expFragmentDefs[0]));
@@ -1092,7 +1092,7 @@ describe('client', () => {
           firstName
           lastName
         }`;
-      client.fragment(fragmentDoc, []);
+      client.fragment(fragmentDoc);
       assert.equal(Object.keys(client.fragmentDefinitionsMap).length, 1);
       assert(client.fragmentDefinitionsMap.hasOwnProperty('authorDetails'));
       assert.equal(client.fragmentDefinitionsMap['authorDetails'].length, 1);
@@ -1118,7 +1118,7 @@ describe('client', () => {
         assert.include(str, 'Warning: fragment with name');
       };
 
-      client.fragment(fragmentDoc, []);
+      client.fragment(fragmentDoc);
       assert.equal(Object.keys(client.fragmentDefinitionsMap).length, 1);
       assert.equal(client.fragmentDefinitionsMap['authorDetails'].length, 2);
       console.warn = oldWarn;
@@ -1222,7 +1222,7 @@ describe('client', () => {
           lastName
         }`);
 
-      client.query({ query: queryDoc }, fragmentDefs).then((result) => {
+      client.query({ query: queryDoc, fragments: fragmentDefs }).then((result) => {
         assert.deepEqual(result, { data });
         done();
       });
@@ -1264,7 +1264,7 @@ describe('client', () => {
           lastName
         }`);
 
-      client.mutate({ mutation: mutationDoc }, fragmentDefs).then((result) => {
+      client.mutate({ mutation: mutationDoc, fragments: fragmentDefs }).then((result) => {
         assert.deepEqual(result, { data });
         done();
       });
@@ -1306,7 +1306,7 @@ describe('client', () => {
           lastName
         }`);
 
-      const observer = client.watchQuery({ query: queryDoc }, fragmentDefs);
+      const observer = client.watchQuery({ query: queryDoc, fragments: fragmentDefs });
       observer.subscribe({
         next(result) {
           assert.deepEqual(result, { data });
@@ -1351,7 +1351,8 @@ describe('client', () => {
           lastName
         }`);
 
-      const observer = client.watchQuery({ query: queryDoc, pollInterval: 30}, fragmentDefs);
+      const observer = client.watchQuery(
+        { query: queryDoc, pollInterval: 30, fragments: fragmentDefs});
       const subscription = observer.subscribe({
         next(result) {
           assert.deepEqual(result, { data });

--- a/test/getFromAST.ts
+++ b/test/getFromAST.ts
@@ -7,8 +7,6 @@ import {
   createFragmentMap,
   FragmentMap,
   getOperationName,
-  createFragmentMapFromDocuments,
-  addFragmentsToDocument,
 } from '../src/queries/getFromAST';
 
 import {
@@ -240,61 +238,4 @@ describe('AST utility functions', () => {
     const operationName = getOperationName(query);
     assert.equal(operationName, 'nameOfMutation');
   });
-
-  it('should create a fragment map out of documents containing fragment definitions', () => {
-    const fragment1 = gql`
-      fragment author on Author {
-        firstName
-        lastName
-      }`;
-    const fragment2 = gql`
-      fragment person on Person {
-        name
-      }`;
-    const fragments = [fragment1, fragment2];
-    const fragmentMap = createFragmentMapFromDocuments(fragments);
-    assert.equal(Object.keys(fragmentMap).length, 2);
-    assert.equal(print(fragmentMap['author']), print(getFragmentDefinitions(fragment1)[0]));
-    assert.equal(print(fragmentMap['person']), print(getFragmentDefinitions(fragment2)[0]));
-  });
-
-  it('should add fragment definitions from fragment documents to a query doc', () => {
-    const fragment1 = gql`
-      fragment authorDetails on Author {
-        firstName
-        lastName
-      }`;
-    const fragment2 = gql`
-      fragment personDetails on Person {
-        name
-      }`;
-    const query = gql`
-      query {
-        author {
-          ...authorDetails
-        }
-        person {
-          ...personDetails
-        }
-      }`;
-    const composedQuery = gql`
-      query {
-        author {
-          ...authorDetails
-        }
-        person {
-          ...personDetails
-        }
-      }
-      fragment authorDetails on Author {
-        firstName
-        lastName
-      }
-      fragment personDetails on Person {
-        name
-      }`;
-    const doc = addFragmentsToDocument(query, [fragment1, fragment2]);
-    assert.equal(print(doc), print(composedQuery));
-  });
-
 });

--- a/test/getFromAST.ts
+++ b/test/getFromAST.ts
@@ -7,6 +7,8 @@ import {
   createFragmentMap,
   FragmentMap,
   getOperationName,
+  createFragmentMapFromDocuments,
+  addFragmentsToDocument,
 } from '../src/queries/getFromAST';
 
 import {
@@ -238,4 +240,61 @@ describe('AST utility functions', () => {
     const operationName = getOperationName(query);
     assert.equal(operationName, 'nameOfMutation');
   });
+
+  it('should create a fragment map out of documents containing fragment definitions', () => {
+    const fragment1 = gql`
+      fragment author on Author {
+        firstName
+        lastName
+      }`;
+    const fragment2 = gql`
+      fragment person on Person {
+        name
+      }`;
+    const fragments = [fragment1, fragment2];
+    const fragmentMap = createFragmentMapFromDocuments(fragments);
+    assert.equal(Object.keys(fragmentMap).length, 2);
+    assert.equal(print(fragmentMap['author']), print(getFragmentDefinitions(fragment1)[0]));
+    assert.equal(print(fragmentMap['person']), print(getFragmentDefinitions(fragment2)[0]));
+  });
+
+  it('should add fragment definitions from fragment documents to a query doc', () => {
+    const fragment1 = gql`
+      fragment authorDetails on Author {
+        firstName
+        lastName
+      }`;
+    const fragment2 = gql`
+      fragment personDetails on Person {
+        name
+      }`;
+    const query = gql`
+      query {
+        author {
+          ...authorDetails
+        }
+        person {
+          ...personDetails
+        }
+      }`;
+    const composedQuery = gql`
+      query {
+        author {
+          ...authorDetails
+        }
+        person {
+          ...personDetails
+        }
+      }
+      fragment authorDetails on Author {
+        firstName
+        lastName
+      }
+      fragment personDetails on Person {
+        name
+      }`;
+    const doc = addFragmentsToDocument(query, [fragment1, fragment2]);
+    assert.equal(print(doc), print(composedQuery));
+  });
+
 });


### PR DESCRIPTION
Adding a way to reference fragments from different components of your application and compose queries using those fragments. See #338 

TODO:

- [x] Update CHANGELOG.md with your change
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
