### PR TITLE
[WIP - Going to transfer] Add "silenced" paginationArguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ This release has a minor version bump, which means npm will not automatically up
 
 ### v0.3.30
 
+- Strip away apollo-specific directives before they reach the network interface. This is useful to implement apollo-client only directives such as the upcoming `@apolloFetchMore`. [PR #374](https://github.com/apollostack/apollo-client/pull/374)
 - Don't throw on unknown directives, instead just pass them through. This can open the door to implementing `@live`, `@defer`, and `@stream`, if coupled with some changes in the network layer. [PR #372](https://github.com/apollostack/apollo-client/pull/372)
 
 ### v0.3.29

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -61,6 +61,10 @@ import {
 } from './queryPrinting';
 
 import {
+  stripApolloDirectivesFromRequest,
+} from './queries/directives';
+
+import {
   QueryFetchRequest,
   QueryBatcher,
 } from './batching';
@@ -237,7 +241,7 @@ export class QueryManager {
       resultBehaviors: [...resultBehaviors, ...updateQueriesResultBehaviors],
     });
 
-    return this.networkInterface.query(request)
+    return this.networkInterface.query(stripApolloDirectivesFromRequest(request))
       .then((result) => {
         this.store.dispatch({
           type: 'APOLLO_MUTATION_RESULT',

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -46,6 +46,7 @@ export interface QueryInitAction {
   queryId: string;
   requestId: number;
   fragmentMap: FragmentMap;
+  paginationArguments?: string[];
 }
 
 export function isQueryInitAction(action: ApolloAction): action is QueryInitAction {
@@ -81,6 +82,7 @@ export interface MutationInitAction {
   fragmentMap: FragmentMap;
   optimisticResponse: Object;
   resultBehaviors?: MutationBehavior[];
+  paginationArguments?: string[];
 }
 
 export function isMutationInitAction(action: ApolloAction): action is MutationInitAction {

--- a/src/batching.ts
+++ b/src/batching.ts
@@ -9,6 +9,10 @@ import {
 } from './networkInterface';
 
 import {
+  stripApolloDirectivesFromRequest,
+} from './queries/directives';
+
+import {
   GraphQLResult,
 } from 'graphql';
 
@@ -81,7 +85,7 @@ export class QueryBatcher {
         variables: queuedRequest.options.variables,
         operationName: queuedRequest.operationName,
       };
-    });
+    }).map(stripApolloDirectivesFromRequest);
 
     const promises: Promise<GraphQLResult>[] = [];
     const resolvers = [];

--- a/src/data/diffAgainstStore.ts
+++ b/src/data/diffAgainstStore.ts
@@ -47,10 +47,12 @@ export function diffQueryAgainstStore({
   store,
   query,
   variables,
+  paginationArguments = [],
 }: {
   store: NormalizedCache,
   query: Document,
   variables?: Object,
+  paginationArguments?: string[],
 }): DiffResult {
   const queryDef = getQueryDefinition(query);
 
@@ -60,6 +62,7 @@ export function diffQueryAgainstStore({
     selectionSet: queryDef.selectionSet,
     throwOnMissingField: false,
     variables,
+    paginationArguments,
   });
 }
 
@@ -68,11 +71,13 @@ export function diffFragmentAgainstStore({
   fragment,
   rootId,
   variables,
+  paginationArguments = [],
 }: {
   store: NormalizedCache,
   fragment: Document,
   rootId: string,
   variables?: Object,
+  paginationArguments?: string[],
 }): DiffResult {
   const fragmentDef = getFragmentDefinition(fragment);
 
@@ -82,6 +87,7 @@ export function diffFragmentAgainstStore({
     selectionSet: fragmentDef.selectionSet,
     throwOnMissingField: false,
     variables,
+    paginationArguments,
   });
 }
 
@@ -103,6 +109,7 @@ export function diffSelectionSetAgainstStore({
   throwOnMissingField = false,
   variables,
   fragmentMap,
+  paginationArguments = [],
 }: {
   selectionSet: SelectionSet,
   store: NormalizedCache,
@@ -110,6 +117,7 @@ export function diffSelectionSetAgainstStore({
   throwOnMissingField: boolean,
   variables: Object,
   fragmentMap?: FragmentMap,
+  paginationArguments?: string[],
 }): DiffResult {
   if (selectionSet.kind !== 'SelectionSet') {
     throw new Error('Must be a selection set.');
@@ -146,6 +154,7 @@ export function diffSelectionSetAgainstStore({
           store,
           fragmentMap,
           included: includeField,
+          paginationArguments,
         });
 
       const resultFieldKey = resultKeyNameFromField(selection);
@@ -169,6 +178,7 @@ export function diffSelectionSetAgainstStore({
         rootId,
         store,
         fragmentMap,
+        paginationArguments,
       });
 
       if (fieldIsMissing) {
@@ -192,6 +202,7 @@ export function diffSelectionSetAgainstStore({
         rootId,
         store,
         fragmentMap,
+        paginationArguments,
       });
 
       if (fieldIsMissing) {
@@ -243,6 +254,7 @@ function diffFieldAgainstStore({
   store,
   fragmentMap,
   included = true,
+  paginationArguments = [],
 }: {
   field: Field,
   throwOnMissingField: boolean,
@@ -251,9 +263,10 @@ function diffFieldAgainstStore({
   store: NormalizedCache,
   fragmentMap?: FragmentMap,
   included?: Boolean,
+  paginationArguments?: string[],
 }): FieldDiffResult {
   const storeObj = store[rootId] || {};
-  const storeFieldKey = storeKeyNameFromField(field, variables);
+  const storeFieldKey = storeKeyNameFromField(field, variables, paginationArguments);
 
   if (! has(storeObj, storeFieldKey)) {
     if (throwOnMissingField && included) {
@@ -308,6 +321,7 @@ Perhaps you want to use the \`returnPartialData\` option?`);
         selectionSet: field.selectionSet,
         variables,
         fragmentMap,
+        paginationArguments,
       });
 
       if (itemDiffResult.isMissing) {

--- a/src/data/readFromStore.ts
+++ b/src/data/readFromStore.ts
@@ -26,11 +26,13 @@ export function readQueryFromStore({
   query,
   variables,
   returnPartialData,
+  paginationArguments = [],
 }: {
   store: NormalizedCache,
   query: Document,
   variables?: Object,
   returnPartialData?: boolean,
+  paginationArguments?: string[],
 }): Object {
   const queryDef = getQueryDefinition(query);
 
@@ -40,6 +42,7 @@ export function readQueryFromStore({
     selectionSet: queryDef.selectionSet,
     variables,
     returnPartialData,
+    paginationArguments,
   });
 }
 
@@ -49,12 +52,14 @@ export function readFragmentFromStore({
   rootId,
   variables,
   returnPartialData,
+  paginationArguments = [],
 }: {
   store: NormalizedCache,
   fragment: Document,
   rootId: string,
   variables?: Object,
   returnPartialData?: boolean,
+  paginationArguments?: string[],
 }): Object {
   const fragmentDef = getFragmentDefinition(fragment);
 
@@ -64,6 +69,7 @@ export function readFragmentFromStore({
     selectionSet: fragmentDef.selectionSet,
     variables,
     returnPartialData,
+    paginationArguments,
   });
 }
 
@@ -74,6 +80,7 @@ export function readSelectionSetFromStore({
   variables,
   returnPartialData = false,
   fragmentMap,
+  paginationArguments = [],
 }: {
   store: NormalizedCache,
   rootId: string,
@@ -81,6 +88,7 @@ export function readSelectionSetFromStore({
   variables: Object,
   returnPartialData?: boolean,
   fragmentMap?: FragmentMap,
+  paginationArguments?: string[],
 }): Object {
   const {
     result,
@@ -91,6 +99,7 @@ export function readSelectionSetFromStore({
     throwOnMissingField: !returnPartialData,
     variables,
     fragmentMap,
+    paginationArguments,
   });
 
   return result;

--- a/src/data/store.ts
+++ b/src/data/store.ts
@@ -101,6 +101,7 @@ export function data(
         store: clonedState,
         dataIdFromObject: config.dataIdFromObject,
         fragmentMap: queryStoreValue.fragmentMap,
+        paginationArguments: queryStoreValue.paginationArguments,
       });
 
       return newState;
@@ -121,6 +122,7 @@ export function data(
         store: clonedState,
         dataIdFromObject: config.dataIdFromObject,
         fragmentMap: queryStoreValue.fragmentMap,
+        paginationArguments: queryStoreValue.paginationArguments,
       });
 
       if (constAction.resultBehaviors) {

--- a/src/data/storeUtils.ts
+++ b/src/data/storeUtils.ts
@@ -12,6 +12,7 @@ import {
   Selection,
   GraphQLResult,
   Name,
+  Argument,
 } from 'graphql';
 
 import includes = require('lodash.includes');
@@ -104,4 +105,14 @@ export function isInlineFragment(selection: Selection): selection is InlineFragm
 
 export function graphQLResultHasError(result: GraphQLResult) {
   return result.errors && result.errors.length;
+}
+
+export function argsToKeyValueMap(graphQLArgs: Argument[], variables: Object): Object {
+  const args = {};
+
+  graphQLArgs.forEach(arg => {
+    valueToObjectRepresentation(args, arg.name, arg.value, variables);
+  });
+
+  return args;
 }

--- a/src/data/storeUtils.ts
+++ b/src/data/storeUtils.ts
@@ -70,11 +70,12 @@ function valueToObjectRepresentation(argObj: Object, name: Name, value: Value, v
   }
 }
 
-export function storeKeyNameFromField(field: Field, variables?: Object): string {
+export function storeKeyNameFromField(field: Field, variables?: Object, paginationArguments: string[] = []): string {
   if (field.arguments && field.arguments.length) {
     const argObj: Object = {};
 
-    field.arguments.forEach(({name, value}) => valueToObjectRepresentation(
+    field.arguments.filter(({name}) => paginationArguments.indexOf(name.value) < 0)
+    .forEach(({name, value}) => valueToObjectRepresentation(
       argObj, name, value, variables));
 
     return storeKeyNameFromFieldNameAndArgs(field.name.value, argObj);

--- a/src/data/writeToStore.ts
+++ b/src/data/writeToStore.ts
@@ -64,12 +64,14 @@ export function writeFragmentToStore({
   store = {} as NormalizedCache,
   variables,
   dataIdFromObject = null,
+  paginationArguments = [],
 }: {
   result: Object,
   fragment: Document,
   store?: NormalizedCache,
   variables?: Object,
   dataIdFromObject?: IdGetter,
+  paginationArguments?: string[],
 }): NormalizedCache {
   // Argument validation
   if (!fragment) {
@@ -90,6 +92,7 @@ export function writeFragmentToStore({
     store,
     variables,
     dataIdFromObject,
+    paginationArguments,
   });
 }
 
@@ -99,12 +102,14 @@ export function writeQueryToStore({
   store = {} as NormalizedCache,
   variables,
   dataIdFromObject = null,
+  paginationArguments = [],
 }: {
   result: Object,
   query: Document,
   store?: NormalizedCache,
   variables?: Object,
   dataIdFromObject?: IdGetter,
+  paginationArguments?: string[],
 }): NormalizedCache {
   const queryDefinition: OperationDefinition = getQueryDefinition(query);
 
@@ -115,6 +120,7 @@ export function writeQueryToStore({
     store,
     variables,
     dataIdFromObject,
+    paginationArguments,
   });
 }
 
@@ -126,6 +132,7 @@ export function writeSelectionSetToStore({
   variables,
   dataIdFromObject,
   fragmentMap,
+  paginationArguments = [],
 }: {
   dataId: string,
   result: any,
@@ -134,6 +141,7 @@ export function writeSelectionSetToStore({
   variables: Object,
   dataIdFromObject: IdGetter,
   fragmentMap?: FragmentMap,
+  paginationArguments?: string[],
 }): NormalizedCache {
 
   if (!fragmentMap) {
@@ -165,6 +173,7 @@ export function writeSelectionSetToStore({
           field: selection,
           dataIdFromObject,
           fragmentMap,
+          paginationArguments,
         });
       }
     } else if (isInlineFragment(selection)) {
@@ -177,6 +186,7 @@ export function writeSelectionSetToStore({
         dataId,
         dataIdFromObject,
         fragmentMap,
+        paginationArguments,
       });
     } else {
       //look up the fragment referred to in the selection
@@ -193,6 +203,7 @@ export function writeSelectionSetToStore({
         dataId,
         dataIdFromObject,
         fragmentMap,
+        paginationArguments,
       });
 
       //throw new Error('Non-inline fragments not supported.');
@@ -233,6 +244,7 @@ function writeFieldToStore({
   dataId,
   dataIdFromObject,
   fragmentMap,
+  paginationArguments = [],
 }: {
   field: Field,
   value: any,
@@ -241,10 +253,11 @@ function writeFieldToStore({
   dataId: string,
   dataIdFromObject: IdGetter,
   fragmentMap?: FragmentMap,
+  paginationArguments?: string[],
 }) {
   let storeValue;
 
-  const storeFieldName: string = storeKeyNameFromField(field, variables);
+  const storeFieldName: string = storeKeyNameFromField(field, variables, paginationArguments);
   // specifies if we need to merge existing keys in the store
   let shouldMerge = false;
   // If we merge, this will be the generatedKey
@@ -288,6 +301,7 @@ function writeFieldToStore({
           variables,
           dataIdFromObject,
           fragmentMap,
+          paginationArguments,
         });
       }
     });
@@ -329,6 +343,7 @@ function writeFieldToStore({
       variables,
       dataIdFromObject,
       fragmentMap,
+      paginationArguments,
     });
 
     // We take the id and escape it (i.e. wrap it with an enclosing object).

--- a/src/mutations/store.ts
+++ b/src/mutations/store.ts
@@ -27,6 +27,7 @@ export interface MutationStoreValue {
   loading: boolean;
   error: Error;
   fragmentMap: FragmentMap;
+  paginationArguments?: string[];
 }
 
 export interface SelectionSetWithRoot {
@@ -49,6 +50,7 @@ export function mutations(
       loading: true,
       error: null,
       fragmentMap: action.fragmentMap,
+      paginationArguments: action.paginationArguments,
     };
 
     return newState;

--- a/src/queries/directives.ts
+++ b/src/queries/directives.ts
@@ -11,6 +11,7 @@ import {
 
 import isEqual = require('lodash.isequal');
 import isBoolean = require('lodash.isboolean');
+import isString = require('lodash.isstring');
 
 function validateDirective(
   selection: Selection,
@@ -22,6 +23,12 @@ function validateDirective(
 
   if (directive.name.value === 'skip' || directive.name.value === 'include') {
     if (!isEqual(argKeys, ['if']) || !isBoolean(args['if'])) {
+      throw new Error(`Invalid arguments ${JSON.stringify(argKeys)} for the @${directive.name.value} directive.`);
+    }
+  }
+
+  if (directive.name.value === 'apolloFetchMore') {
+    if (!isEqual(argKeys, []) && (!isEqual(argKeys, ['name']) || !isString(args['name']))) {
       throw new Error(`Invalid arguments ${JSON.stringify(argKeys)} for the @${directive.name.value} directive.`);
     }
   }

--- a/src/queries/directives.ts
+++ b/src/queries/directives.ts
@@ -13,6 +13,10 @@ import {
 } from 'graphql';
 
 import {
+  Request,
+} from '../networkInterface';
+
+import {
   argsToKeyValueMap,
 } from '../data/storeUtils';
 
@@ -135,4 +139,10 @@ export function stripApolloDirectivesFromDocument(document: Document): Document 
   return assign({}, document, {
     definitions: document.definitions.map(stripApolloDirectivesFromDefinition),
   }) as Document;
+}
+
+export function stripApolloDirectivesFromRequest(request: Request): Request {
+  return assign({}, request, {
+    query: stripApolloDirectivesFromDocument(request.query),
+  }) as Request;
 }

--- a/src/queries/store.ts
+++ b/src/queries/store.ts
@@ -41,6 +41,7 @@ export interface QueryStoreValue {
   returnPartialData: boolean;
   lastRequestId: number;
   fragmentMap: FragmentMap;
+  paginationArguments?: string[];
 }
 
 export interface SelectionSetWithRoot {
@@ -72,6 +73,7 @@ export function queries(
       returnPartialData: action.returnPartialData,
       lastRequestId: action.requestId,
       fragmentMap: action.fragmentMap,
+      paginationArguments: action.paginationArguments,
     };
 
     return newState;

--- a/src/watchQueryOptions.ts
+++ b/src/watchQueryOptions.ts
@@ -11,4 +11,5 @@ export interface WatchQueryOptions {
   noFetch?: boolean;
   pollInterval?: number;
   fragments?: FragmentDefinition[];
+  paginationArguments?: string[];
 }

--- a/test/client.ts
+++ b/test/client.ts
@@ -347,6 +347,7 @@ describe('client', () => {
             fragmentMap: {},
             returnPartialData: false,
             lastRequestId: 1,
+            paginationArguments: undefined,
           },
         },
         mutations: {},

--- a/test/diffAgainstStore.ts
+++ b/test/diffAgainstStore.ts
@@ -219,6 +219,52 @@ describe('diffing queries against the store', () => {
     assert.deepEqual(store['1'], result.people_one);
   });
 
+  it('does not diffs root queries if IDs are paginationArguments', () => {
+    const firstQuery = gql`
+      {
+        people_one(id: "1") {
+          __typename,
+          id,
+          name
+        }
+      }
+    `;
+
+    const result = {
+      people_one: {
+        __typename: 'Person',
+        id: '1',
+        name: 'Luke Skywalker',
+      },
+    };
+
+    const store = writeQueryToStore({
+      result,
+      query: firstQuery,
+      dataIdFromObject: getIdField,
+      paginationArguments: ['id'],
+    });
+
+    const secondQuery = gql`
+      {
+        people_one(id: "2") {
+          __typename
+          id
+          name
+        }
+      }
+    `;
+
+    const { missingSelectionSets } = diffQueryAgainstStore({
+      store,
+      query: secondQuery,
+      paginationArguments: ['id'],
+    });
+
+    assert.isUndefined(missingSelectionSets);
+    assert.deepEqual(store['1'], result.people_one);
+  });
+
   it('works with inline fragments', () => {
     const firstQuery = gql`
       {

--- a/test/directives.ts
+++ b/test/directives.ts
@@ -3,8 +3,12 @@ const { assert } = chai;
 
 import {
   shouldInclude,
-  stripApolloDirectivesFromDocument,
+  stripApolloDirectivesTransformer,
 } from '../src/queries/directives';
+
+import {
+  applyTransformers,
+} from '../src/queries/queryTransform';
 
 import {
   getQueryDefinition,
@@ -187,7 +191,7 @@ describe('query directives', () => {
           fortuneCookie @apolloFetchMore
         }
       `;
-      const strippedDoc = stripApolloDirectivesFromDocument(doc);
+      const strippedDoc = applyTransformers(doc, [stripApolloDirectivesTransformer]);
       assert.notDeepEqual(doc, strippedDoc);
       assert.deepPropertyVal(strippedDoc,
         'definitions.0.selectionSet.selections.0.directives.length', 0);
@@ -201,7 +205,7 @@ describe('query directives', () => {
           }
         }
       `;
-      const strippedDoc = stripApolloDirectivesFromDocument(doc);
+      const strippedDoc = applyTransformers(doc, [stripApolloDirectivesTransformer]);
       assert.notDeepEqual(doc, strippedDoc);
       assert.deepPropertyVal(strippedDoc,
         'definitions.0.selectionSet.selections.0.selectionSet.selections.0.directives.length', 0);
@@ -215,7 +219,7 @@ describe('query directives', () => {
           }
         }
       `;
-      const strippedDoc = stripApolloDirectivesFromDocument(doc);
+      const strippedDoc = applyTransformers(doc, [stripApolloDirectivesTransformer]);
       assert.notDeepEqual(doc, strippedDoc);
       assert.deepPropertyVal(strippedDoc,
         'definitions.0.selectionSet.selections.0.directives.length', 0);
@@ -231,7 +235,7 @@ describe('query directives', () => {
           fortuneCookie
         }
       `;
-      const strippedDoc = stripApolloDirectivesFromDocument(doc);
+      const strippedDoc = applyTransformers(doc, [stripApolloDirectivesTransformer]);
       assert.notDeepEqual(doc, strippedDoc);
       assert.deepPropertyVal(strippedDoc,
         'definitions.0.selectionSet.selections.0.directives.length', 0);
@@ -247,7 +251,7 @@ describe('query directives', () => {
           fortuneCookie @apolloFetchMore
         }
       `;
-      const strippedDoc = stripApolloDirectivesFromDocument(doc);
+      const strippedDoc = applyTransformers(doc, [stripApolloDirectivesTransformer]);
       assert.notDeepEqual(doc, strippedDoc);
       assert.deepPropertyVal(strippedDoc,
         'definitions.1.selectionSet.selections.0.directives.length', 0);

--- a/test/directives.ts
+++ b/test/directives.ts
@@ -3,6 +3,7 @@ const { assert } = chai;
 
 import {
   shouldInclude,
+  stripApolloDirectivesFromDocument,
 } from '../src/queries/directives';
 
 import {
@@ -176,6 +177,80 @@ describe('query directives', () => {
     const field = getQueryDefinition(query).selectionSet.selections[0];
     assert.throws(() => {
       shouldInclude(field, {});
+    });
+  });
+
+  describe('stripping', () => {
+    it('should strip @apolloFetchMore from query fields', () => {
+      const doc = gql`
+        query {
+          fortuneCookie @apolloFetchMore
+        }
+      `;
+      const strippedDoc = stripApolloDirectivesFromDocument(doc);
+      assert.notDeepEqual(doc, strippedDoc);
+      assert.deepPropertyVal(strippedDoc,
+        'definitions.0.selectionSet.selections.0.directives.length', 0);
+    });
+
+    it('should strip nested @apolloFetchMore from query fields', () => {
+      const doc = gql`
+        query {
+          test {
+            fortuneCookie @apolloFetchMore
+          }
+        }
+      `;
+      const strippedDoc = stripApolloDirectivesFromDocument(doc);
+      assert.notDeepEqual(doc, strippedDoc);
+      assert.deepPropertyVal(strippedDoc,
+        'definitions.0.selectionSet.selections.0.selectionSet.selections.0.directives.length', 0);
+    });
+
+    it('should strip @apolloFetchMore from inline fragments', () => {
+      const doc = gql`
+        query {
+          ... on Cookie @apolloFetchMore {
+            fortuneCookie
+          }
+        }
+      `;
+      const strippedDoc = stripApolloDirectivesFromDocument(doc);
+      assert.notDeepEqual(doc, strippedDoc);
+      assert.deepPropertyVal(strippedDoc,
+        'definitions.0.selectionSet.selections.0.directives.length', 0);
+    });
+
+    it('should strip @apolloFetchMore from fragment spreads', () => {
+      const doc = gql`
+        query {
+          ...cookieSpread @apolloFetchMore
+        }
+
+        fragment cookieSpread on Cookie {
+          fortuneCookie
+        }
+      `;
+      const strippedDoc = stripApolloDirectivesFromDocument(doc);
+      assert.notDeepEqual(doc, strippedDoc);
+      assert.deepPropertyVal(strippedDoc,
+        'definitions.0.selectionSet.selections.0.directives.length', 0);
+    });
+
+    it('should strip @apolloFetchMore in named fragments', () => {
+      const doc = gql`
+        query {
+          ...cookieSpread
+        }
+
+        fragment cookieSpread on Cookie {
+          fortuneCookie @apolloFetchMore
+        }
+      `;
+      const strippedDoc = stripApolloDirectivesFromDocument(doc);
+      assert.notDeepEqual(doc, strippedDoc);
+      assert.deepPropertyVal(strippedDoc,
+        'definitions.1.selectionSet.selections.0.directives.length', 0);
     });
   });
 });

--- a/test/readFromStore.ts
+++ b/test/readFromStore.ts
@@ -106,6 +106,48 @@ describe('reading from the store', () => {
     });
   });
 
+  it('runs a basic fragment with arguments and paginationArguments', () => {
+    const fragment = gql`
+      fragment Item on ItemType {
+        id,
+        stringField(arg: $stringArg, cur: $cur),
+        numberField(intArg: $intArg, floatArg: $floatArg, cur: $cur),
+        nullField
+      }
+    `;
+
+    const variables = {
+      intArg: 5,
+      floatArg: 3.14,
+      stringArg: 'This is a string!',
+      cur: 1,
+    };
+
+    const store = {
+      abcd: {
+        id: 'abcd',
+        nullField: null,
+        'numberField({"intArg":5,"floatArg":3.14})': 5,
+        'stringField({"arg":"This is a string!"})': 'Heyo',
+      },
+    } as NormalizedCache;
+
+    const result = readFragmentFromStore({
+      store,
+      fragment,
+      variables,
+      rootId: 'abcd',
+      paginationArguments: ['cur'],
+    });
+
+    assert.deepEqual(result, {
+      id: 'abcd',
+      nullField: null,
+      numberField: 5,
+      stringField: 'Heyo',
+    });
+  });
+
   it('runs a nested fragment', () => {
     const result = {
       id: 'abcd',

--- a/test/storeUtils.ts
+++ b/test/storeUtils.ts
@@ -1,0 +1,90 @@
+import { assert } from 'chai';
+import {
+  Field,
+} from 'graphql';
+import {
+  storeKeyNameFromField,
+} from '../src/data/storeUtils';
+
+describe('storeUtils', () => {
+  describe('storeKeyNameFromField', () => {
+    it('generates a simple key with the name without args', () => {
+      const simpleField: Field = {
+        kind: 'Field',
+        name: {
+          kind: 'Name',
+          value: 'fortuneCookie',
+        },
+      };
+      const key = storeKeyNameFromField(simpleField);
+      assert.equal(key, 'fortuneCookie');
+    });
+
+    it('generates a key with some args', () => {
+      const simpleField: Field = {
+        kind: 'Field',
+        name: { kind: 'Name', value: 'fortuneCookie' },
+        arguments: [
+          {
+            kind: 'Argument',
+            name: { kind: 'Name', value: 'type' },
+            value: { kind: 'StringValue', value: 'fortune' },
+          },
+          {
+            kind: 'Argument',
+            name: { kind: 'Name', value: 'cursor' },
+            value: { kind: 'IntValue', value: '1' },
+          },
+        ],
+      };
+      const key = storeKeyNameFromField(simpleField);
+      assert.equal(key, 'fortuneCookie({"type":"fortune","cursor":1})');
+    });
+
+    it('generates a key with some args from variables', () => {
+      const simpleField: Field = {
+        kind: 'Field',
+        name: { kind: 'Name', value: 'fortuneCookie' },
+        arguments: [
+          {
+            kind: 'Argument',
+            name: { kind: 'Name', value: 'type' },
+            value: { kind: 'StringValue', value: 'fortune' },
+          },
+          {
+            kind: 'Argument',
+            name: { kind: 'Name', value: 'cursor' },
+            value: { kind: 'Variable', name: {kind: 'Name', value: 'cursor'} },
+          },
+        ],
+      };
+      const variablesMap = {
+        cursor: 1,
+      };
+      const key = storeKeyNameFromField(simpleField, variablesMap);
+      assert.equal(key, 'fortuneCookie({"type":"fortune","cursor":1})');
+    });
+
+    it('generates a key with some args as paginationArguments', () => {
+      const simpleField: Field = {
+        kind: 'Field',
+        name: { kind: 'Name', value: 'fortuneCookie' },
+        arguments: [
+          {
+            kind: 'Argument',
+            name: { kind: 'Name', value: 'type' },
+            value: { kind: 'StringValue', value: 'fortune' },
+          },
+          {
+            kind: 'Argument',
+            name: { kind: 'Name', value: 'cursor' },
+            value: { kind: 'IntValue', value: '1' },
+          },
+        ],
+      };
+      const paginationArgs = ['cursor'];
+      const key = storeKeyNameFromField(simpleField, {}, paginationArgs);
+      assert.equal(key, 'fortuneCookie({"type":"fortune"})');
+    });
+  });
+});

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -26,3 +26,4 @@ import './mutationResults';
 import './optimistic';
 import './scopeQuery';
 import './errors';
+import './storeUtils'


### PR DESCRIPTION
**IMPORTANT**: This PR is rebased on top of #374. Be careful syncing things correctly and **not** merge this one until #374 is done!

So the first commit of this PR is 147173e.

### Goal

Silence all fields marked as paginationArguments

### Internal TODO

- [x] write to store can ignore writing `paginationArguments` in keys
- [x] diff to store can ignore diffing on `paginationArguments` in keys
- [x] read from store can ignore reading with `paginationArguments` in keys
- [ ] query defines `paginationArguments`

### Pre-review TODO

- [ ] Update CHANGELOG.md with your change
- [x] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
