### PR TITLE
Add forceFetch option to ObservableQuery.refetch()

### DIFF
--- a/src/ObservableQuery.ts
+++ b/src/ObservableQuery.ts
@@ -77,7 +77,9 @@ export class ObservableQuery extends Observable<ApolloQueryResult> {
     this.queryManager = queryManager;
     this.queryId = queryId;
 
-    this.refetch = (variables?: any) => {
+    this.refetch = (variables?: any, {
+      forceFetch = true,
+    } = {}) => {
       // If no new variables passed, use existing variables
       variables = variables || this.options.variables;
       if (this.options.noFetch) {
@@ -85,7 +87,7 @@ export class ObservableQuery extends Observable<ApolloQueryResult> {
       }
       // Use the same options as before, but with new variables and forceFetch true
       return this.queryManager.fetchQuery(this.queryId, assign(this.options, {
-        forceFetch: true,
+        forceFetch,
         variables,
       }) as WatchQueryOptions);
     };


### PR DESCRIPTION
This allows to call `refetch` with `forceFetch: false`, to change the
variables of the watchQuery while still using the cached data if any.

See #442