### PR TITLE
Add batcherPollInterval as an option to ApolloClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 3 to 6 months), to signal the start of a more stable API.
 
 ### vNEXT
-- Added the `batcherPollInterval` option to ApolloClient that allows you to specify the width of the batcher polling interval as per your app's needs. [Issue #394](https://github.com/apollostack/apollo-client/issues/394) and [PR #395](https://github.com/apollostack/apollo-client/pull/395).
+- Added the `batchInterval` option to ApolloClient that allows you to specify the width of the batching interval as per your app's needs. [Issue #394](https://github.com/apollostack/apollo-client/issues/394) and [PR #395](https://github.com/apollostack/apollo-client/pull/395).
 
 - Stringify `storeObj` for error message in `diffFieldAgainstStore`.
 - Fix map function returning `undefined` in `removeRefsFromStoreObj`. [PR #393](https://github.com/apollostack/apollo-client/pull/393)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 3 to 6 months), to signal the start of a more stable API.
 
 ### vNEXT
+- Added the `batcherPollInterval` option to ApolloClient that allows you to specify the width of the batcher polling interval as per your app's needs. [Issue #394](https://github.com/apollostack/apollo-client/issues/394) and [PR #395](https://github.com/apollostack/apollo-client/pull/395).
 
 ### v0.4.1
 

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -141,7 +141,7 @@ export class QueryManager {
 
   private scheduler: QueryScheduler;
   private batcher: QueryBatcher;
-  private batcherPollInterval: number;
+  private batchInterval: number;
 
   // A map going from an index (i.e. just like an array index, except that we can remove
   // some of them) to a promise that has not yet been resolved. We use this to keep
@@ -167,14 +167,14 @@ export class QueryManager {
     reduxRootKey,
     queryTransformer,
     shouldBatch = false,
-    batcherPollInterval = 10,
+    batchInterval = 10,
   }: {
     networkInterface: NetworkInterface,
     store: ApolloStore,
     reduxRootKey: string,
     queryTransformer?: QueryTransformer,
     shouldBatch?: Boolean,
-    batcherPollInterval?: number,
+    batchInterval?: number,
   }) {
     // XXX this might be the place to do introspection for inserting the `id` into the query? or
     // is that the network interface?
@@ -183,7 +183,7 @@ export class QueryManager {
     this.reduxRootKey = reduxRootKey;
     this.queryTransformer = queryTransformer;
     this.pollingTimers = {};
-    this.batcherPollInterval = batcherPollInterval;
+    this.batchInterval = batchInterval;
     this.queryListeners = {};
 
     this.scheduler = new QueryScheduler({
@@ -195,7 +195,7 @@ export class QueryManager {
       networkInterface: this.networkInterface,
     });
 
-    this.batcher.start(this.batcherPollInterval);
+    this.batcher.start(this.batchInterval);
     this.fetchQueryPromises = {};
     this.observableQueries = {};
 

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -141,7 +141,7 @@ export class QueryManager {
 
   private scheduler: QueryScheduler;
   private batcher: QueryBatcher;
-  private batcherPollInterval = 10;
+  private batcherPollInterval: number;
 
   // A map going from an index (i.e. just like an array index, except that we can remove
   // some of them) to a promise that has not yet been resolved. We use this to keep
@@ -167,12 +167,14 @@ export class QueryManager {
     reduxRootKey,
     queryTransformer,
     shouldBatch = false,
+    batcherPollInterval = 10,
   }: {
     networkInterface: NetworkInterface,
     store: ApolloStore,
     reduxRootKey: string,
     queryTransformer?: QueryTransformer,
     shouldBatch?: Boolean,
+    batcherPollInterval?: number,
   }) {
     // XXX this might be the place to do introspection for inserting the `id` into the query? or
     // is that the network interface?
@@ -181,7 +183,7 @@ export class QueryManager {
     this.reduxRootKey = reduxRootKey;
     this.queryTransformer = queryTransformer;
     this.pollingTimers = {};
-
+    this.batcherPollInterval = batcherPollInterval;
     this.queryListeners = {};
 
     this.scheduler = new QueryScheduler({

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,7 +150,7 @@ export default class ApolloClient {
   public shouldForceFetch: boolean;
   public dataId: IdGetter;
   public fieldWithArgs: (fieldName: string, args?: Object) => string;
-  public batcherPollInterval: number;
+  public batchInterval: number;
 
   constructor({
     networkInterface,
@@ -162,7 +162,7 @@ export default class ApolloClient {
     ssrMode = false,
     ssrForceFetchDelay = 0,
     mutationBehaviorReducers = {} as MutationBehaviorReducerMap,
-    batcherPollInterval,
+    batchInterval,
   }: {
     networkInterface?: NetworkInterface,
     reduxRootKey?: string,
@@ -173,7 +173,7 @@ export default class ApolloClient {
     ssrMode?: boolean,
     ssrForceFetchDelay?: number
     mutationBehaviorReducers?: MutationBehaviorReducerMap,
-    batcherPollInterval?: number,
+    batchInterval?: number,
   } = {}) {
     this.reduxRootKey = reduxRootKey ? reduxRootKey : 'apollo';
     this.initialState = initialState ? initialState : {};
@@ -184,7 +184,7 @@ export default class ApolloClient {
     this.shouldForceFetch = !(ssrMode || ssrForceFetchDelay > 0);
     this.dataId = dataIdFromObject;
     this.fieldWithArgs = storeKeyNameFromFieldNameAndArgs;
-    this.batcherPollInterval = batcherPollInterval;
+    this.batchInterval = batchInterval;
 
     if (ssrForceFetchDelay) {
       setTimeout(() => this.shouldForceFetch = true, ssrForceFetchDelay);
@@ -285,7 +285,7 @@ export default class ApolloClient {
       store,
       queryTransformer: this.queryTransformer,
       shouldBatch: this.shouldBatch,
-      batcherPollInterval: this.batcherPollInterval,
+      batchInterval: this.batchInterval,
     });
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,6 +150,7 @@ export default class ApolloClient {
   public shouldForceFetch: boolean;
   public dataId: IdGetter;
   public fieldWithArgs: (fieldName: string, args?: Object) => string;
+  public batcherPollInterval: number;
 
   constructor({
     networkInterface,
@@ -161,6 +162,7 @@ export default class ApolloClient {
     ssrMode = false,
     ssrForceFetchDelay = 0,
     mutationBehaviorReducers = {} as MutationBehaviorReducerMap,
+    batcherPollInterval,
   }: {
     networkInterface?: NetworkInterface,
     reduxRootKey?: string,
@@ -171,6 +173,7 @@ export default class ApolloClient {
     ssrMode?: boolean,
     ssrForceFetchDelay?: number
     mutationBehaviorReducers?: MutationBehaviorReducerMap,
+    batcherPollInterval?: number,
   } = {}) {
     this.reduxRootKey = reduxRootKey ? reduxRootKey : 'apollo';
     this.initialState = initialState ? initialState : {};
@@ -181,6 +184,7 @@ export default class ApolloClient {
     this.shouldForceFetch = !(ssrMode || ssrForceFetchDelay > 0);
     this.dataId = dataIdFromObject;
     this.fieldWithArgs = storeKeyNameFromFieldNameAndArgs;
+    this.batcherPollInterval = batcherPollInterval;
 
     if (ssrForceFetchDelay) {
       setTimeout(() => this.shouldForceFetch = true, ssrForceFetchDelay);
@@ -281,6 +285,7 @@ export default class ApolloClient {
       store,
       queryTransformer: this.queryTransformer,
       shouldBatch: this.shouldBatch,
+      batcherPollInterval: this.batcherPollInterval,
     });
   };
 }


### PR DESCRIPTION
Adds an option that lets the application developer specify the width of the batcher's polling interval. Fixes #394 

TODO:

- [x] Update CHANGELOG.md with your change
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

