### PR TITLE
Fix paths of ObservableQuery and WatchQueryOptions in index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,11 +34,11 @@ import {
 
 import {
     ObservableQuery,
-} from '../src/ObservableQuery';
+} from './ObservableQuery';
 
 import {
   WatchQueryOptions,
-} from '../src/watchQueryOptions';
+} from './watchQueryOptions';
 
 import {
   readQueryFromStore,


### PR DESCRIPTION
There is no `/src` after publishing ApolloClient to the npm so TypeScript is very angry.

Closes #429 