### PR TITLE
Fragment flattening

### DIFF
--- a/test/client.ts
+++ b/test/client.ts
@@ -3,7 +3,7 @@ const { assert } = chai;
 import * as sinon from 'sinon';
 
 import ApolloClient, {
-  createFragment
+  createFragment,
   fragmentDefinitionsMap,
   clearFragmentDefinitions,
   disableFragmentWarnings,
@@ -1107,7 +1107,15 @@ describe('client', () => {
           address
         }`;
       const fragmentDoc3 = gql`
-        fragment
+        fragment personDetails on Person {
+          personDetails
+        }`;
+      const fragments1 = createFragment(fragmentDoc1);
+      const fragments2 = createFragment(fragmentDoc2, fragments1);
+      const fragments3 = createFragment(fragmentDoc3, fragments2);
+      assert.equal(fragments1.length, 1);
+      assert.equal(fragments2.length, 2);
+      assert.equal(fragments3.length, 3);
     });
 
     it('should add a fragment to the fragmentDefinitionsMap', () => {

--- a/test/client.ts
+++ b/test/client.ts
@@ -3,7 +3,7 @@ const { assert } = chai;
 import * as sinon from 'sinon';
 
 import ApolloClient, {
-  createFragment,
+  createFragment
   fragmentDefinitionsMap,
   clearFragmentDefinitions,
   disableFragmentWarnings,
@@ -1093,6 +1093,21 @@ describe('client', () => {
       const expFragmentDefs = getFragmentDefinitions(otherFragmentDoc)
         .concat(getFragmentDefinitions(fragmentDoc));
       assert.deepEqual(fragmentDefs.map(print), expFragmentDefs.map(print));
+    });
+
+    it('should always return a flat array of fragment defs', () => {
+      const fragmentDoc1 = gql`
+        fragment authorDetails on Author {
+          firstName
+          lastName
+          ...otherAuthorDetails
+        }`;
+      const fragmentDoc2 = gql`
+        fragment otherAuthorDetails on Author {
+          address
+        }`;
+      const fragmentDoc3 = gql`
+        fragment
     });
 
     it('should add a fragment to the fragmentDefinitionsMap', () => {


### PR DESCRIPTION
Added a (passing) test that checks whether or not the list of fragment definitions is flattened by `createFragment`. Motivated by #421 

TODO:

- [x] Update CHANGELOG.md with your change
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
