### PR TITLE
Update Typescript to 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "license": "MIT",
   "dependencies": {
     "es6-promise": "^3.1.2",
-    "graphql-tag": "^0.1.8",
+    "graphql-tag": "^0.1.10",
     "lodash.assign": "^4.0.8",
     "lodash.clonedeep": "^4.3.2",
     "lodash.countby": "^4.4.0",
@@ -88,7 +88,7 @@
     "sinon": "^1.17.4",
     "source-map-support": "^0.4.0",
     "tslint": "3.13.0",
-    "typescript": "^1.8.9",
+    "typescript": "^2.0.0",
     "typings": "^1.0.0",
     "uglify-js": "^2.6.2"
   }

--- a/src/data/store.ts
+++ b/src/data/store.ts
@@ -50,6 +50,10 @@ export function data(
   mutations: MutationStore,
   config: ApolloReducerConfig
 ): NormalizedCache {
+  // XXX This is hopefully a temporary binding to get around
+  // https://github.com/Microsoft/TypeScript/issues/7719
+  const constAction = action;
+
   if (isQueryResultAction(action)) {
     if (!queries[action.queryId]) {
       return previousState;
@@ -81,16 +85,16 @@ export function data(
 
       return newState;
     }
-  } else if (isMutationResultAction(action)) {
+  } else if (isMutationResultAction(constAction)) {
     // Incorporate the result from this mutation into the store
-    if (!action.result.errors) {
-      const queryStoreValue = mutations[action.mutationId];
+    if (!constAction.result.errors) {
+      const queryStoreValue = mutations[constAction.mutationId];
 
       // XXX use immutablejs instead of cloning
       const clonedState = assign({}, previousState) as NormalizedCache;
 
       let newState = writeSelectionSetToStore({
-        result: action.result.data,
+        result: constAction.result.data,
         dataId: queryStoreValue.mutation.id,
         selectionSet: queryStoreValue.mutation.selectionSet,
         variables: queryStoreValue.variables,
@@ -99,11 +103,11 @@ export function data(
         fragmentMap: queryStoreValue.fragmentMap,
       });
 
-      if (action.resultBehaviors) {
-        action.resultBehaviors.forEach((behavior) => {
+      if (constAction.resultBehaviors) {
+        constAction.resultBehaviors.forEach((behavior) => {
           const args: MutationBehaviorReducerArgs = {
             behavior,
-            result: action.result,
+            result: constAction.result,
             variables: queryStoreValue.variables,
             fragmentMap: queryStoreValue.fragmentMap,
             selectionSet: queryStoreValue.mutation.selectionSet,


### PR DESCRIPTION
The soon-to-be-released v2.0 of TypeScript will bring a lot of new cool features. Cherry-picking the releases notes, I believe the apollo-client will especially benefit from the discriminated union types (https://github.com/Microsoft/TypeScript/pull/9163), the smarter flow analysis, and the explicit `null` and `undefined` checks.

This PR updates the Typescript compiler to use the v2.0-[beta](https://blogs.msdn.microsoft.com/typescript/2016/07/11/announcing-typescript-2-0-beta/). There is one logic error detected by the new flow analysis:

```
106             result: action.result,
                               ~~~~~~

src/data/store.ts(106,28): error TS2339: Property 'result' does not exist on type 'QueryResultAction | QueryErrorAction | QueryInitAction | QueryResultClientAction | QueryStopActio...'.
```

I haven’t opt-in the `strictNullChecks` option as I’m not that comfortable with the code base, but it sure would be great if someone else could do it.