### PR TITLE
Added a test for `noFetch` error

### DIFF
--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -971,6 +971,34 @@ describe('QueryManager', () => {
     });
   });
 
+  it('should error if we pass noFetch on a polling query', (done) => {
+    const query = gql`
+      query {
+        author {
+          firstName
+          lastName
+        }
+      }`;
+    const queryManager = new QueryManager({
+      networkInterface: mockNetworkInterface(),
+      store: createApolloStore(),
+      reduxRootKey: 'apollo',
+    });
+    const handle = queryManager.watchQuery({
+      query,
+      pollInterval: 200,
+      noFetch: true,
+    });
+    assert.throws(() => {
+      handle.subscribe({
+        next(result) {
+          done(new Error('Returned a result when it should not have.'));
+        },
+      });
+    });
+    done();
+  });
+
   it('supports noFetch fetching only cached data', () => {
     const primeQuery = gql`
       query primeQuery {


### PR DESCRIPTION
Added a test for the error that is supposed to be thrown when we try to `noFetch` a polling query.

TODO:

- [x] Update CHANGELOG.md with your change
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
