### PR TITLE
Pagination arguments support (silenced arguments)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Expect active development and potentially significant breaking changes in the `0
 
 ### vNEXT
 
+- Add `paginationArguments` to the query options in order to control the way keys are written in the normalized store for the upcoming pagination system. This `paginationArguments` sytsem spans to the whole normalized store management system.
+
 ### v0.4.8
 
 - Add `useAfter` function that accepts `afterwares`. Afterwares run after a request is made (after middlewares). In the afterware function, you get the whole response and request options, so you can handle status codes and errors if you need to. For example, if your requests return a `401` in the case of user logout, you can use this to identify when that starts happening. It can be used just as a `middleware` is used. Just pass an array of afterwares to the `useAfter` function.

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -187,6 +187,7 @@ export class QueryManager {
     fragments = [],
     optimisticResponse,
     updateQueries,
+    paginationArguments = [],
   }: {
     mutation: Document,
     variables?: Object,
@@ -194,6 +195,7 @@ export class QueryManager {
     fragments?: FragmentDefinition[],
     optimisticResponse?: Object,
     updateQueries?: MutationQueryReducersMap,
+    paginationArguments?: string[],
   }): Promise<ApolloQueryResult> {
     const mutationId = this.generateQueryId();
 
@@ -220,7 +222,7 @@ export class QueryManager {
     // In the future we want to re-factor this part of code to avoid using
     // `resultBehaviors` so we can remove `resultBehaviors` entirely.
     const updateQueriesResultBehaviors = !optimisticResponse ? [] :
-      this.collectResultBehaviorsFromUpdateQueries(updateQueries, { data: optimisticResponse }, true);
+      this.collectResultBehaviorsFromUpdateQueries(updateQueries, { data: optimisticResponse }, true, paginationArguments);
 
     this.store.dispatch({
       type: 'APOLLO_MUTATION_INIT',
@@ -235,6 +237,7 @@ export class QueryManager {
       fragmentMap: queryFragmentMap,
       optimisticResponse,
       resultBehaviors: [...resultBehaviors, ...updateQueriesResultBehaviors],
+      paginationArguments,
     });
 
     return new Promise((resolve, reject) => {
@@ -312,6 +315,7 @@ export class QueryManager {
                 variables: queryStoreValue.variables,
                 returnPartialData: options.returnPartialData || options.noFetch,
                 fragmentMap: queryStoreValue.fragmentMap,
+                paginationArguments: options.paginationArguments,
               }),
             };
 
@@ -498,7 +502,8 @@ export class QueryManager {
   private collectResultBehaviorsFromUpdateQueries(
     updateQueries: MutationQueryReducersMap,
     mutationResult: Object,
-    isOptimistic = false
+    isOptimistic = false,
+    paginationArguments: string[] = []
   ): MutationBehavior[] {
     if (!updateQueries) {
       return [];
@@ -554,6 +559,7 @@ export class QueryManager {
           variables: queryOptions.variables,
           returnPartialData: queryOptions.returnPartialData || queryOptions.noFetch,
           fragmentMap: createFragmentMap(fragments || []),
+          paginationArguments,
         });
 
         resultBehaviors.push({
@@ -624,6 +630,7 @@ export class QueryManager {
         rootId: querySS.id,
         variables,
         fragmentMap: queryFragmentMap,
+        paginationArguments: options.paginationArguments,
       });
 
       initialResult = result;
@@ -667,6 +674,7 @@ export class QueryManager {
       queryId,
       requestId,
       fragmentMap: queryFragmentMap,
+      paginationArguments: options.paginationArguments,
     });
 
     if (! minimizedQuery || returnPartialData || noFetch) {
@@ -724,6 +732,7 @@ export class QueryManager {
                 variables,
                 returnPartialData: returnPartialData || noFetch,
                 fragmentMap: queryFragmentMap,
+                paginationArguments: options.paginationArguments,
               });
               // ensure multiple errors don't get thrown
               /* tslint:disable */

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -46,6 +46,7 @@ export interface QueryInitAction {
   queryId: string;
   requestId: number;
   fragmentMap: FragmentMap;
+  paginationArguments?: string[];
 }
 
 export function isQueryInitAction(action: ApolloAction): action is QueryInitAction {
@@ -81,6 +82,7 @@ export interface MutationInitAction {
   fragmentMap: FragmentMap;
   optimisticResponse: Object;
   resultBehaviors?: MutationBehavior[];
+  paginationArguments?: string[];
 }
 
 export function isMutationInitAction(action: ApolloAction): action is MutationInitAction {

--- a/src/data/diffAgainstStore.ts
+++ b/src/data/diffAgainstStore.ts
@@ -51,10 +51,12 @@ export function diffQueryAgainstStore({
   store,
   query,
   variables,
+  paginationArguments = [],
 }: {
   store: NormalizedCache,
   query: Document,
   variables?: Object,
+  paginationArguments?: string[],
 }): DiffResult {
   const queryDef = getQueryDefinition(query);
 
@@ -64,6 +66,7 @@ export function diffQueryAgainstStore({
     selectionSet: queryDef.selectionSet,
     throwOnMissingField: false,
     variables,
+    paginationArguments,
   });
 }
 
@@ -72,11 +75,13 @@ export function diffFragmentAgainstStore({
   fragment,
   rootId,
   variables,
+  paginationArguments = [],
 }: {
   store: NormalizedCache,
   fragment: Document,
   rootId: string,
   variables?: Object,
+  paginationArguments?: string[],
 }): DiffResult {
   const fragmentDef = getFragmentDefinition(fragment);
 
@@ -86,6 +91,7 @@ export function diffFragmentAgainstStore({
     selectionSet: fragmentDef.selectionSet,
     throwOnMissingField: false,
     variables,
+    paginationArguments,
   });
 }
 
@@ -127,6 +133,7 @@ export function diffSelectionSetAgainstStore({
   throwOnMissingField = false,
   variables,
   fragmentMap,
+  paginationArguments = [],
 }: {
   selectionSet: SelectionSet,
   store: NormalizedCache,
@@ -134,6 +141,7 @@ export function diffSelectionSetAgainstStore({
   throwOnMissingField: boolean,
   variables: Object,
   fragmentMap?: FragmentMap,
+  paginationArguments?: string[],
 }): DiffResult {
   if (selectionSet.kind !== 'SelectionSet') {
     throw new Error('Must be a selection set.');
@@ -179,6 +187,7 @@ export function diffSelectionSetAgainstStore({
         store,
         fragmentMap,
         included,
+        paginationArguments,
       });
       fieldIsMissing = diffResult.isMissing;
       fieldResult = diffResult.result;
@@ -205,6 +214,7 @@ export function diffSelectionSetAgainstStore({
             rootId,
             store,
             fragmentMap,
+            paginationArguments,
           });
           fieldIsMissing = diffResult.isMissing;
           fieldResult = diffResult.result;
@@ -244,6 +254,7 @@ export function diffSelectionSetAgainstStore({
             rootId,
             store,
             fragmentMap,
+            paginationArguments,
           });
           fieldIsMissing = diffResult.isMissing;
           fieldResult = diffResult.result;
@@ -313,6 +324,7 @@ function diffFieldAgainstStore({
   store,
   fragmentMap,
   included = true,
+  paginationArguments = [],
 }: {
   field: Field,
   throwOnMissingField: boolean,
@@ -321,9 +333,10 @@ function diffFieldAgainstStore({
   store: NormalizedCache,
   fragmentMap?: FragmentMap,
   included?: Boolean,
+  paginationArguments?: string[],
 }): FieldDiffResult {
   const storeObj = store[rootId] || {};
-  const storeFieldKey = storeKeyNameFromField(field, variables);
+  const storeFieldKey = storeKeyNameFromField(field, variables, paginationArguments);
 
   if (! has(storeObj, storeFieldKey)) {
     if (throwOnMissingField && included) {
@@ -383,6 +396,7 @@ Perhaps you want to use the \`returnPartialData\` option?`,
         selectionSet: field.selectionSet,
         variables,
         fragmentMap,
+        paginationArguments,
       });
 
       if (itemDiffResult.isMissing) {

--- a/src/data/diffAgainstStore.ts
+++ b/src/data/diffAgainstStore.ts
@@ -424,6 +424,7 @@ Perhaps you want to use the \`returnPartialData\` option?`,
       selectionSet: field.selectionSet,
       variables,
       fragmentMap,
+      paginationArguments,
     });
   }
 

--- a/src/data/readFromStore.ts
+++ b/src/data/readFromStore.ts
@@ -27,12 +27,14 @@ export function readQueryFromStore({
   variables,
   returnPartialData,
   fragmentMap,
+  paginationArguments = [],
 }: {
   store: NormalizedCache,
   query: Document,
   variables?: Object,
   returnPartialData?: boolean,
   fragmentMap?: FragmentMap,
+  paginationArguments?: string[],
 }): Object {
   const queryDef = getQueryDefinition(query);
 
@@ -43,6 +45,7 @@ export function readQueryFromStore({
     variables,
     returnPartialData,
     fragmentMap,
+    paginationArguments,
   });
 }
 
@@ -52,12 +55,14 @@ export function readFragmentFromStore({
   rootId,
   variables,
   returnPartialData,
+  paginationArguments = [],
 }: {
   store: NormalizedCache,
   fragment: Document,
   rootId: string,
   variables?: Object,
   returnPartialData?: boolean,
+  paginationArguments?: string[],
 }): Object {
   const fragmentDef = getFragmentDefinition(fragment);
 
@@ -67,6 +72,7 @@ export function readFragmentFromStore({
     selectionSet: fragmentDef.selectionSet,
     variables,
     returnPartialData,
+    paginationArguments,
   });
 }
 
@@ -77,6 +83,7 @@ export function readSelectionSetFromStore({
   variables,
   returnPartialData = false,
   fragmentMap,
+  paginationArguments = [],
 }: {
   store: NormalizedCache,
   rootId: string,
@@ -84,6 +91,7 @@ export function readSelectionSetFromStore({
   variables: Object,
   returnPartialData?: boolean,
   fragmentMap?: FragmentMap,
+  paginationArguments?: string[],
 }): Object {
   const {
     result,
@@ -94,6 +102,7 @@ export function readSelectionSetFromStore({
     throwOnMissingField: !returnPartialData,
     variables,
     fragmentMap,
+    paginationArguments,
   });
 
   return result;

--- a/src/data/store.ts
+++ b/src/data/store.ts
@@ -101,6 +101,7 @@ export function data(
         store: clonedState,
         dataIdFromObject: config.dataIdFromObject,
         fragmentMap: queryStoreValue.fragmentMap,
+        paginationArguments: queryStoreValue.paginationArguments,
       });
 
       return newState;
@@ -121,6 +122,7 @@ export function data(
         store: clonedState,
         dataIdFromObject: config.dataIdFromObject,
         fragmentMap: queryStoreValue.fragmentMap,
+        paginationArguments: queryStoreValue.paginationArguments,
       });
 
       if (constAction.resultBehaviors) {

--- a/src/data/storeUtils.ts
+++ b/src/data/storeUtils.ts
@@ -69,11 +69,12 @@ function valueToObjectRepresentation(argObj: Object, name: Name, value: Value, v
   }
 }
 
-export function storeKeyNameFromField(field: Field, variables?: Object): string {
+export function storeKeyNameFromField(field: Field, variables?: Object, paginationArguments: string[] = []): string {
   if (field.arguments && field.arguments.length) {
     const argObj: Object = {};
 
-    field.arguments.forEach(({name, value}) => valueToObjectRepresentation(
+    field.arguments.filter(({name}) => paginationArguments.indexOf(name.value) < 0)
+    .forEach(({name, value}) => valueToObjectRepresentation(
       argObj, name, value, variables));
 
     return storeKeyNameFromFieldNameAndArgs(field.name.value, argObj);

--- a/src/data/writeToStore.ts
+++ b/src/data/writeToStore.ts
@@ -68,12 +68,14 @@ export function writeFragmentToStore({
   store = {} as NormalizedCache,
   variables,
   dataIdFromObject = null,
+  paginationArguments = [],
 }: {
   result: Object,
   fragment: Document,
   store?: NormalizedCache,
   variables?: Object,
   dataIdFromObject?: IdGetter,
+  paginationArguments?: string[],
 }): NormalizedCache {
   // Argument validation
   if (!fragment) {
@@ -94,6 +96,7 @@ export function writeFragmentToStore({
     store,
     variables,
     dataIdFromObject,
+    paginationArguments,
   });
 }
 
@@ -104,6 +107,7 @@ export function writeQueryToStore({
   variables,
   dataIdFromObject = null,
   fragmentMap,
+  paginationArguments = [],
 }: {
   result: Object,
   query: Document,
@@ -111,6 +115,7 @@ export function writeQueryToStore({
   variables?: Object,
   dataIdFromObject?: IdGetter,
   fragmentMap?: FragmentMap,
+  paginationArguments?: string[],
 }): NormalizedCache {
   const queryDefinition: OperationDefinition = getQueryDefinition(query);
 
@@ -122,6 +127,7 @@ export function writeQueryToStore({
     variables,
     dataIdFromObject,
     fragmentMap,
+    paginationArguments,
   });
 }
 
@@ -133,6 +139,7 @@ export function writeSelectionSetToStore({
   variables,
   dataIdFromObject,
   fragmentMap,
+  paginationArguments = [],
 }: {
   dataId: string,
   result: any,
@@ -141,6 +148,7 @@ export function writeSelectionSetToStore({
   variables: Object,
   dataIdFromObject: IdGetter,
   fragmentMap?: FragmentMap,
+  paginationArguments?: string[],
 }): NormalizedCache {
 
   if (!fragmentMap) {
@@ -189,6 +197,7 @@ export function writeSelectionSetToStore({
           field: selection,
           dataIdFromObject,
           fragmentMap,
+          paginationArguments,
         });
       }
     } else if (isInlineFragment(selection)) {
@@ -205,6 +214,7 @@ export function writeSelectionSetToStore({
             dataId,
             dataIdFromObject,
             fragmentMap,
+            paginationArguments,
           });
 
           if (!fragmentErrors[typename]) {
@@ -238,6 +248,7 @@ export function writeSelectionSetToStore({
             dataId,
             dataIdFromObject,
             fragmentMap,
+            paginationArguments,
           });
 
           if (!fragmentErrors[typename]) {
@@ -291,6 +302,7 @@ function writeFieldToStore({
   dataId,
   dataIdFromObject,
   fragmentMap,
+  paginationArguments = [],
 }: {
   field: Field,
   value: any,
@@ -299,10 +311,11 @@ function writeFieldToStore({
   dataId: string,
   dataIdFromObject: IdGetter,
   fragmentMap?: FragmentMap,
+  paginationArguments?: string[],
 }) {
   let storeValue;
 
-  const storeFieldName: string = storeKeyNameFromField(field, variables);
+  const storeFieldName: string = storeKeyNameFromField(field, variables, paginationArguments);
   // specifies if we need to merge existing keys in the store
   let shouldMerge = false;
   // If we merge, this will be the generatedKey
@@ -346,6 +359,7 @@ function writeFieldToStore({
           variables,
           dataIdFromObject,
           fragmentMap,
+          paginationArguments,
         });
       }
     });
@@ -387,6 +401,7 @@ function writeFieldToStore({
       variables,
       dataIdFromObject,
       fragmentMap,
+      paginationArguments,
     });
 
     // We take the id and escape it (i.e. wrap it with an enclosing object).

--- a/src/mutations/store.ts
+++ b/src/mutations/store.ts
@@ -27,6 +27,7 @@ export interface MutationStoreValue {
   loading: boolean;
   error: Error;
   fragmentMap: FragmentMap;
+  paginationArguments?: string[];
 }
 
 export interface SelectionSetWithRoot {
@@ -49,6 +50,7 @@ export function mutations(
       loading: true,
       error: null,
       fragmentMap: action.fragmentMap,
+      paginationArguments: action.paginationArguments,
     };
 
     return newState;

--- a/src/queries/store.ts
+++ b/src/queries/store.ts
@@ -41,6 +41,7 @@ export interface QueryStoreValue {
   returnPartialData: boolean;
   lastRequestId: number;
   fragmentMap: FragmentMap;
+  paginationArguments?: string[];
 }
 
 export interface SelectionSetWithRoot {
@@ -72,6 +73,7 @@ export function queries(
       returnPartialData: action.returnPartialData,
       lastRequestId: action.requestId,
       fragmentMap: action.fragmentMap,
+      paginationArguments: action.paginationArguments,
     };
 
     return newState;

--- a/src/watchQueryOptions.ts
+++ b/src/watchQueryOptions.ts
@@ -11,4 +11,5 @@ export interface WatchQueryOptions {
   noFetch?: boolean;
   pollInterval?: number;
   fragments?: FragmentDefinition[];
+  paginationArguments?: string[];
 }

--- a/test/client.ts
+++ b/test/client.ts
@@ -347,6 +347,7 @@ describe('client', () => {
             fragmentMap: {},
             returnPartialData: false,
             lastRequestId: 1,
+            paginationArguments: undefined,
           },
         },
         mutations: {},

--- a/test/diffAgainstStore.ts
+++ b/test/diffAgainstStore.ts
@@ -223,6 +223,52 @@ describe('diffing queries against the store', () => {
     assert.deepEqual(store['1'], result.people_one);
   });
 
+  it('does not diffs root queries if IDs are paginationArguments', () => {
+    const firstQuery = gql`
+      {
+        people_one(id: "1") {
+          __typename,
+          id,
+          name
+        }
+      }
+    `;
+
+    const result = {
+      people_one: {
+        __typename: 'Person',
+        id: '1',
+        name: 'Luke Skywalker',
+      },
+    };
+
+    const store = writeQueryToStore({
+      result,
+      query: firstQuery,
+      dataIdFromObject: getIdField,
+      paginationArguments: ['id'],
+    });
+
+    const secondQuery = gql`
+      {
+        people_one(id: "2") {
+          __typename
+          id
+          name
+        }
+      }
+    `;
+
+    const { missingSelectionSets } = diffQueryAgainstStore({
+      store,
+      query: secondQuery,
+      paginationArguments: ['id'],
+    });
+
+    assert.isUndefined(missingSelectionSets);
+    assert.deepEqual(store['1'], result.people_one);
+  });
+
   it('works with inline fragments', () => {
     const firstQuery = gql`
       {

--- a/test/readFromStore.ts
+++ b/test/readFromStore.ts
@@ -106,6 +106,48 @@ describe('reading from the store', () => {
     });
   });
 
+  it('runs a basic fragment with arguments and paginationArguments', () => {
+    const fragment = gql`
+      fragment Item on ItemType {
+        id,
+        stringField(arg: $stringArg, cur: $cur),
+        numberField(intArg: $intArg, floatArg: $floatArg, cur: $cur),
+        nullField
+      }
+    `;
+
+    const variables = {
+      intArg: 5,
+      floatArg: 3.14,
+      stringArg: 'This is a string!',
+      cur: 1,
+    };
+
+    const store = {
+      abcd: {
+        id: 'abcd',
+        nullField: null,
+        'numberField({"intArg":5,"floatArg":3.14})': 5,
+        'stringField({"arg":"This is a string!"})': 'Heyo',
+      },
+    } as NormalizedCache;
+
+    const result = readFragmentFromStore({
+      store,
+      fragment,
+      variables,
+      rootId: 'abcd',
+      paginationArguments: ['cur'],
+    });
+
+    assert.deepEqual(result, {
+      id: 'abcd',
+      nullField: null,
+      numberField: 5,
+      stringField: 'Heyo',
+    });
+  });
+
   it('runs a nested fragment', () => {
     const result = {
       id: 'abcd',

--- a/test/storeUtils.ts
+++ b/test/storeUtils.ts
@@ -1,0 +1,90 @@
+import { assert } from 'chai';
+import {
+  Field,
+} from 'graphql';
+import {
+  storeKeyNameFromField,
+} from '../src/data/storeUtils';
+
+describe('storeUtils', () => {
+  describe('storeKeyNameFromField', () => {
+    it('generates a simple key with the name without args', () => {
+      const simpleField: Field = {
+        kind: 'Field',
+        name: {
+          kind: 'Name',
+          value: 'fortuneCookie',
+        },
+      };
+      const key = storeKeyNameFromField(simpleField);
+      assert.equal(key, 'fortuneCookie');
+    });
+
+    it('generates a key with some args', () => {
+      const simpleField: Field = {
+        kind: 'Field',
+        name: { kind: 'Name', value: 'fortuneCookie' },
+        arguments: [
+          {
+            kind: 'Argument',
+            name: { kind: 'Name', value: 'type' },
+            value: { kind: 'StringValue', value: 'fortune' },
+          },
+          {
+            kind: 'Argument',
+            name: { kind: 'Name', value: 'cursor' },
+            value: { kind: 'IntValue', value: '1' },
+          },
+        ],
+      };
+      const key = storeKeyNameFromField(simpleField);
+      assert.equal(key, 'fortuneCookie({"type":"fortune","cursor":1})');
+    });
+
+    it('generates a key with some args from variables', () => {
+      const simpleField: Field = {
+        kind: 'Field',
+        name: { kind: 'Name', value: 'fortuneCookie' },
+        arguments: [
+          {
+            kind: 'Argument',
+            name: { kind: 'Name', value: 'type' },
+            value: { kind: 'StringValue', value: 'fortune' },
+          },
+          {
+            kind: 'Argument',
+            name: { kind: 'Name', value: 'cursor' },
+            value: { kind: 'Variable', name: {kind: 'Name', value: 'cursor'} },
+          },
+        ],
+      };
+      const variablesMap = {
+        cursor: 1,
+      };
+      const key = storeKeyNameFromField(simpleField, variablesMap);
+      assert.equal(key, 'fortuneCookie({"type":"fortune","cursor":1})');
+    });
+
+    it('generates a key with some args as paginationArguments', () => {
+      const simpleField: Field = {
+        kind: 'Field',
+        name: { kind: 'Name', value: 'fortuneCookie' },
+        arguments: [
+          {
+            kind: 'Argument',
+            name: { kind: 'Name', value: 'type' },
+            value: { kind: 'StringValue', value: 'fortune' },
+          },
+          {
+            kind: 'Argument',
+            name: { kind: 'Name', value: 'cursor' },
+            value: { kind: 'IntValue', value: '1' },
+          },
+        ],
+      };
+      const paginationArgs = ['cursor'];
+      const key = storeKeyNameFromField(simpleField, {}, paginationArgs);
+      assert.equal(key, 'fortuneCookie({"type":"fortune"})');
+    });
+  });
+});

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -26,3 +26,4 @@ import './mutationResults';
 import './optimistic';
 import './scopeQuery';
 import './errors';
+import './storeUtils'


### PR DESCRIPTION
### Goal

Silence all fields marked as paginationArguments

This PR is a partial refactor of the work started in #350

### Internal TODO

- [x] write to store can ignore writing `paginationArguments` in keys
- [x] diff to store can ignore diffing on `paginationArguments` in keys
- [x] read from store can ignore reading with `paginationArguments` in keys
- [x] query defines `paginationArguments`
- [x] some more tests

### Pre-review TODO

- [x] Update CHANGELOG.md with your change
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
