### PR TITLE
[Breaking change] Unify error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Expect active development and potentially significant breaking changes in the `0
 
 - Removed dependency on `graphql` npm package, which was causing compilation errors in the React Native bundler. Issues [#261](https://github.com/apollostack/apollo-client/issues/261) [#163](https://github.com/apollostack/apollo-client/issues/163), [PR #357](https://github.com/apollostack/apollo-client/pull/357)
 - Added support for query composition through fragments [Issue #338](https://github.com/apollostack/apollo-client/issues/338) and [PR #343](https://github.com/apollostack/apollo-client/pull/343)
-- Unified error handling for GraphQL errors and network errors. Both now result in rejected promises and passed as errors on observables through a new `ApolloError` type. This is a significant departure from the previous method of error handling which passed GraphQL errors in resolvers and `next` methods on subscriptions.
+- Introduced a breaking change in the form of unified error handling for GraphQL errors and network errors. Both now result in rejected promises and passed as errors on observables through a new `ApolloError` type. This is a significant departure from the previous method of error handling which passed GraphQL errors in resolvers and `next` methods on subscriptions. [PR #352](https://github.com/apollostack/apollo-client/pull/352)
 
 ### v0.3.26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Expect active development and potentially significant breaking changes in the `0
 ### vNEXT
 
 - **Breaking change** Moved refetch(), startPolling(), and stopPolling() methods from QuerySubscription to ObservableQuery. This shouldn't affect anyone using `react-apollo`, but if you were calling those methods on the subscription directly, you need to call them on the query handle/observable instead. The benefit of this is that developers that want to use RxJS for their observable handling can now have access to these methods. [Issue #194] (https://github.com/apollostack/apollo-client/issues/194) and [PR #362] (https://github.com/apollostack/apollo-client/pull/362)
+- **Breaking change** Unified error handling for GraphQL errors and network errors. Both now result in rejected promises and passed as errors on observables through a new `ApolloError` type. This is a significant departure from the previous method of error handling which passed GraphQL errors in resolvers and `next` methods on subscriptions. [PR #352](https://github.com/apollostack/apollo-client/pull/352)
 
 ### v0.3.30
 
@@ -23,7 +24,6 @@ Expect active development and potentially significant breaking changes in the `0
 
 - Removed dependency on `graphql` npm package, which was causing compilation errors in the React Native bundler. Issues [#261](https://github.com/apollostack/apollo-client/issues/261) [#163](https://github.com/apollostack/apollo-client/issues/163), [PR #357](https://github.com/apollostack/apollo-client/pull/357)
 - Added support for query composition through fragments [Issue #338](https://github.com/apollostack/apollo-client/issues/338) and [PR #343](https://github.com/apollostack/apollo-client/pull/343)
-- Introduced a breaking change in the form of unified error handling for GraphQL errors and network errors. Both now result in rejected promises and passed as errors on observables through a new `ApolloError` type. This is a significant departure from the previous method of error handling which passed GraphQL errors in resolvers and `next` methods on subscriptions. [PR #352](https://github.com/apollostack/apollo-client/pull/352)
 
 ### v0.3.26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Expect active development and potentially significant breaking changes in the `0
 
 - Removed dependency on `graphql` npm package, which was causing compilation errors in the React Native bundler. Issues [#261](https://github.com/apollostack/apollo-client/issues/261) [#163](https://github.com/apollostack/apollo-client/issues/163), [PR #357](https://github.com/apollostack/apollo-client/pull/357)
 - Added support for query composition through fragments [Issue #338](https://github.com/apollostack/apollo-client/issues/338) and [PR #343](https://github.com/apollostack/apollo-client/pull/343)
+- Unified error handling for GraphQL errors and network errors. Both now result in rejected promises and passed as errors on observables through a new `ApolloError` type. This is a significant departure from the previous method of error handling which passed GraphQL errors in resolvers and `next` methods on subscriptions.
 
 ### v0.3.26
 

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -639,6 +639,11 @@ export class QueryManager {
             });
 
             this.removeFetchQueryPromise(requestId);
+            if (result.errors) {
+              reject(new ApolloError({
+                graphQLErrors: result.errors,
+              }));
+            }
             return result;
           }).then(() => {
 
@@ -672,7 +677,9 @@ export class QueryManager {
             });
 
             this.removeFetchQueryPromise(requestId);
-            return error;
+            reject(new ApolloError({
+              networkError: error,
+            }));
           });
       });
       return retPromise;

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -1,3 +1,4 @@
+
 import {
   NetworkInterface,
   Request,
@@ -286,7 +287,7 @@ export class QueryManager {
         // XXX Currently, returning errors and data is exclusive because we
         // don't handle partial results
 
-        // If we have either a GraphQL error or a network error, we create a
+        // If we have either a GraphQL error or a network error, we create
         // an error and tell the observer about it.
         if (queryStoreValue.graphQLErrors || queryStoreValue.networkError) {
           const apolloError = new ApolloError({
@@ -329,11 +330,12 @@ export class QueryManager {
   public watchQuery(options: WatchQueryOptions, shouldSubscribe = true): ObservableQuery {
     // Call just to get errors synchronously
     getQueryDefinition(options.query);
+
     const queryId = this.generateQueryId();
 
     let observableQuery;
 
-    const subscriberFunction = (observer) => {
+    const subscriberFunction = (observer: Observer<GraphQLResult>) => {
       const retQuerySubscription = {
         unsubscribe: () => {
           this.stopQuery(queryId);
@@ -345,7 +347,11 @@ export class QueryManager {
         this.addQuerySubscription(queryId, retQuerySubscription);
       }
 
-      this.startQuery(queryId, options, this.queryListenerForObserver(options, observer));
+      this.startQuery(
+        queryId,
+        options,
+        this.queryListenerForObserver(options, observer)
+      );
 
       return retQuerySubscription;
     };

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -21,7 +21,11 @@ export class ApolloError extends Error {
     this.graphQLErrors = graphQLErrors;
     this.networkError = networkError;
 
-    this.generateErrorMessage();
+    if (!errorMessage) {
+      this.generateErrorMessage();
+    } else {
+      this.message = errorMessage;
+    }
   }
 
   // Sets the error message on this error according to the
@@ -38,12 +42,12 @@ export class ApolloError extends Error {
     // If we have GraphQL errors present, add that to the error message.
     if (Array.isArray(this.graphQLErrors) && this.graphQLErrors.length !== 0) {
       this.graphQLErrors.forEach((graphQLError) => {
-        message += graphQLError.message + '\n';
+        message += 'GraphQL error: ' + graphQLError.message + '\n';
       });
     }
 
     if (this.networkError) {
-      message += this.networkError.message + '\n';
+      message += 'Network error: ' + this.networkError.message + '\n';
     }
 
     // strip newline from the end of the message

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,53 @@
+import { GraphQLError } from 'graphql';
+
+export class ApolloError extends Error {
+  public message: string;
+  public graphQLErrors: GraphQLError[];
+  public networkError: Error;
+
+  // Constructs an instance of ApolloError given a GraphQLError
+  // or a network error. Note that one of these has to be a valid
+  // value or the constructed error will be meaningless.
+  constructor({
+    graphQLErrors,
+    networkError,
+    errorMessage,
+  }: {
+    graphQLErrors?: GraphQLError[],
+    networkError?: Error,
+    errorMessage?: string,
+  }) {
+    super(errorMessage);
+    this.graphQLErrors = graphQLErrors;
+    this.networkError = networkError;
+
+    this.generateErrorMessage();
+  }
+
+  // Sets the error message on this error according to the
+  // the GraphQL and network errors that are present.
+  // If the error message has already been set through the
+  // constructor or otherwise, this function is a nop.
+  private generateErrorMessage() {
+    if (typeof this.message !== 'undefined' &&
+       this.message !== '') {
+      return;
+    }
+
+    let message = '';
+    // If we have GraphQL errors present, add that to the error message.
+    if (Array.isArray(this.graphQLErrors) && this.graphQLErrors.length !== 0) {
+      this.graphQLErrors.forEach((graphQLError) => {
+        message += graphQLError.message + '\n';
+      });
+    }
+
+    if (this.networkError) {
+      message += this.networkError.message + '\n';
+    }
+
+    // strip newline from the end of the message
+    message = message.replace(/\n$/, '');
+    this.message = message;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,6 @@ import {
 } from './networkInterface';
 
 import {
-  GraphQLResult,
   Document,
   FragmentDefinition,
 } from 'graphql';
@@ -77,6 +76,12 @@ export {
   print as printAST,
 };
 
+export type ApolloQueryResult = {
+  data: any;
+  // Right now only has one property, but will later include loading state, and possibly other info
+  // This is different from the GraphQLResult type because it doesn't include errors - those are
+  // thrown via the standard promise/observer catch mechanism
+}
 
 // A map going from the name of a fragment to that fragment's definition.
 // The point is to keep track of fragments that exist and print a warning if we encounter two
@@ -204,7 +209,7 @@ export default class ApolloClient {
     return this.queryManager.watchQuery(options);
   };
 
-  public query = (options: WatchQueryOptions): Promise<GraphQLResult> => {
+  public query = (options: WatchQueryOptions): Promise<ApolloQueryResult> => {
     this.initStore();
 
     if (!this.shouldForceFetch && options.forceFetch) {
@@ -226,7 +231,7 @@ export default class ApolloClient {
     resultBehaviors?: MutationBehavior[],
     variables?: Object,
     fragments?: FragmentDefinition[],
-  }): Promise<GraphQLResult> => {
+  }): Promise<ApolloQueryResult> => {
     this.initStore();
     return this.queryManager.mutate(options);
   };

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -96,6 +96,7 @@ export class QueryScheduler {
     if (!options.pollInterval) {
       throw new Error('Tried to register a non-polling query with the scheduler.');
     }
+
     const queryId = this.queryManager.generateQueryId();
 
     const subscriberFunction = (observer) => {

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -232,9 +232,13 @@ describe('QueryManager', () => {
 
     handle.subscribe({
       next(result) {
-        assert.equal(result.errors[0].message, 'This is an error message.');
-        done();
+        done(new Error('Returned a result when it was supposed to error out'));
       },
+
+      error(apolloError) {
+        assert(apolloError);
+        done();
+      }
     });
   });
 
@@ -282,7 +286,11 @@ describe('QueryManager', () => {
 
     handle.subscribe({
       next(result) {
-        assert.equal(result.errors[0].message, 'This is an error message.');
+        done(new Error('Returned data when it was supposed to error out.'));
+      },
+
+      error(apolloError) {
+        assert(apolloError);
         done();
       },
     });

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -50,6 +50,10 @@ import {
   getFragmentDefinition,
 } from '../src/queries/getFromAST';
 
+import {
+  ApolloError,
+} from '../src/errors';
+
 describe('QueryManager', () => {
   it('properly roundtrips through a Redux store', (done) => {
     const query = gql`
@@ -238,7 +242,7 @@ describe('QueryManager', () => {
       error(apolloError) {
         assert(apolloError);
         done();
-      }
+      },
     });
   });
 
@@ -375,7 +379,9 @@ describe('QueryManager', () => {
         done(new Error('Should not deliver result'));
       },
       error: (error) => {
-        assert.equal(error.message, 'Network error');
+        const apolloError = error as ApolloError;
+        assert(apolloError.networkError);
+        assert.include(apolloError.networkError.message, 'Network error');
         done();
       },
     });

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -1819,7 +1819,7 @@ describe('QueryManager', () => {
         }
       },
       error: (error) => {
-        assert.equal(error.message, 'Network error');
+        assert.include(error.message, 'Network error');
         subscription.unsubscribe();
       },
     });

--- a/test/client.ts
+++ b/test/client.ts
@@ -61,6 +61,8 @@ import { getFragmentDefinitions } from '../src/queries/getFromAST';
 
 import * as chaiAsPromised from 'chai-as-promised';
 
+import { ApolloError } from '../src/errors';
+
 // make it easy to assert with promises
 chai.use(chaiAsPromised);
 
@@ -447,8 +449,9 @@ describe('client', () => {
     });
 
     return client.query({ query })
-      .then((result) => {
-        assert.deepEqual(result, { errors });
+      .catch((error) => {
+        const apolloError = error as ApolloError;
+        assert.deepEqual(apolloError.graphQLErrors, errors);
       });
   });
 

--- a/test/errors.ts
+++ b/test/errors.ts
@@ -1,0 +1,71 @@
+import { assert } from 'chai';
+import { ApolloError } from '../src/errors';
+
+describe('ApolloError', () => {
+  it('should construct itself correctly', () => {
+    const graphQLErrors = [
+      new Error('Something went wrong with GraphQL'),
+      new Error('Something else went wrong with GraphQL'),
+    ];
+    const networkError = new Error('Network error');
+    const errorMessage = 'this is an error message';
+    const apolloError = new ApolloError({
+      graphQLErrors: graphQLErrors,
+      networkError: networkError,
+      errorMessage: errorMessage,
+    });
+    assert.equal(apolloError.graphQLErrors, graphQLErrors);
+    assert.equal(apolloError.networkError, networkError);
+    assert.equal(apolloError.message, errorMessage);
+  });
+
+  it('should add a network error to the message', () => {
+    const networkError = new Error('this is an error message');
+    const apolloError = new ApolloError({
+      networkError,
+    });
+    assert.include(apolloError.message, 'Network error: ');
+    assert.include(apolloError.message, 'this is an error message');
+    assert.equal(apolloError.message.split('\n').length, 1);
+  });
+
+  it('should add a graphql error to the message', () => {
+    const graphQLErrors = [ new Error('this is an error message') ];
+    const apolloError = new ApolloError({
+      graphQLErrors,
+    });
+    assert.include(apolloError.message, 'GraphQL error: ');
+    assert.include(apolloError.message, 'this is an error message');
+    assert.equal(apolloError.message.split('\n').length, 1);
+  });
+
+  it('should add multiple graphql errors to the message', () => {
+    const graphQLErrors = [ new Error('this is new'),
+                            new Error('this is old'),
+                          ];
+    const apolloError = new ApolloError({
+      graphQLErrors,
+    });
+    const messages = apolloError.message.split('\n');
+    assert.equal(messages.length, 2);
+    assert.include(messages[0], 'GraphQL error');
+    assert.include(messages[0], 'this is new');
+    assert.include(messages[1], 'GraphQL error');
+    assert.include(messages[1], 'this is old');
+  });
+
+  it('should add both network and graphql errors to the message', () => {
+    const graphQLErrors = [ new Error('graphql error message') ];
+    const networkError = new Error('network error message');
+    const apolloError = new ApolloError({
+      graphQLErrors,
+      networkError,
+    });
+    const messages = apolloError.message.split('\n');
+    assert.equal(messages.length, 2);
+    assert.include(messages[0], 'GraphQL error');
+    assert.include(messages[0], 'graphql error message');
+    assert.include(messages[1], 'Network error');
+    assert.include(messages[1], 'network error message');
+  });
+});

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -24,3 +24,4 @@ import './batching';
 import './scheduler';
 import './mutationResults';
 import './scopeQuery';
+import './errors';


### PR DESCRIPTION
Unifying the error handling so that both GraphQL errors and network errors will be presented in the form of rejected promises or errors on observers. This makes it easier to deal with both types of errors and not have to always introduce two different types of error handling code.

TODO:

- [x] Update CHANGELOG.md with your change
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
