### PR TITLE
Bugfix: Don't mutate fragments that are attached to query documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Expect active development and potentially significant breaking changes in the `0
 - Add `useAfter` function that accepts `afterwares`. Afterwares run after a request is made (after middlewares). In the afterware function, you get the whole response and request options, so you can handle status codes and errors if you need to. For example, if your requests return a `401` in the case of user logout, you can use this to identify when that starts happening. It can be used just as a `middleware` is used. Just pass an array of afterwares to the `useAfter` function.
 - Add a stack trace to `ApolloError`. [PR #445](https://github.com/apollostack/apollo-client/pull/445) and [Issue #434](https://github.com/apollostack/apollo-client/issues/434).
 - Fixed an extra log of errors on `query` calls. [PR #445](https://github.com/apollostack/apollo-client/pull/445) and [Issue #423](https://github.com/apollostack/apollo-client/issues/423).
+- Fix repeat calls to a query that includes fragments [PR #447](https://github.com/apollostack/apollo-client/pull/447).
 
 ### v0.4.7
 

--- a/src/queries/getFromAST.ts
+++ b/src/queries/getFromAST.ts
@@ -4,6 +4,7 @@ import {
   FragmentDefinition,
 } from 'graphql';
 
+import assign = require('lodash.assign');
 import countBy = require('lodash.countby');
 import identity = require('lodash.identity');
 
@@ -124,6 +125,7 @@ export function createFragmentMap(fragments: FragmentDefinition[]): FragmentMap 
 export function addFragmentsToDocument(queryDoc: Document,
   fragments: FragmentDefinition[]): Document {
   checkDocument(queryDoc);
-  queryDoc.definitions = queryDoc.definitions.concat(fragments);
-  return queryDoc;
+  return <Document>assign({}, queryDoc, {
+    definitions: queryDoc.definitions.concat(fragments),
+  });
 }

--- a/test/client.ts
+++ b/test/client.ts
@@ -1445,5 +1445,21 @@ describe('client', () => {
       assert(fragmentDefinitionsMap.hasOwnProperty('authorDetails'));
       assert.equal(fragmentDefinitionsMap['authorDetails'].length, 1);
     });
+
+    it('should not mutate the input document when querying', () => {
+      const client = new ApolloClient();
+
+      const fragments = createFragment(gql`
+        fragment authorDetails on Author {
+          author {
+            firstName
+            lastName
+          }
+        }`);
+      const query = gql`{ author { ...authorDetails } }`;
+      const initialDefinitions = query.definitions;
+      client.query({query, fragments});
+      assert.equal(query.definitions, initialDefinitions);
+    });
   });
 });


### PR DESCRIPTION
This fixes an issue that arises when you perform the same query multiple times, and that query has fragments.

Because `addFragmentsToDocument` _appends_ fragments to `queryDoc.definitions`, each time the query is performed, the query document gains a new copy of each fragment.  This is particularly egregious, since `graphql-tag` maintains an identity map for queries.

For example, the following currently results in a server error (duplicate fragment authorDetails) on the second query:

```js
const fragments = createFragment(gql`
  fragment authorDetails on Author {
    author {
      firstName
      lastName
    }
}`);
const query = gql`{ author { ...authorDetails } }`;

client.query({query, fragments}); // Success
client.query({query, fragments}); // BOOM: Duplicate fragment authorDetails
```