### PR TITLE
Don't fire any query observables if the query result didn't change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ Expect active development and potentially significant breaking changes in the `0
 
 ### vNEXT
 - Added the `batchInterval` option to ApolloClient that allows you to specify the width of the batching interval as per your app's needs. [Issue #394](https://github.com/apollostack/apollo-client/issues/394) and [PR #395](https://github.com/apollostack/apollo-client/pull/395).
-
 - Stringify `storeObj` for error message in `diffFieldAgainstStore`.
 - Fix map function returning `undefined` in `removeRefsFromStoreObj`. [PR #393](https://github.com/apollostack/apollo-client/pull/393)
+- Added data diffing so that observers are only fired when the data associated with a particular query changes. This change eliminates unnecessary re-renders and improves UI performance. [PR #402](https://github.com/apollostack/apollo-client/pull/402) and [Issue #400](https://github.com/apollostack/apollo-client/issues/400).
 
 - Added a "noFetch" option to WatchQueryOptions that only returns available data from the local store (even it is incomplete). [Issue #225](https://github.com/apollostack/apollo-client/issues/225) and [PR #385](https://github.com/apollostack/apollo-client/pull/385).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Expect active development and potentially significant breaking changes in the `0
 - Added the `batchInterval` option to ApolloClient that allows you to specify the width of the batching interval as per your app's needs. [Issue #394](https://github.com/apollostack/apollo-client/issues/394) and [PR #395](https://github.com/apollostack/apollo-client/pull/395).
 - Stringify `storeObj` for error message in `diffFieldAgainstStore`.
 - Fix map function returning `undefined` in `removeRefsFromStoreObj`. [PR #393](https://github.com/apollostack/apollo-client/pull/393)
-- Added data diffing so that observers are only fired when the data associated with a particular query changes. This change eliminates unnecessary re-renders and improves UI performance. [PR #402](https://github.com/apollostack/apollo-client/pull/402) and [Issue #400](https://github.com/apollostack/apollo-client/issues/400).
+- Added deep result comparison so that observers are only fired when the data associated with a particular query changes. This change eliminates unnecessary re-renders and improves UI performance. [PR #402](https://github.com/apollostack/apollo-client/pull/402) and [Issue #400](https://github.com/apollostack/apollo-client/issues/400).
 
 - Added a "noFetch" option to WatchQueryOptions that only returns available data from the local store (even it is incomplete). [Issue #225](https://github.com/apollostack/apollo-client/issues/225) and [PR #385](https://github.com/apollostack/apollo-client/pull/385).
 

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -124,7 +124,7 @@ export class ObservableQuery extends Observable<ApolloQueryResult> {
       queryManager.startQuery(
         queryId,
         options,
-        queryManager.queryListenerForObserver(options, observer)
+        queryManager.queryListenerForObserver(queryId, options, observer)
       );
       return retQuerySubscription;
     };
@@ -418,69 +418,10 @@ export class QueryManager {
     // Call just to get errors synchronously
     getQueryDefinition(options.query);
 
-<<<<<<< HEAD
     let observableQuery = new ObservableQuery({
       queryManager: this,
       options: options,
       shouldSubscribe: shouldSubscribe,
-=======
-    const queryId = this.generateQueryId();
-
-    let observableQuery;
-
-    const subscriberFunction = (observer: Observer<ApolloQueryResult>) => {
-      const retQuerySubscription = {
-        unsubscribe: () => {
-          this.stopQuery(queryId);
-        },
-      };
-
-      if (shouldSubscribe) {
-        this.addObservableQuery(queryId, observableQuery);
-        this.addQuerySubscription(queryId, retQuerySubscription);
-      }
-
-      this.startQuery(
-        queryId,
-        options,
-        this.queryListenerForObserver(queryId, options, observer)
-      );
-
-      return retQuerySubscription;
-    };
-
-    const refetch = (variables?: any) => {
-      // If no new variables passed, use existing variables
-      variables = variables || options.variables;
-
-      // Use the same options as before, but with new variables and forceFetch true
-      return this.fetchQuery(queryId, assign(options, {
-        forceFetch: true,
-        variables,
-      }) as WatchQueryOptions);
-    };
-
-    const stopPolling = () => {
-      if (this.pollingTimers[queryId]) {
-        clearInterval(this.pollingTimers[queryId]);
-      }
-    };
-
-    const startPolling = (pollInterval) => {
-      this.pollingTimers[queryId] = setInterval(() => {
-        const pollingOptions = assign({}, options) as WatchQueryOptions;
-        // subsequent fetches from polling always reqeust new data
-        pollingOptions.forceFetch = true;
-        this.fetchQuery(queryId, pollingOptions);
-      }, pollInterval);
-    };
-
-    observableQuery = new ObservableQuery({
-      subscriberFunction,
-      refetch,
-      stopPolling,
-      startPolling,
->>>>>>> in progress commit for the component updating code
     });
 
     return observableQuery;
@@ -794,6 +735,10 @@ export class QueryManager {
               // ensure result is combined with data already in store
               // this will throw an error if there are missing fields in
               // the results if returnPartialData is false.
+
+
+              console.log('Return partial data: %s', returnPartialData);
+              console.log('No fetch: %s', noFetch);
               resultFromStore = readSelectionSetFromStore({
                 store: this.getApolloState().data,
                 rootId: querySS.id,
@@ -834,47 +779,12 @@ export class QueryManager {
     });
   }
 
-<<<<<<< HEAD
-=======
-  private startQuery(queryId: string, options: WatchQueryOptions, listener: QueryListener) {
-    this.queryListeners[queryId] = listener;
-    this.fetchQuery(queryId, options);
-
-    if (options.pollInterval) {
-      this.pollingTimers[queryId] = setInterval(() => {
-        const pollingOptions = assign({}, options) as WatchQueryOptions;
-        // subsequent fetches from polling always reqeust new data
-        pollingOptions.forceFetch = true;
-        this.fetchQuery(queryId, pollingOptions);
-      }, options.pollInterval);
-    }
-
-    return queryId;
-  }
-
-  private stopQuery(queryId: string) {
-    // XXX in the future if we should cancel the request
-    // so that it never tries to return data
-    delete this.queryListeners[queryId];
-
-    // if we have a polling interval running, stop it
-    if (this.pollingTimers[queryId]) {
-      clearInterval(this.pollingTimers[queryId]);
-    }
-
-    this.store.dispatch({
-      type: 'APOLLO_QUERY_STOP',
-      queryId,
-    });
-  }
-
   // Given a query id and a new result, this checks if the old result is
   // the same as the last result for that particular query id.
   private isDifferentResult(queryId: string, result: ApolloQueryResult): boolean {
     return !isEqual(this.queryResults[queryId], result);
   }
 
->>>>>>> in progress commit for the component updating code
   private broadcastQueries() {
     const queries = this.getApolloState().queries;
     forOwn(this.queryListeners, (listener: QueryListener, queryId: string) => {

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -194,7 +194,7 @@ export class QueryManager {
   private queryListeners: { [queryId: string]: QueryListener };
 
   // A map going from queryId to the last result/state that the queryListener was told about.
-  private queryResults: { [queryId: string]: ApolloQueryResult }
+  private queryResults: { [queryId: string]: ApolloQueryResult };
 
   private idCounter = 0;
 
@@ -364,7 +364,6 @@ export class QueryManager {
       if (!queryStoreValue) {
         return;
       }
-      console.log('QUERY LISTENER');
 
       if (!queryStoreValue.loading || queryStoreValue.returnPartialData) {
         // XXX Currently, returning errors and data is exclusive because we
@@ -395,13 +394,10 @@ export class QueryManager {
           };
 
           if (observer.next) {
-            console.log('Is it a different result?');
-            observer.next(resultFromStore);
-            /*
             if (this.isDifferentResult(queryId, resultFromStore )) {
               this.queryResults[queryId] = resultFromStore;
               observer.next(resultFromStore);
-            } */
+            }
           }
         }
       }

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -388,7 +388,7 @@ export class QueryManager {
               rootId: queryStoreValue.query.id,
               selectionSet: queryStoreValue.query.selectionSet,
               variables: queryStoreValue.variables,
-              returnPartialData: options.returnPartialData,
+              returnPartialData: options.returnPartialData || options.noFetch,
               fragmentMap: queryStoreValue.fragmentMap,
             }),
           };
@@ -735,10 +735,6 @@ export class QueryManager {
               // ensure result is combined with data already in store
               // this will throw an error if there are missing fields in
               // the results if returnPartialData is false.
-
-
-              console.log('Return partial data: %s', returnPartialData);
-              console.log('No fetch: %s', noFetch);
               resultFromStore = readSelectionSetFromStore({
                 store: this.getApolloState().data,
                 rootId: querySS.id,

--- a/src/data/readFromStore.ts
+++ b/src/data/readFromStore.ts
@@ -93,5 +93,7 @@ export function readSelectionSetFromStore({
     fragmentMap,
   });
 
+  console.log('Return partial data (selection set): %s', returnPartialData);
+
   return result;
 }

--- a/src/data/readFromStore.ts
+++ b/src/data/readFromStore.ts
@@ -93,7 +93,5 @@ export function readSelectionSetFromStore({
     fragmentMap,
   });
 
-  console.log('Return partial data (selection set): %s', returnPartialData);
-
   return result;
 }

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -664,7 +664,7 @@ describe('QueryManager', () => {
 
     const data3 = {
       people_one: {
-        name: 'Luke Skywalker has a new name',
+        name: 'Luke Skywalker has a new name and age',
       },
     };
 
@@ -683,7 +683,7 @@ describe('QueryManager', () => {
       },
       {
         request: { query: query, variables },
-        result: { data: data2 },
+        result: { data: data3 },
       }
     );
 
@@ -1467,9 +1467,7 @@ describe('QueryManager', () => {
     });
 
     function checkDone() {
-      // If we make sure queries aren't called twice if the result didn't change, handle2Count
-      // should change to 1
-      if (handle1Count === 1 && handle2Count === 2) {
+      if (handle1Count === 1 && handle2Count === 1) {
         done();
       }
 
@@ -1546,7 +1544,7 @@ describe('QueryManager', () => {
           queryManager.query({
             query: query2,
           });
-        } else if (handle1Count === 3 &&
+        } else if (handle1Count === 2 &&
             result.data['people_one'].name === 'Luke Skywalker has a new name') {
           // 3 because the query init action for the second query causes a callback
           assert.deepEqual(result.data, {
@@ -1736,7 +1734,7 @@ describe('QueryManager', () => {
     });
 
     setTimeout(() => {
-      assert.equal(handleCount, 4);
+      assert.equal(handleCount, 3);
       done();
     }, 400);
   });
@@ -2746,7 +2744,7 @@ describe('QueryManager', () => {
       author: {
         firstName: 'John',
         lastName: 'Smith',
-      }
+      },
     };
     const networkInterface = mockNetworkInterface(
       {
@@ -2774,9 +2772,6 @@ describe('QueryManager', () => {
     });
     queryManager.query({ query }).then((result) => {
       assert.deepEqual(result, { data });
-      console.log('Times fired: ');
-      console.log(timesFired);
-
       assert.equal(timesFired, 1);
       done();
     });


### PR DESCRIPTION
This PR makes it so that observables are only fired when the data received changes. This means that observers will only be fired if there's an updated result in the store. We do a deep diff before doing this. Solves #400. 

I ran a comparison using the Chrome CPU profiler with and without this particular changeset on the Galaxy UI. 

Before: 
![here](http://i.imgur.com/KSJvt9f.png) 

After: 
![Here](http://i.imgur.com/0QfPgvD.png)

There is a single large element on this page that isn't changing in this particular query. As you can see clearly in the "before", this element is rendered for no reason and this rendering is eliminated in the "after". Secondly, there is also consistently reduced time to render the list of items that _are_ changing since some of them don't actually change (~80ms to ~40ms). This isn't a particularly complex page so the performance improvements aren't incredible but it is easy to imagine cases where polling queries would be needlessly causes re-renders within React.

TODO:

- [x] Update CHANGELOG.md with your change
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
