### PR TITLE
StoreFetchMiddleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Expect active development and potentially significant breaking changes in the `0
 ### vNEXT
 - Fixed an issue with named fragments in batched queries. [PR #509](https://github.com/apollostack/apollo-client/pull/509) and [Issue #501](https://github.com/apollostack/apollo-client/issues/501).
 - Fixed an issue with unused variables in queries after diffing queries against information available in the store. [PR #518](https://github.com/apollostack/apollo-client/pull/518) and [Issue #496](https://github.com/apollostack/apollo-client/issues/496).
+- Added a `storeFetchMiddleware` option to `ApolloClient` that allows transformation of values returned from the store. Also exposes a `cachedFetchById` middleware to handle the common case of fetching cached resources by id. [PR #376](https://github.com/apollostack/apollo-client/pull/376)
 
 ### v0.4.11
 

--- a/ambient.d.ts
+++ b/ambient.d.ts
@@ -103,6 +103,11 @@ declare module 'lodash.pick' {
   export = main.pick;
 }
 
+declare module 'lodash.every' {
+  import main = require('~lodash/index');
+  export = main.every;
+}
+
 /*
 
   GRAPHQL

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "lodash.assign": "^4.0.8",
     "lodash.clonedeep": "^4.3.2",
     "lodash.countby": "^4.4.0",
+    "lodash.every": "^4.4.0",
     "lodash.flatten": "^4.2.0",
     "lodash.forown": "^4.1.0",
     "lodash.has": "^4.3.1",

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -61,6 +61,10 @@ import {
 } from './data/diffAgainstStore';
 
 import {
+  StoreFetchMiddleware,
+} from './data/fetchMiddleware';
+
+import {
   MutationBehavior,
   MutationQueryReducersMap,
 } from './data/mutationResults';
@@ -103,6 +107,7 @@ export class QueryManager {
   private networkInterface: NetworkInterface;
   private reduxRootKey: string;
   private queryTransformer: QueryTransformer;
+  private storeFetchMiddleware: StoreFetchMiddleware;
   private queryListeners: { [queryId: string]: QueryListener };
 
   // A map going from queryId to the last result/state that the queryListener was told about.
@@ -140,6 +145,7 @@ export class QueryManager {
     store,
     reduxRootKey,
     queryTransformer,
+    storeFetchMiddleware,
     shouldBatch = false,
     batchInterval = 10,
   }: {
@@ -147,6 +153,7 @@ export class QueryManager {
     store: ApolloStore,
     reduxRootKey: string,
     queryTransformer?: QueryTransformer,
+    storeFetchMiddleware?: StoreFetchMiddleware,
     shouldBatch?: Boolean,
     batchInterval?: number,
   }) {
@@ -156,6 +163,7 @@ export class QueryManager {
     this.store = store;
     this.reduxRootKey = reduxRootKey;
     this.queryTransformer = queryTransformer;
+    this.storeFetchMiddleware = storeFetchMiddleware;
     this.pollingTimers = {};
     this.batchInterval = batchInterval;
     this.queryListeners = {};
@@ -328,6 +336,7 @@ export class QueryManager {
                 context: {
                   store: this.getDataWithOptimisticResults(),
                   fragmentMap: queryStoreValue.fragmentMap,
+                  fetchMiddleware: this.storeFetchMiddleware,
                 },
                 rootId: queryStoreValue.query.id,
                 selectionSet: queryStoreValue.query.selectionSet,
@@ -681,6 +690,7 @@ export class QueryManager {
       context: {
         store: this.store.getState()[this.reduxRootKey].data,
         fragmentMap,
+        fetchMiddleware: this.storeFetchMiddleware,
       },
       selectionSet: queryDef.selectionSet,
       throwOnMissingField: false,
@@ -770,6 +780,7 @@ export class QueryManager {
               context: {
                 store: this.getApolloState().data,
                 fragmentMap,
+                fetchMiddleware: this.storeFetchMiddleware,
               },
               rootId: querySS.id,
               selectionSet: querySS.selectionSet,

--- a/src/data/fetchMiddleware.ts
+++ b/src/data/fetchMiddleware.ts
@@ -1,0 +1,70 @@
+import every = require('lodash.every');
+import has = require('lodash.has');
+
+import {
+  Field,
+  Variable,
+} from 'graphql';
+
+import {
+  NormalizedCache,
+  StoreValue,
+  IdValue,
+} from './store';
+
+// Middleware that is given an opportunity to rewrite results from the store.
+// It should call `next()` to look up the default value.
+export type StoreFetchMiddleware = (
+  field: Field,
+  variables: {},
+  store: NormalizedCache,
+  next: () => StoreValue
+) => StoreValue;
+
+// StoreFetchMiddleware that special cases all parameterized queries containing
+// either `id` or `ids` to retrieve nodes by those ids directly from the store.
+//
+// This allows the client to avoid an extra round trip when it is fetching a
+// node by id that was previously fetched by a different query.
+//
+// NOTE: This middleware assumes that you are mapping data ids to the id of
+// your nodes.  E.g. `dataIdFromObject: value => value.id`.
+export function cachedFetchById(
+  field: Field,
+  variables: {},
+  store: NormalizedCache,
+  next: () => StoreValue
+): StoreValue {
+  // Note that we are careful to _not_ return an id if it doesn't exist in the
+  // store!  apollo-client assumes that if an id exists in the store, the node
+  // referenced must also exist.
+  if (field.arguments && field.arguments.length === 1) {
+    const onlyArg = field.arguments[0];
+    // Only supports variables, for now.
+    if (onlyArg.value.kind === 'Variable') {
+      const variable = <Variable>onlyArg.value;
+      if (onlyArg.name.value === 'id') {
+        const id = variables[variable.name.value];
+        if (has(store, id)) {
+          return toIdValue(id);
+        }
+      } else if (onlyArg.name.value === 'ids') {
+        const ids = variables[variable.name.value];
+        if (every(ids, id => has(store, id))) {
+          return ids;
+        }
+      }
+    }
+  }
+
+  // Otherwise, fall back to the regular behavior.
+  return next();
+}
+
+function toIdValue(id): IdValue {
+  return {
+    type: 'id',
+    id,
+    generated: false,
+  };
+}

--- a/src/data/readFromStore.ts
+++ b/src/data/readFromStore.ts
@@ -1,5 +1,6 @@
 import {
   diffSelectionSetAgainstStore,
+  StoreContext,
 } from './diffAgainstStore';
 
 import {
@@ -37,12 +38,14 @@ export function readQueryFromStore({
   const queryDef = getQueryDefinition(query);
 
   return readSelectionSetFromStore({
-    store,
+    context: {
+      store,
+      fragmentMap: fragmentMap || {},
+    },
     rootId: 'ROOT_QUERY',
     selectionSet: queryDef.selectionSet,
     variables,
     returnPartialData,
-    fragmentMap,
   });
 }
 
@@ -62,7 +65,7 @@ export function readFragmentFromStore({
   const fragmentDef = getFragmentDefinition(fragment);
 
   return readSelectionSetFromStore({
-    store,
+    context: { store, fragmentMap: {} },
     rootId,
     selectionSet: fragmentDef.selectionSet,
     variables,
@@ -71,29 +74,26 @@ export function readFragmentFromStore({
 }
 
 export function readSelectionSetFromStore({
-  store,
+  context,
   rootId,
   selectionSet,
   variables,
   returnPartialData = false,
-  fragmentMap,
 }: {
-  store: NormalizedCache,
+  context: StoreContext,
   rootId: string,
   selectionSet: SelectionSet,
   variables: Object,
   returnPartialData?: boolean,
-  fragmentMap?: FragmentMap,
 }): Object {
   const {
     result,
   } = diffSelectionSetAgainstStore({
+    context,
     selectionSet,
     rootId,
-    store,
     throwOnMissingField: !returnPartialData,
     variables,
-    fragmentMap,
   });
 
   return result;

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,11 @@ import {
 } from './queries/queryTransform';
 
 import {
+  cachedFetchById,
+  StoreFetchMiddleware,
+} from './data/fetchMiddleware';
+
+import {
   MutationBehavior,
   MutationBehaviorReducerMap,
   MutationQueryReducersMap,
@@ -87,6 +92,7 @@ export {
   readQueryFromStore,
   readFragmentFromStore,
   addTypenameToSelectionSet as addTypename,
+  cachedFetchById,
   writeQueryToStore,
   writeFragmentToStore,
   print as printAST,
@@ -167,6 +173,7 @@ export default class ApolloClient {
   public queryManager: QueryManager;
   public reducerConfig: ApolloReducerConfig;
   public queryTransformer: QueryTransformer;
+  public storeFetchMiddleware: StoreFetchMiddleware;
   public shouldBatch: boolean;
   public shouldForceFetch: boolean;
   public dataId: IdGetter;
@@ -179,6 +186,7 @@ export default class ApolloClient {
     initialState,
     dataIdFromObject,
     queryTransformer,
+    storeFetchMiddleware,
     shouldBatch = false,
     ssrMode = false,
     ssrForceFetchDelay = 0,
@@ -190,6 +198,7 @@ export default class ApolloClient {
     initialState?: any,
     dataIdFromObject?: IdGetter,
     queryTransformer?: QueryTransformer,
+    storeFetchMiddleware?: StoreFetchMiddleware,
     shouldBatch?: boolean,
     ssrMode?: boolean,
     ssrForceFetchDelay?: number
@@ -201,6 +210,7 @@ export default class ApolloClient {
     this.networkInterface = networkInterface ? networkInterface :
       createNetworkInterface('/graphql');
     this.queryTransformer = queryTransformer;
+    this.storeFetchMiddleware = storeFetchMiddleware;
     this.shouldBatch = shouldBatch;
     this.shouldForceFetch = !(ssrMode || ssrForceFetchDelay > 0);
     this.dataId = dataIdFromObject;
@@ -307,6 +317,7 @@ export default class ApolloClient {
       reduxRootKey: this.reduxRootKey,
       store,
       queryTransformer: this.queryTransformer,
+      storeFetchMiddleware: this.storeFetchMiddleware,
       shouldBatch: this.shouldBatch,
       batchInterval: this.batchInterval,
     });

--- a/test/diffAgainstStore.ts
+++ b/test/diffAgainstStore.ts
@@ -311,7 +311,10 @@ describe('diffing queries against the store', () => {
       }`;
     assert.throws(() => {
       diffSelectionSetAgainstStore({
-        store,
+        context: {
+          store,
+          fragmentMap: {},
+        },
         rootId: 'ROOT_QUERY',
         selectionSet: getQueryDefinition(unionQuery).selectionSet,
         variables: null,
@@ -353,7 +356,10 @@ describe('diffing queries against the store', () => {
       }`;
     assert.doesNotThrow(() => {
       diffSelectionSetAgainstStore({
-        store,
+        context: {
+          store,
+          fragmentMap: {},
+        },
         rootId: 'ROOT_QUERY',
         selectionSet: getQueryDefinition(unionQuery).selectionSet,
         variables: null,
@@ -395,12 +401,14 @@ describe('diffing queries against the store', () => {
       }`;
     assert.doesNotThrow(() => {
       diffSelectionSetAgainstStore({
-        store,
+        context: {
+          store,
+          fragmentMap: createFragmentMap(getFragmentDefinitions(unionQuery)),
+        },
         rootId: 'ROOT_QUERY',
         selectionSet: getQueryDefinition(unionQuery).selectionSet,
         variables: null,
         throwOnMissingField: true,
-        fragmentMap: createFragmentMap(getFragmentDefinitions(unionQuery)),
       });
     });
   });
@@ -439,12 +447,14 @@ describe('diffing queries against the store', () => {
       }`;
     assert.throw(() => {
       diffSelectionSetAgainstStore({
-        store,
+        context: {
+          store,
+          fragmentMap: createFragmentMap(getFragmentDefinitions(unionQuery)),
+        },
         rootId: 'ROOT_QUERY',
         selectionSet: getQueryDefinition(unionQuery).selectionSet,
         variables: null,
         throwOnMissingField: true,
-        fragmentMap: createFragmentMap(getFragmentDefinitions(unionQuery)),
       });
     });
   });
@@ -484,7 +494,10 @@ describe('diffing queries against the store', () => {
 
     assert.throw(() => {
       diffSelectionSetAgainstStore({
-        store,
+        context: {
+          store,
+          fragmentMap: {},
+        },
         rootId: 'ROOT_QUERY',
         selectionSet: getQueryDefinition(unionQuery).selectionSet,
         variables: null,
@@ -527,7 +540,7 @@ describe('diffing queries against the store', () => {
     `;
 
     const { result } = diffSelectionSetAgainstStore({
-      store,
+      context: { store, fragmentMap: {} },
       rootId: 'ROOT_QUERY',
       selectionSet: getQueryDefinition(queryWithMissingField).selectionSet,
       variables: null,
@@ -541,7 +554,7 @@ describe('diffing queries against the store', () => {
     });
     assert.throws(function() {
       diffSelectionSetAgainstStore({
-        store,
+        context: { store, fragmentMap: {} },
         rootId: 'ROOT_QUERY',
         selectionSet: getQueryDefinition(queryWithMissingField).selectionSet,
         variables: null,

--- a/typings/browser/globals/apollo-client/index.d.ts
+++ b/typings/browser/globals/apollo-client/index.d.ts
@@ -100,6 +100,11 @@ declare module 'lodash.pick' {
   export = main.pick;
 }
 
+declare module 'lodash.every' {
+  import main = require('~lodash/index');
+  export = main.every;
+}
+
 /*
 
   GRAPHQL

--- a/typings/main/globals/apollo-client/index.d.ts
+++ b/typings/main/globals/apollo-client/index.d.ts
@@ -100,6 +100,11 @@ declare module 'lodash.pick' {
   export = main.pick;
 }
 
+declare module 'lodash.every' {
+  import main = require('~lodash/index');
+  export = main.every;
+}
+
 /*
 
   GRAPHQL


### PR DESCRIPTION
StoreFetchMiddleware allows the caller to rewrite fetches from the store (for example, to redirect a read to another node)

This also includes a reference implementation to cover the case outlined by #332 (and I suspect the primary use of this middleware):

```js
import ApolloClient, { cachedFetchById } from 'apollo-client';
const client = new ApolloClient({
  dataIdFromObject: value => value.id,
  storeFetchMiddleware: cachedFetchById,
});

await client.query({
 query: gql`
    query fetchAll {
      tasks { id, name }
    }
  `,
});

// abc123 is fetched from cache, if fetchAll returned it!
await client.query({
 query: gql`
    query fetchOne($id: ID!) {
      task(id: $id) { id, name }
    }
  `,
  variables: { id: "abc123" },
});
```

---

Also, FYI, Mocha is promise-aware - just return the promise from a test, and it'll take care of the rest!  No need to use `done`