### PR TITLE
result transformer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Expect active development and potentially significant breaking changes in the `0
 
 - Added a "noFetch" option to WatchQueryOptions that only returns available data from the local store (even it is incomplete). [Issue #225](https://github.com/apollostack/apollo-client/issues/225) and [PR #385](https://github.com/apollostack/apollo-client/pull/385).
 
+- Added `resultTransformer`, which can be used to mutate results just before they are returned via the client's query interface. [PR #378](https://github.com/apollostack/apollo-client/pull/378)
+
 ### v0.4.1
 
 - Allow `client.mutate` to accept an `optimisticResponse` argument to update the cache immediately, then after the server responds replace the `optimisticResponse` with the real response. [Issue #287](https://github.com/apollostack/apollo-client/issues/287) [PR #336](https://github.com/apollostack/apollo-client/pull/336)

--- a/ambient.d.ts
+++ b/ambient.d.ts
@@ -93,6 +93,11 @@ declare module 'lodash.identity' {
   export = main.identity;
 }
 
+declare module 'lodash.pick' {
+  import main = require('~lodash/index');
+  export = main.pick;
+}
+
 /*
 
   GRAPHQL

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "lodash": "^4.6.1",
     "lodash.mapvalues": "^4.3.0",
     "lodash.omit": "^4.2.1",
+    "lodash.pick": "^4.2.1",
     "minimist": "^1.2.0",
     "mocha": "^2.3.3",
     "nodemon": "^1.9.2",

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -51,6 +51,7 @@ import {
 
 import {
   diffSelectionSetAgainstStore,
+  ResultTransformer,
 } from './data/diffAgainstStore';
 
 import {
@@ -191,6 +192,7 @@ export class QueryManager {
   private store: ApolloStore;
   private reduxRootKey: string;
   private queryTransformer: QueryTransformer;
+  private resultTransformer: ResultTransformer;
   private queryListeners: { [queryId: string]: QueryListener };
 
   private idCounter = 0;
@@ -222,6 +224,7 @@ export class QueryManager {
     store,
     reduxRootKey,
     queryTransformer,
+    resultTransformer,
     shouldBatch = false,
     batchInterval = 10,
   }: {
@@ -229,6 +232,7 @@ export class QueryManager {
     store: ApolloStore,
     reduxRootKey: string,
     queryTransformer?: QueryTransformer,
+    resultTransformer?: ResultTransformer,
     shouldBatch?: Boolean,
     batchInterval?: number,
   }) {
@@ -238,6 +242,7 @@ export class QueryManager {
     this.store = store;
     this.reduxRootKey = reduxRootKey;
     this.queryTransformer = queryTransformer;
+    this.resultTransformer = resultTransformer;
     this.pollingTimers = {};
     this.batchInterval = batchInterval;
     this.queryListeners = {};
@@ -382,6 +387,7 @@ export class QueryManager {
             context: {
               store: this.getDataWithOptimisticResults(),
               fragmentMap: queryStoreValue.fragmentMap,
+              resultTransformer: this.resultTransformer,
             },
             rootId: queryStoreValue.query.id,
             selectionSet: queryStoreValue.query.selectionSet,
@@ -627,6 +633,7 @@ export class QueryManager {
         context: {
           store: this.store.getState()[this.reduxRootKey].data,
           fragmentMap: queryFragmentMap,
+          resultTransformer: this.resultTransformer,
         },
         selectionSet: querySS.selectionSet,
         throwOnMissingField: false,
@@ -734,6 +741,7 @@ export class QueryManager {
                 context: {
                   store: this.getApolloState().data,
                   fragmentMap: queryFragmentMap,
+                  resultTransformer: this.resultTransformer,
                 },
                 rootId: querySS.id,
                 selectionSet: querySS.selectionSet,

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -379,12 +379,14 @@ export class QueryManager {
           }
         } else {
           const resultFromStore = readSelectionSetFromStore({
-            store: this.getDataWithOptimisticResults(),
+            context: {
+              store: this.getDataWithOptimisticResults(),
+              fragmentMap: queryStoreValue.fragmentMap,
+            },
             rootId: queryStoreValue.query.id,
             selectionSet: queryStoreValue.query.selectionSet,
             variables: queryStoreValue.variables,
             returnPartialData: options.returnPartialData || options.noFetch,
-            fragmentMap: queryStoreValue.fragmentMap,
           });
 
           if (observer.next) {
@@ -622,12 +624,14 @@ export class QueryManager {
       // query, use the query diff algorithm to get as much of a result as we can, and identify
       // what data is missing from the store
       const { missingSelectionSets, result } = diffSelectionSetAgainstStore({
+        context: {
+          store: this.store.getState()[this.reduxRootKey].data,
+          fragmentMap: queryFragmentMap,
+        },
         selectionSet: querySS.selectionSet,
-        store: this.store.getState()[this.reduxRootKey].data,
         throwOnMissingField: false,
         rootId: querySS.id,
         variables,
-        fragmentMap: queryFragmentMap,
       });
 
       initialResult = result;
@@ -727,12 +731,14 @@ export class QueryManager {
               // this will throw an error if there are missing fields in
               // the results if returnPartialData is false.
               resultFromStore = readSelectionSetFromStore({
-                store: this.getApolloState().data,
+                context: {
+                  store: this.getApolloState().data,
+                  fragmentMap: queryFragmentMap,
+                },
                 rootId: querySS.id,
                 selectionSet: querySS.selectionSet,
                 variables,
                 returnPartialData: returnPartialData || noFetch,
-                fragmentMap: queryFragmentMap,
               });
               // ensure multiple errors don't get thrown
               /* tslint:disable */

--- a/src/data/diffAgainstStore.ts
+++ b/src/data/diffAgainstStore.ts
@@ -42,11 +42,14 @@ export interface DiffResult {
   missingSelectionSets?: SelectionSetWithRoot[];
 }
 
+export type ResultTransformer = (result: DiffResult) => DiffResult;
+
 // Contexual state and configuration that is used throught a request from the
 // store.
 export interface StoreContext {
   store: NormalizedCache;
   fragmentMap: FragmentMap;
+  resultTransformer?: ResultTransformer;
 }
 
 export function diffQueryAgainstStore({
@@ -225,11 +228,17 @@ export function diffSelectionSetAgainstStore({
     }
   }
 
-  return {
+  let diffResult: DiffResult = {
     result,
     isMissing,
     missingSelectionSets,
   };
+
+  if (context.resultTransformer) {
+    diffResult = context.resultTransformer(diffResult);
+  }
+
+  return diffResult;
 }
 
 function diffFieldAgainstStore({

--- a/src/data/readFromStore.ts
+++ b/src/data/readFromStore.ts
@@ -1,5 +1,6 @@
 import {
   diffSelectionSetAgainstStore,
+  StoreContext,
 } from './diffAgainstStore';
 
 import {
@@ -10,7 +11,6 @@ import {
 import {
   getQueryDefinition,
   getFragmentDefinition,
-  FragmentMap,
 } from '../queries/getFromAST';
 
 import {
@@ -35,7 +35,7 @@ export function readQueryFromStore({
   const queryDef = getQueryDefinition(query);
 
   return readSelectionSetFromStore({
-    store,
+    context: { store, fragmentMap: {} },
     rootId: 'ROOT_QUERY',
     selectionSet: queryDef.selectionSet,
     variables,
@@ -59,7 +59,7 @@ export function readFragmentFromStore({
   const fragmentDef = getFragmentDefinition(fragment);
 
   return readSelectionSetFromStore({
-    store,
+    context: { store, fragmentMap: {} },
     rootId,
     selectionSet: fragmentDef.selectionSet,
     variables,
@@ -68,29 +68,26 @@ export function readFragmentFromStore({
 }
 
 export function readSelectionSetFromStore({
-  store,
+  context,
   rootId,
   selectionSet,
   variables,
   returnPartialData = false,
-  fragmentMap,
 }: {
-  store: NormalizedCache,
+  context: StoreContext,
   rootId: string,
   selectionSet: SelectionSet,
   variables: Object,
   returnPartialData?: boolean,
-  fragmentMap?: FragmentMap,
 }): Object {
   const {
     result,
   } = diffSelectionSetAgainstStore({
+    context,
     selectionSet,
     rootId,
-    store,
     throwOnMissingField: !returnPartialData,
     variables,
-    fragmentMap,
   });
 
   return result;

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,10 @@ import {
 } from './queries/queryTransform';
 
 import {
+  ResultTransformer,
+} from './data/diffAgainstStore';
+
+import {
   MutationBehavior,
   MutationBehaviorReducerMap,
 } from './data/mutationResults';
@@ -137,7 +141,6 @@ export function clearFragmentDefinitions() {
   fragmentDefinitionsMap = {};
 }
 
-
 export default class ApolloClient {
   public networkInterface: NetworkInterface;
   public store: ApolloStore;
@@ -146,6 +149,7 @@ export default class ApolloClient {
   public queryManager: QueryManager;
   public reducerConfig: ApolloReducerConfig;
   public queryTransformer: QueryTransformer;
+  public resultTransformer: ResultTransformer;
   public shouldBatch: boolean;
   public shouldForceFetch: boolean;
   public dataId: IdGetter;
@@ -158,6 +162,7 @@ export default class ApolloClient {
     initialState,
     dataIdFromObject,
     queryTransformer,
+    resultTransformer,
     shouldBatch = false,
     ssrMode = false,
     ssrForceFetchDelay = 0,
@@ -169,6 +174,7 @@ export default class ApolloClient {
     initialState?: any,
     dataIdFromObject?: IdGetter,
     queryTransformer?: QueryTransformer,
+    resultTransformer?: ResultTransformer,
     shouldBatch?: boolean,
     ssrMode?: boolean,
     ssrForceFetchDelay?: number
@@ -180,6 +186,7 @@ export default class ApolloClient {
     this.networkInterface = networkInterface ? networkInterface :
       createNetworkInterface('/graphql');
     this.queryTransformer = queryTransformer;
+    this.resultTransformer = resultTransformer;
     this.shouldBatch = shouldBatch;
     this.shouldForceFetch = !(ssrMode || ssrForceFetchDelay > 0);
     this.dataId = dataIdFromObject;
@@ -284,6 +291,7 @@ export default class ApolloClient {
       reduxRootKey: this.reduxRootKey,
       store,
       queryTransformer: this.queryTransformer,
+      resultTransformer: this.resultTransformer,
       shouldBatch: this.shouldBatch,
       batchInterval: this.batchInterval,
     });

--- a/test/client.ts
+++ b/test/client.ts
@@ -1422,7 +1422,7 @@ describe('client', () => {
     });
   });
 
-  describe.only('result transformation', () => {
+  describe('result transformation', () => {
 
     class Task {
       constructor(properties) {
@@ -1435,7 +1435,7 @@ describe('client', () => {
       }
     }
 
-    let getTerseTask, getFullTask, task, client, requests;
+    let task, client;
     beforeEach(() => {
       task = {
         __typename: 'Task',

--- a/test/client.ts
+++ b/test/client.ts
@@ -15,6 +15,7 @@ import {
   GraphQLError,
   OperationDefinition,
   GraphQLResult,
+  Field,
 } from 'graphql';
 
 import {
@@ -62,6 +63,7 @@ import { getFragmentDefinitions } from '../src/queries/getFromAST';
 import * as chaiAsPromised from 'chai-as-promised';
 
 import { ApolloError } from '../src/errors';
+import pick = require('lodash.pick');
 
 // make it easy to assert with promises
 chai.use(chaiAsPromised);
@@ -1419,4 +1421,110 @@ describe('client', () => {
       assert.equal(fragmentDefinitionsMap['authorDetails'].length, 1);
     });
   });
+
+  describe.only('result transformation', () => {
+
+    class Task {
+      constructor(properties) {
+        (<any>Object).assign(this, properties);
+      }
+    }
+    class User {
+      constructor(properties) {
+        (<any>Object).assign(this, properties);
+      }
+    }
+
+    let getTerseTask, getFullTask, task, client, requests;
+    beforeEach(() => {
+      task = {
+        __typename: 'Task',
+        id: 'abc123',
+        name: 'Do stuff',
+        author: {
+          __typename: 'User',
+          id: 'def456',
+        },
+      };
+      const networkInterface: NetworkInterface = {
+        query(request: Request): Promise<GraphQLResult> {
+          return new Promise((resolve) => {
+            assert.equal(request.operationName, 'getTask');
+            const definition = <OperationDefinition>request.query.definitions[0];
+            const field = <Field>definition.selectionSet.selections[0];
+            const attributes = field.selectionSet.selections.map((s: Field) => s.name.value);
+            resolve({
+              data: {
+                task: pick(task, ...attributes),
+                __typename: 'RootQuery',
+              },
+            });
+          });
+        },
+      };
+      client = new ApolloClient({
+        networkInterface,
+        queryTransformer: addTypenameToSelectionSet,
+        resultTransformer: (diffResult) => {
+          if (!diffResult.isMissing && diffResult.result['__typename'] === 'Task') {
+            diffResult.result = new Task(diffResult.result);
+          } else if (!diffResult.isMissing && diffResult.result['__typename'] === 'User') {
+            diffResult.result = new User(diffResult.result);
+          }
+          return diffResult;
+        },
+      });
+    });
+
+    it('it transforms query results', () => {
+      return client.query({query: gql`
+        query getTask {
+          task {
+            id
+            name
+          }
+        }
+      `})
+      .then((actualResult) => {
+        const resultTask = actualResult.data.task;
+        assert.equal(resultTask.id, 'abc123');
+        assert.equal(resultTask.name, 'Do stuff');
+        assert.instanceOf(resultTask, Task);
+      });
+    });
+
+    it('it handles nested nodes', () => {
+      return client.query({query: gql`
+        query getTask {
+          task {
+            id
+            name
+          }
+        }
+      `})
+      .then((actualResult) => {
+        return client.query({query: gql`
+          query getTask {
+            task {
+              id
+              name
+              author {
+                id
+              }
+            }
+          }
+        `});
+      })
+      .then((actualResult) => {
+        const resultTask = actualResult.data.task;
+        assert.equal(resultTask.id, 'abc123');
+        assert.equal(resultTask.name, 'Do stuff');
+        assert.instanceOf(resultTask, Task);
+        assert.instanceOf(resultTask.author, User);
+        assert.equal(resultTask.author.id, 'def456');
+      });
+    });
+
+  });
+
 });

--- a/test/diffAgainstStore.ts
+++ b/test/diffAgainstStore.ts
@@ -319,7 +319,7 @@ describe('diffing queries against the store', () => {
     `;
 
     const { result } = diffSelectionSetAgainstStore({
-      store,
+      context: { store, fragmentMap: {} },
       rootId: 'ROOT_QUERY',
       selectionSet: getQueryDefinition(queryWithMissingField).selectionSet,
       variables: null,
@@ -333,7 +333,7 @@ describe('diffing queries against the store', () => {
     });
     assert.throws(function() {
       diffSelectionSetAgainstStore({
-        store,
+        context: { store, fragmentMap: {} },
         rootId: 'ROOT_QUERY',
         selectionSet: getQueryDefinition(queryWithMissingField).selectionSet,
         variables: null,

--- a/typings/browser/globals/apollo-client/index.d.ts
+++ b/typings/browser/globals/apollo-client/index.d.ts
@@ -90,6 +90,11 @@ declare module 'lodash.identity' {
   export = main.identity;
 }
 
+declare module 'lodash.pick' {
+  import main = require('~lodash/index');
+  export = main.pick;
+}
+
 /*
 
   GRAPHQL

--- a/typings/main/globals/apollo-client/index.d.ts
+++ b/typings/main/globals/apollo-client/index.d.ts
@@ -95,6 +95,11 @@ declare module 'lodash.identity' {
   export = main.identity;
 }
 
+declare module 'lodash.pick' {
+  import main = require('~lodash/index');
+  export = main.pick;
+}
+
 /*
 
   GRAPHQL

--- a/typings/main/globals/apollo-client/index.d.ts
+++ b/typings/main/globals/apollo-client/index.d.ts
@@ -40,11 +40,6 @@ declare module 'lodash.merge' {
   export = main.merge;
 }
 
-declare module 'lodash.pick' {
-  import main = require('~lodash/index');
-  export = main.pick;
-}
-
 declare module 'lodash.includes' {
   import main = require('~lodash/index');
   export = main.includes;


### PR DESCRIPTION
Please note that this PR depends on, and includes #377.  For a standalone diff, see https://github.com/convoyinc/apollo-client/compare/store-context...store-result-transformer

---

This adds a `resultTransformer` callback that can be used to modify the results of a query just before they are handed off to the caller.

For example, we're crazy and like to attach a prototype to response objects, as a convenient place to hang read only helpers.