### PR TITLE
Remove node 5 from tests to speed things up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
   - "6"
-  - "5"
   - "4"
 install:
   - npm install -g coveralls


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md with your change
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

I've never seen something pass in 4 and 6 but fail in 5, and nobody should be using 5 anyway since it's not LTS or the latest stable.