### PR TITLE
[Waiting for #374] Add fetchMore method to the observable query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Expect active development and potentially significant breaking changes in the `0
 
 ### vNEXT
 
+- Basic infinite pagination support via the `fetchMore` method and the `@apolloFetchMore` directive. By naming an array field with the directive and by calling the method with this name, you can complete the array with new retrieved data. If an element with the same ID field is re-added, the last value will be kept.
+
 ### v0.4.8
 
 - Add `useAfter` function that accepts `afterwares`. Afterwares run after a request is made (after middlewares). In the afterware function, you get the whole response and request options, so you can handle status codes and errors if you need to. For example, if your requests return a `401` in the case of user logout, you can use this to identify when that starts happening. It can be used just as a `middleware` is used. Just pass an array of afterwares to the `useAfter` function.

--- a/src/ObservableQuery.ts
+++ b/src/ObservableQuery.ts
@@ -18,6 +18,7 @@ import assign = require('lodash.assign');
 
 export class ObservableQuery extends Observable<ApolloQueryResult> {
   public refetch: (variables?: any) => Promise<ApolloQueryResult>;
+  public fetchMore: (fetchMoreLocations: string[], variables?: any) => Promise<ApolloQueryResult>;
   public stopPolling: () => void;
   public startPolling: (p: number) => void;
   public options: WatchQueryOptions;
@@ -86,6 +87,17 @@ export class ObservableQuery extends Observable<ApolloQueryResult> {
       // Use the same options as before, but with new variables and forceFetch true
       return this.queryManager.fetchQuery(this.queryId, assign(this.options, {
         forceFetch: true,
+        variables,
+      }) as WatchQueryOptions);
+    };
+
+    this.fetchMore = (fetchMoreLocations: string[], variables?: any) => {
+      if (options.pollInterval) {
+        throw new Error('fetchMore is incompatible with polling.');
+      }
+      return this.queryManager.fetchQuery(this.queryId, assign(this.options, {
+        forceFetch: true,
+        fetchMoreLocations,
         variables,
       }) as WatchQueryOptions);
     };

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -671,6 +671,7 @@ export class QueryManager {
       queryId,
       requestId,
       fragmentMap: queryFragmentMap,
+      fetchMoreLocations: options.fetchMoreLocations,
     });
 
     if (! minimizedQuery || returnPartialData || noFetch) {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -46,6 +46,7 @@ export interface QueryInitAction {
   queryId: string;
   requestId: number;
   fragmentMap: FragmentMap;
+  fetchMoreLocations: string[];
 }
 
 export function isQueryInitAction(action: ApolloAction): action is QueryInitAction {

--- a/src/data/diffAgainstStore.ts
+++ b/src/data/diffAgainstStore.ts
@@ -305,7 +305,7 @@ export function diffSelectionSetAgainstStore({
   };
 }
 
-function diffFieldAgainstStore({
+export function diffFieldAgainstStore({
   field,
   throwOnMissingField,
   variables,
@@ -416,7 +416,7 @@ Perhaps you want to use the \`returnPartialData\` option?`,
   throw new Error('Unexpected value in the store where the query had a subselection.');
 }
 
-interface FieldDiffResult {
+export interface FieldDiffResult {
   result?: any;
   isMissing?: 'true';
 }

--- a/src/data/store.ts
+++ b/src/data/store.ts
@@ -101,6 +101,7 @@ export function data(
         store: clonedState,
         dataIdFromObject: config.dataIdFromObject,
         fragmentMap: queryStoreValue.fragmentMap,
+        fetchMoreLocations: queryStoreValue.fetchMoreLocations,
       });
 
       return newState;

--- a/src/data/writeToStore.ts
+++ b/src/data/writeToStore.ts
@@ -240,15 +240,6 @@ export function writeSelectionSetToStore({
       }
 
       const typename = fragment.typeCondition.name.value;
-        result,
-        selectionSet: fragment.selectionSet,
-        store,
-        variables,
-        dataId,
-        dataIdFromObject,
-        fragmentMap,
-        fetchMoreLocations,
-      });
 
       if (included) {
         try {
@@ -260,6 +251,7 @@ export function writeSelectionSetToStore({
             dataId,
             dataIdFromObject,
             fragmentMap,
+            fetchMoreLocations,
           });
 
           if (!fragmentErrors[typename]) {

--- a/src/data/writeToStore.ts
+++ b/src/data/writeToStore.ts
@@ -360,7 +360,7 @@ function writeFieldToStore({
         fragmentMap,
         included: true,
       });
-      value = [].concat(oldValue, value);
+      value = defaultListMerging(oldValue, value);
     }
 
     value.forEach((item, index) => {
@@ -474,4 +474,10 @@ function writeFieldToStore({
     store[dataId] = newStoreObj;
   }
 
+}
+
+function defaultListMerging(oldValues: any[], newValues: any[]): any[] {
+  const newIds = newValues.map(value => value.id ? value.id : null) .filter(id => id !== null);
+  const filteredOldValues = oldValues.filter(value => !value.id || newIds.indexOf(value.id) < 0);
+  return [].concat(filteredOldValues, newValues);
 }

--- a/src/data/writeToStore.ts
+++ b/src/data/writeToStore.ts
@@ -18,6 +18,10 @@ import {
 } from './storeUtils';
 
 import {
+  diffFieldAgainstStore,
+} from './diffAgainstStore';
+
+import {
   OperationDefinition,
   SelectionSet,
   FragmentDefinition,
@@ -42,6 +46,7 @@ import {
 
 import {
   shouldInclude,
+  getDirectiveArgs,
 } from '../queries/directives';
 
 import {
@@ -68,12 +73,14 @@ export function writeFragmentToStore({
   store = {} as NormalizedCache,
   variables,
   dataIdFromObject = null,
+  fetchMoreLocations = [],
 }: {
   result: Object,
   fragment: Document,
   store?: NormalizedCache,
   variables?: Object,
   dataIdFromObject?: IdGetter,
+  fetchMoreLocations?: string[],
 }): NormalizedCache {
   // Argument validation
   if (!fragment) {
@@ -94,6 +101,7 @@ export function writeFragmentToStore({
     store,
     variables,
     dataIdFromObject,
+    fetchMoreLocations,
   });
 }
 
@@ -104,6 +112,7 @@ export function writeQueryToStore({
   variables,
   dataIdFromObject = null,
   fragmentMap,
+  fetchMoreLocations = [],
 }: {
   result: Object,
   query: Document,
@@ -111,6 +120,7 @@ export function writeQueryToStore({
   variables?: Object,
   dataIdFromObject?: IdGetter,
   fragmentMap?: FragmentMap,
+  fetchMoreLocations?: string[],
 }): NormalizedCache {
   const queryDefinition: OperationDefinition = getQueryDefinition(query);
 
@@ -133,6 +143,7 @@ export function writeSelectionSetToStore({
   variables,
   dataIdFromObject,
   fragmentMap,
+  fetchMoreLocations = [],
 }: {
   dataId: string,
   result: any,
@@ -141,6 +152,7 @@ export function writeSelectionSetToStore({
   variables: Object,
   dataIdFromObject: IdGetter,
   fragmentMap?: FragmentMap,
+  fetchMoreLocations?: string[],
 }): NormalizedCache {
 
   if (!fragmentMap) {
@@ -189,6 +201,7 @@ export function writeSelectionSetToStore({
           field: selection,
           dataIdFromObject,
           fragmentMap,
+          fetchMoreLocations,
         });
       }
     } else if (isInlineFragment(selection)) {
@@ -227,6 +240,15 @@ export function writeSelectionSetToStore({
       }
 
       const typename = fragment.typeCondition.name.value;
+        result,
+        selectionSet: fragment.selectionSet,
+        store,
+        variables,
+        dataId,
+        dataIdFromObject,
+        fragmentMap,
+        fetchMoreLocations,
+      });
 
       if (included) {
         try {
@@ -291,6 +313,7 @@ function writeFieldToStore({
   dataId,
   dataIdFromObject,
   fragmentMap,
+  fetchMoreLocations = [],
 }: {
   field: Field,
   value: any,
@@ -299,6 +322,7 @@ function writeFieldToStore({
   dataId: string,
   dataIdFromObject: IdGetter,
   fragmentMap?: FragmentMap,
+  fetchMoreLocations?: string[],
 }) {
   let storeValue;
 
@@ -321,6 +345,23 @@ function writeFieldToStore({
   } else if (isArray(value)) {
     // this is an array with sub-objects
     const thisIdList: Array<string> = [];
+
+    const fetchMoreArgs = getDirectiveArgs(field, 'apolloFetchMore');
+    if (
+      fetchMoreArgs && fetchMoreArgs.name &&
+      fetchMoreLocations.indexOf(fetchMoreArgs.name) >= 0
+    ) {
+      const { result: oldValue = [] } = diffFieldAgainstStore({
+        field,
+        throwOnMissingField: false,
+        variables,
+        rootId: dataId,
+        store,
+        fragmentMap,
+        included: true,
+      });
+      value = [].concat(oldValue, value);
+    }
 
     value.forEach((item, index) => {
       if (isNull(item)) {
@@ -346,6 +387,7 @@ function writeFieldToStore({
           variables,
           dataIdFromObject,
           fragmentMap,
+          fetchMoreLocations,
         });
       }
     });
@@ -387,6 +429,7 @@ function writeFieldToStore({
       variables,
       dataIdFromObject,
       fragmentMap,
+      fetchMoreLocations,
     });
 
     // We take the id and escape it (i.e. wrap it with an enclosing object).

--- a/src/queries/store.ts
+++ b/src/queries/store.ts
@@ -41,6 +41,7 @@ export interface QueryStoreValue {
   returnPartialData: boolean;
   lastRequestId: number;
   fragmentMap: FragmentMap;
+  fetchMoreLocations: string[];
 }
 
 export interface SelectionSetWithRoot {
@@ -72,6 +73,7 @@ export function queries(
       returnPartialData: action.returnPartialData,
       lastRequestId: action.requestId,
       fragmentMap: action.fragmentMap,
+      fetchMoreLocations: action.fetchMoreLocations,
     };
 
     return newState;

--- a/src/watchQueryOptions.ts
+++ b/src/watchQueryOptions.ts
@@ -11,4 +11,5 @@ export interface WatchQueryOptions {
   noFetch?: boolean;
   pollInterval?: number;
   fragments?: FragmentDefinition[];
+  fetchMoreLocations?: string[];
 }

--- a/test/client.ts
+++ b/test/client.ts
@@ -347,6 +347,7 @@ describe('client', () => {
             fragmentMap: {},
             returnPartialData: false,
             lastRequestId: 1,
+            fetchMoreLocations: undefined,
           },
         },
         mutations: {},

--- a/test/fetchMore.ts
+++ b/test/fetchMore.ts
@@ -1,0 +1,94 @@
+import gql from 'graphql-tag';
+import mockNetworkInterface from './mocks/mockNetworkInterface';
+import {
+  QueryManager,
+} from '../src/QueryManager';
+import {
+  createApolloStore,
+} from '../src/store';
+import {
+  assert,
+} from 'chai';
+
+
+describe('fetchMore-kind queries on QueryManager', () => {
+  it('properly fetches more data with just a targeted directive', (done) => {
+    const query = gql`
+      query people {
+        allPeople {
+          people @apolloFetchMore(name: "people") {
+            name
+          }
+        }
+      }
+    `;
+
+    const strippedQuery = gql`
+      query people {
+        allPeople {
+          people {
+            name
+          }
+        }
+      }
+    `;
+
+    const data1 = {
+      allPeople: {
+        people: [
+          {
+            name: 'Luke Skywalker',
+          },
+        ],
+      },
+    };
+
+    const data2 = {
+      allPeople: {
+        people: [
+          {
+            name: 'Jar Jar binks',
+          },
+        ],
+      },
+    };
+
+    const networkInterface = mockNetworkInterface(
+      {
+        request: { query: strippedQuery },
+        result: { data: data1 },
+      },
+      {
+        request: { query: strippedQuery },
+        result: { data: data2 },
+      }
+    );
+
+    const queryManager = new QueryManager({
+      networkInterface,
+      store: createApolloStore(),
+      reduxRootKey: 'apollo',
+    });
+
+    const handle = queryManager.watchQuery({
+      query,
+    });
+
+    let handleCount = 0;
+    handle.subscribe({
+      next(result) {
+        handleCount ++;
+        if (handleCount === 1) {
+          assert.deepEqual(result.data, data1);
+          handle.fetchMore(['people']);
+        } else {
+          assert.deepEqual(
+            result.data.allPeople.people,
+            [].concat(data1.allPeople.people, data2.allPeople.people)
+          );
+          done();
+        }
+      },
+    });
+  });
+});

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -26,3 +26,4 @@ import './mutationResults';
 import './optimistic';
 import './scopeQuery';
 import './errors';
+import './fetchMore';


### PR DESCRIPTION
- This PR is based onto #374.
- It must be rebased regularly onto #374 until it's merged.
- Once #374 is merged a new PR must be created against master.

TODO:

- [x] Update CHANGELOG.md with your change
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

Linked to the work of #350 

### Usage example

```js
let handleCount = 0;
const handle = client.watchQuery({
  query: gql`{
    allPeople @apolloFetchMore(name: "people") {
      id
      name
   }
  `
}).subscribe({
  next({data}) {
    handleCount ++;
    if(handleCount === 1) {
      // data === {allPeople: [{id: 'luke', name: 'Luke Skywalker'}]}
      handle.fetchMore(['people']);
    } else {
      // data === {allPeople: [{id: 'luke', name: 'Master Luke Skywalker'}, {id: 'jarjar', name: 'Jar Jar Binks'}]}
      // Note: if the id matches, consider the item new and discard the old one
    }
  }
});
```

You can't control the order in which the data is merged, that's why, for now, you should define the order in your rendering function. A next PR may change that but we have the issue of serialising functions into the store ...

### Usage example after #453 

```js
let handleCount = 0;
const handle = client.watchQuery({
  query: gql`query people($cur: ID){
    allPeople(cursor: $cur) @apolloFetchMore(name: "people") {
      id
      name
   }
  `,
  paginationArguments: ['cursor'],
}).subscribe({
  next({data}) {
    handleCount ++;
    if(handleCount === 1) {
      // data === {allPeople: [{id: 'luke', name: 'Luke Skywalker'}]}
      handle.fetchMore(['people'], {cur: "afterluke"});
    } else {
      // data === {allPeople: [{id: 'luke', name: 'Luke Skywalker'}, {id: 'jarjar', name: 'Jar Jar Binks'}]}
    }
  }
});
```
