### PR TITLE
Remove graphql dependency entirely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 3 to 6 months), to signal the start of a more stable API.
 
 ### vNEXT
+
+- Removed dependency on `graphql` npm package, which was causing compilation errors in the React Native bundler. Issues [#261](https://github.com/apollostack/apollo-client/issues/261) [#163](https://github.com/apollostack/apollo-client/issues/163), [PR #357](https://github.com/apollostack/apollo-client/pull/357)
 - Added support for query composition through fragments [Issue #338](https://github.com/apollostack/apollo-client/issues/338) and [PR #343](https://github.com/apollostack/apollo-client/pull/343)
 
 ### v0.3.26

--- a/ambient.d.ts
+++ b/ambient.d.ts
@@ -93,7 +93,7 @@ declare module 'lodash.identity' {
   GRAPHQL
 
 */
-declare module 'graphql/language/parser' {
+declare module 'graphql-tag/parser' {
   import { Source, ParseOptions, Document } from 'graphql';
   // XXX figure out how to directly export this method
   function parse(
@@ -102,6 +102,6 @@ declare module 'graphql/language/parser' {
   ): Document;
 }
 
-declare module 'graphql/language/printer' {
+declare module 'graphql-tag/printer' {
   function print(ast: any): string;
 }

--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
   "license": "MIT",
   "dependencies": {
     "es6-promise": "^3.1.2",
-    "graphql": "^0.4.18 || ^0.5.0 || ^0.6.0",
-    "graphql-tag": "^0.1.1",
+    "graphql-tag": "^0.1.8",
     "lodash.assign": "^4.0.8",
     "lodash.clonedeep": "^4.3.2",
     "lodash.countby": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "rxjs": "^5.0.0-beta.7",
     "sinon": "^1.17.4",
     "source-map-support": "^0.4.0",
-    "swapi-graphql": "^0.0.4",
     "tslint": "3.13.0",
     "typescript": "^1.8.9",
     "typings": "^1.0.0",

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -39,7 +39,7 @@ import {
   FragmentDefinition,
 } from 'graphql';
 
-import { print } from 'graphql/language/printer';
+import { print } from 'graphql-tag/printer';
 
 import {
   readSelectionSetFromStore,

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import {
 
 import {
   print,
-} from 'graphql/language/printer';
+} from 'graphql-tag/printer';
 
 import {
   createApolloStore,

--- a/src/networkInterface.ts
+++ b/src/networkInterface.ts
@@ -7,7 +7,7 @@ import {
   Document,
 } from 'graphql';
 
-import { print } from 'graphql/language/printer';
+import { print } from 'graphql-tag/printer';
 
 import { MiddlewareInterface } from './middleware';
 

--- a/src/queryPrinting.ts
+++ b/src/queryPrinting.ts
@@ -5,7 +5,7 @@ import {
   Document,
 } from 'graphql';
 
-import { print } from 'graphql/language/printer';
+import { print } from 'graphql-tag/printer';
 
 import {
   SelectionSetWithRoot,

--- a/test/client.ts
+++ b/test/client.ts
@@ -14,7 +14,6 @@ import ApolloClient, {
 import {
   GraphQLError,
   OperationDefinition,
-  print,
   GraphQLResult,
 } from 'graphql';
 
@@ -27,6 +26,10 @@ import {
 } from '../src/store';
 
 import gql from 'graphql-tag';
+
+import {
+  print,
+} from 'graphql-tag/printer';
 
 import {
   createStore,

--- a/test/getFromAST.ts
+++ b/test/getFromAST.ts
@@ -13,7 +13,7 @@ import {
   FragmentDefinition,
   OperationDefinition,
 } from 'graphql';
-import { print } from 'graphql/language/printer';
+import { print } from 'graphql-tag/printer';
 import gql from 'graphql-tag';
 import { assert } from 'chai';
 

--- a/test/mocks/mockNetworkInterface.ts
+++ b/test/mocks/mockNetworkInterface.ts
@@ -7,8 +7,11 @@ import {
 import {
   GraphQLResult,
   Document,
-  print,
 } from 'graphql';
+
+import {
+  print,
+} from 'graphql-tag/printer';
 
 // Pass in multiple mocked responses, so that you can test flows that end up
 // making multiple queries to the server

--- a/test/networkInterface.ts
+++ b/test/networkInterface.ts
@@ -21,7 +21,7 @@ import {
 
 import gql from 'graphql-tag';
 
-import { print } from 'graphql/language/printer';
+import { print } from 'graphql-tag/printer';
 
 import { GraphQLResult } from 'graphql';
 

--- a/test/networkInterface.ts
+++ b/test/networkInterface.ts
@@ -25,14 +25,6 @@ import { print } from 'graphql-tag/printer';
 
 import { GraphQLResult } from 'graphql';
 
-// import {
-//   graphql,
-// } from 'graphql';
-
-/* tslint:disable */
-// const swapiSchema = require('swapi-graphql').schema;
-/* tslint:enable */
-
 describe('network interface', () => {
   before(() => {
     this.realFetch = global['fetch'];

--- a/test/queryMerging.ts
+++ b/test/queryMerging.ts
@@ -20,10 +20,13 @@ import {
 } from '../src/queries/getFromAST';
 
 import {
-  print,
   Field,
   OperationDefinition,
 } from 'graphql';
+
+import {
+  print,
+} from 'graphql-tag/printer';
 
 import gql from 'graphql-tag';
 import { assert } from 'chai';

--- a/test/queryTransform.ts
+++ b/test/queryTransform.ts
@@ -7,7 +7,7 @@ import {
   getQueryDefinition,
   getMutationDefinition,
 } from '../src/queries/getFromAST';
-import { print } from 'graphql/language/printer';
+import { print } from 'graphql-tag/printer';
 import gql from 'graphql-tag';
 import { assert } from 'chai';
 

--- a/test/scopeQuery.ts
+++ b/test/scopeQuery.ts
@@ -12,9 +12,12 @@ import {
 import gql from 'graphql-tag';
 
 import {
-  print,
   Document,
 } from 'graphql';
+
+import {
+  print,
+} from 'graphql-tag/printer';
 
 // To test:
 // 1. basic

--- a/typings/browser/globals/apollo-client/index.d.ts
+++ b/typings/browser/globals/apollo-client/index.d.ts
@@ -90,7 +90,7 @@ declare module 'lodash.identity' {
   GRAPHQL
 
 */
-declare module 'graphql/language/parser' {
+declare module 'graphql-tag/parser' {
   import { Source, ParseOptions, Document } from 'graphql';
   // XXX figure out how to directly export this method
   function parse(
@@ -99,6 +99,6 @@ declare module 'graphql/language/parser' {
   ): Document;
 }
 
-declare module 'graphql/language/printer' {
+declare module 'graphql-tag/printer' {
   function print(ast: any): string;
 }

--- a/typings/browser/globals/apollo-client/typings.json
+++ b/typings/browser/globals/apollo-client/typings.json
@@ -1,8 +1,8 @@
 {
   "resolution": "browser",
   "tree": {
-    "src": "/Users/dhaivatpandya/dev/apollo-client/ambient.d.ts",
+    "src": "/Users/sashko/git/apollo-client/ambient.d.ts",
     "raw": "file:./ambient.d.ts",
-    "typings": "/Users/dhaivatpandya/dev/apollo-client/ambient.d.ts"
+    "typings": "/Users/sashko/git/apollo-client/ambient.d.ts"
   }
 }

--- a/typings/browser/globals/graphql/index.d.ts
+++ b/typings/browser/globals/graphql/index.d.ts
@@ -936,7 +936,4 @@ declare module "graphql" {
         directives?: Array<GraphQLDirective>;
     }
 
-// utilities/valueFromAST.js
-
-    function valueFromAST(valueAST: Value, type: GraphQLInputType, variables?: Object): any
 }

--- a/typings/browser/modules/lodash/index.d.ts
+++ b/typings/browser/modules/lodash/index.d.ts
@@ -18290,10 +18290,10 @@ export = _;
 interface Map<K, V> {}
 }
 declare module 'lodash/index' {
-import alias = require('~lodash/index');
-export = alias;
+import main = require('~lodash/index');
+export = main;
 }
 declare module 'lodash' {
-import alias = require('~lodash/index');
-export = alias;
+import main = require('~lodash/index');
+export = main;
 }

--- a/typings/main/globals/apollo-client/index.d.ts
+++ b/typings/main/globals/apollo-client/index.d.ts
@@ -90,7 +90,7 @@ declare module 'lodash.identity' {
   GRAPHQL
 
 */
-declare module 'graphql/language/parser' {
+declare module 'graphql-tag/parser' {
   import { Source, ParseOptions, Document } from 'graphql';
   // XXX figure out how to directly export this method
   function parse(
@@ -99,6 +99,6 @@ declare module 'graphql/language/parser' {
   ): Document;
 }
 
-declare module 'graphql/language/printer' {
+declare module 'graphql-tag/printer' {
   function print(ast: any): string;
 }

--- a/typings/main/globals/apollo-client/typings.json
+++ b/typings/main/globals/apollo-client/typings.json
@@ -1,8 +1,8 @@
 {
   "resolution": "main",
   "tree": {
-    "src": "/Users/dhaivatpandya/dev/apollo-client/ambient.d.ts",
+    "src": "/Users/sashko/git/apollo-client/ambient.d.ts",
     "raw": "file:./ambient.d.ts",
-    "typings": "/Users/dhaivatpandya/dev/apollo-client/ambient.d.ts"
+    "typings": "/Users/sashko/git/apollo-client/ambient.d.ts"
   }
 }

--- a/typings/main/globals/graphql/index.d.ts
+++ b/typings/main/globals/graphql/index.d.ts
@@ -936,7 +936,4 @@ declare module "graphql" {
         directives?: Array<GraphQLDirective>;
     }
 
-// utilities/valueFromAST.js
-
-    function valueFromAST(valueAST: Value, type: GraphQLInputType, variables?: Object): any
 }

--- a/typings/main/modules/lodash/index.d.ts
+++ b/typings/main/modules/lodash/index.d.ts
@@ -18290,10 +18290,10 @@ export = _;
 interface Map<K, V> {}
 }
 declare module 'lodash/index' {
-import alias = require('~lodash/index');
-export = alias;
+import main = require('~lodash/index');
+export = main;
 }
 declare module 'lodash' {
-import alias = require('~lodash/index');
-export = alias;
+import main = require('~lodash/index');
+export = main;
 }


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

Success:

```
➜  apollo-client git:(no-graphql-dep) tree node_modules | grep graphql
├── graphql-tag
```

Should resolve #261 and #163

This is to work around https://github.com/graphql/graphql-js/issues/414

Thanks for @abhiaiyer91's work on bundling in the dependency into `graphql-tag`.

TODO:

- [x] Update CHANGELOG.md with your change
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

