### PR TITLE
Pass a context object around with store data

### DIFF
--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -379,12 +379,14 @@ export class QueryManager {
           }
         } else {
           const resultFromStore = readSelectionSetFromStore({
-            store: this.getDataWithOptimisticResults(),
+            context: {
+              store: this.getDataWithOptimisticResults(),
+              fragmentMap: queryStoreValue.fragmentMap,
+            },
             rootId: queryStoreValue.query.id,
             selectionSet: queryStoreValue.query.selectionSet,
             variables: queryStoreValue.variables,
             returnPartialData: options.returnPartialData || options.noFetch,
-            fragmentMap: queryStoreValue.fragmentMap,
           });
 
           if (observer.next) {
@@ -622,12 +624,14 @@ export class QueryManager {
       // query, use the query diff algorithm to get as much of a result as we can, and identify
       // what data is missing from the store
       const { missingSelectionSets, result } = diffSelectionSetAgainstStore({
+        context: {
+          store: this.store.getState()[this.reduxRootKey].data,
+          fragmentMap: queryFragmentMap,
+        },
         selectionSet: querySS.selectionSet,
-        store: this.store.getState()[this.reduxRootKey].data,
         throwOnMissingField: false,
         rootId: querySS.id,
         variables,
-        fragmentMap: queryFragmentMap,
       });
 
       initialResult = result;
@@ -727,12 +731,14 @@ export class QueryManager {
               // this will throw an error if there are missing fields in
               // the results if returnPartialData is false.
               resultFromStore = readSelectionSetFromStore({
-                store: this.getApolloState().data,
+                context: {
+                  store: this.getApolloState().data,
+                  fragmentMap: queryFragmentMap,
+                },
                 rootId: querySS.id,
                 selectionSet: querySS.selectionSet,
                 variables,
                 returnPartialData: returnPartialData || noFetch,
-                fragmentMap: queryFragmentMap,
               });
               // ensure multiple errors don't get thrown
               /* tslint:disable */

--- a/src/data/readFromStore.ts
+++ b/src/data/readFromStore.ts
@@ -1,5 +1,6 @@
 import {
   diffSelectionSetAgainstStore,
+  StoreContext,
 } from './diffAgainstStore';
 
 import {
@@ -10,7 +11,6 @@ import {
 import {
   getQueryDefinition,
   getFragmentDefinition,
-  FragmentMap,
 } from '../queries/getFromAST';
 
 import {
@@ -35,7 +35,7 @@ export function readQueryFromStore({
   const queryDef = getQueryDefinition(query);
 
   return readSelectionSetFromStore({
-    store,
+    context: { store, fragmentMap: {} },
     rootId: 'ROOT_QUERY',
     selectionSet: queryDef.selectionSet,
     variables,
@@ -59,7 +59,7 @@ export function readFragmentFromStore({
   const fragmentDef = getFragmentDefinition(fragment);
 
   return readSelectionSetFromStore({
-    store,
+    context: { store, fragmentMap: {} },
     rootId,
     selectionSet: fragmentDef.selectionSet,
     variables,
@@ -68,29 +68,26 @@ export function readFragmentFromStore({
 }
 
 export function readSelectionSetFromStore({
-  store,
+  context,
   rootId,
   selectionSet,
   variables,
   returnPartialData = false,
-  fragmentMap,
 }: {
-  store: NormalizedCache,
+  context: StoreContext,
   rootId: string,
   selectionSet: SelectionSet,
   variables: Object,
   returnPartialData?: boolean,
-  fragmentMap?: FragmentMap,
 }): Object {
   const {
     result,
   } = diffSelectionSetAgainstStore({
+    context,
     selectionSet,
     rootId,
-    store,
     throwOnMissingField: !returnPartialData,
     variables,
-    fragmentMap,
   });
 
   return result;

--- a/test/diffAgainstStore.ts
+++ b/test/diffAgainstStore.ts
@@ -319,7 +319,7 @@ describe('diffing queries against the store', () => {
     `;
 
     const { result } = diffSelectionSetAgainstStore({
-      store,
+      context: { store, fragmentMap: {} },
       rootId: 'ROOT_QUERY',
       selectionSet: getQueryDefinition(queryWithMissingField).selectionSet,
       variables: null,
@@ -333,7 +333,7 @@ describe('diffing queries against the store', () => {
     });
     assert.throws(function() {
       diffSelectionSetAgainstStore({
-        store,
+        context: { store, fragmentMap: {} },
         rootId: 'ROOT_QUERY',
         selectionSet: getQueryDefinition(queryWithMissingField).selectionSet,
         variables: null,


### PR DESCRIPTION
Prompted by #376's brittleness; this helps keep common state/configuration around when performing a query.

---

I'm not sure whether I should also refactor `diffQueryAgainstStore`, `diffFragmentAgainstStore`, `readQueryFromStore`, `readFragmentFromStore` to expose this context or not.