### PR TITLE
Improve error message.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Expect active development and potentially significant breaking changes in the `0
 
 ### vNEXT
 
+- Stringify `storeObj` for error message in `diffFieldAgainstStore`.
 - Fix map function returning `undefined` in `removeRefsFromStoreObj`. [PR #393](https://github.com/apollostack/apollo-client/pull/393)
 
 ### v0.4.1

--- a/src/data/diffAgainstStore.ts
+++ b/src/data/diffAgainstStore.ts
@@ -256,7 +256,8 @@ function diffFieldAgainstStore({
 
   if (! has(storeObj, storeFieldKey)) {
     if (throwOnMissingField && included) {
-      throw new Error(`Can't find field ${storeFieldKey} on object ${storeObj}.`);
+      throw new Error(`Can't find field ${storeFieldKey} on object ${JSON.stringify(storeObj)}.
+Perhaps you want to use the \`returnPartialData\` option?`);
     }
 
     return {


### PR DESCRIPTION
Trying to improve an error message by using `JSON.stringify` so `storeObj` doesn't show up as `[Object object]` in the console all the time. I suppose it is possible that `storeObj` would be so big that we wouldn't want to do that…but I've not run in to that personally.

I'm not sure if adding the bit about `returnPartialData` is really the best advice, though it is certainly one common solution I've ended up using. Thoughts?

TODO:

- [x] Update CHANGELOG.md with your change
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

