### PR TITLE
Initial implementation of `fetchMore`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Expect active development and potentially significant breaking changes in the `0
 ### vNEXT
 - Fixed issue with `fragments` array for `updateQueries`. [PR #475](https://github.com/apollostack/apollo-client/pull/475) and [Issue #470](https://github.com/apollostack/apollo-client/issues/470).
 
+- Add a new experimental feature to observable queries called `fetchMore`. It allows application developers to update the results of a query in the store by issuing new queries. We are currently testing this feature internally and we will document it once it is stable.
+
 ### v0.4.8
 
 - Add `useAfter` function that accepts `afterwares`. Afterwares run after a request is made (after middlewares). In the afterware function, you get the whole response and request options, so you can handle status codes and errors if you need to. For example, if your requests return a `401` in the case of user logout, you can use this to identify when that starts happening. It can be used just as a `middleware` is used. Just pass an array of afterwares to the `useAfter` function.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "pretest": "npm run compile",
     "test": "npm run testonly --",
     "posttest": "npm run lint",
-    "filesize": "npm run compile:browser && ./scripts/filesize.js --file=./dist/index.min.js --maxGzip=36",
+    "filesize": "npm run compile:browser && ./scripts/filesize.js --file=./dist/index.min.js --maxGzip=37",
     "compile": "tsc",
     "compile:browser": "rm -rf ./dist && mkdir ./dist && browserify ./lib/src/index.js -o=./dist/index.js && npm run minify:browser",
     "minify:browser": "uglifyjs --compress --mangle --screw-ie8 -o=./dist/index.min.js -- ./dist/index.js",

--- a/src/ObservableQuery.ts
+++ b/src/ObservableQuery.ts
@@ -1,4 +1,4 @@
-import { WatchQueryOptions } from './watchQueryOptions';
+import { WatchQueryOptions, FetchMoreQueryOptions } from './watchQueryOptions';
 
 import { Observable, Observer } from './util/Observable';
 
@@ -17,12 +17,15 @@ import {
 import assign = require('lodash.assign');
 
 export interface FetchMoreOptions {
-  updateQuery: (previousQueryResult: any, options: any) => any;
+  updateQuery: (previousQueryResult: Object, options: {
+    fetchMoreResult: Object,
+    queryVariables: Object,
+  }) => Object;
 }
 
 export class ObservableQuery extends Observable<ApolloQueryResult> {
   public refetch: (variables?: any) => Promise<ApolloQueryResult>;
-  public fetchMore: (options: WatchQueryOptions & FetchMoreOptions) => Promise<any>;
+  public fetchMore: (options: FetchMoreQueryOptions & FetchMoreOptions) => Promise<any>;
   public stopPolling: () => void;
   public startPolling: (p: number) => void;
   public options: WatchQueryOptions;

--- a/src/ObservableQuery.ts
+++ b/src/ObservableQuery.ts
@@ -98,18 +98,16 @@ export class ObservableQuery extends Observable<ApolloQueryResult> {
     this.fetchMore = (fetchMoreOptions: WatchQueryOptions & FetchMoreOptions) => {
       return Promise.resolve()
         .then(() => {
+          const qid = this.queryManager.generateQueryId();
           let combinedOptions = null;
-          let qid = null;
 
           if (fetchMoreOptions.query) {
             // fetch a new query
-            qid = this.queryManager.generateQueryId();
             combinedOptions = fetchMoreOptions;
           } else {
             // fetch the same query with a possibly new variables
             combinedOptions =
               assign({}, this.options, fetchMoreOptions);
-            qid = this.queryId;
           }
 
           combinedOptions = assign({}, combinedOptions, {
@@ -123,7 +121,7 @@ export class ObservableQuery extends Observable<ApolloQueryResult> {
             previousResult,
             queryVariables,
             querySelectionSet,
-            queryFragments,
+            queryFragments = [],
           } = this.queryManager.getQueryWithPreviousResult(this.queryId);
 
           this.queryManager.store.dispatch({

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -558,19 +558,19 @@ export class QueryManager {
     }
     const resultBehaviors = [];
 
-    const quieryIdsByName: { [name: string]: string[] } = {};
+    const queryIdsByName: { [name: string]: string[] } = {};
     Object.keys(this.observableQueries).forEach((queryId) => {
       const observableQuery = this.observableQueries[queryId].observableQuery;
       const queryName = getQueryDefinition(observableQuery.options.query).name.value;
 
-      quieryIdsByName[queryName] =
-        quieryIdsByName[queryName] || [];
-      quieryIdsByName[queryName].push(queryId);
+      queryIdsByName[queryName] =
+        queryIdsByName[queryName] || [];
+      queryIdsByName[queryName].push(queryId);
     });
 
     Object.keys(updateQueries).forEach((queryName) => {
       const reducer = updateQueries[queryName];
-      const queries = quieryIdsByName[queryName];
+      const queries = queryIdsByName[queryName];
       if (!queries) {
         // XXX should throw an error?
         return;

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -39,6 +39,12 @@ import {
   GraphQLResult,
   Document,
   FragmentDefinition,
+  // We need to import this here to allow TypeScript to include it in the definition file even
+  // though we don't use it. https://github.com/Microsoft/TypeScript/issues/5711
+  // We need to disable the linter here because TSLint rightfully complains that this is unused.
+  /* tslint:disable */
+  SelectionSet,
+  /* tslint:enable */
 } from 'graphql';
 
 import { print } from 'graphql-tag/printer';
@@ -88,9 +94,9 @@ export type QueryListener = (queryStoreValue: QueryStoreValue) => void;
 export class QueryManager {
   public pollingTimers: {[queryId: string]: NodeJS.Timer | any}; //oddity in Typescript
   public scheduler: QueryScheduler;
+  public store: ApolloStore;
 
   private networkInterface: NetworkInterface;
-  private store: ApolloStore;
   private reduxRootKey: string;
   private queryTransformer: QueryTransformer;
   private queryListeners: { [queryId: string]: QueryListener };
@@ -495,6 +501,53 @@ export class QueryManager {
     this.stopQueryInStore(queryId);
   }
 
+  public getQueryWithPreviousResult(queryId: string, isOptimistic = false) {
+    const observableQuery = this.observableQueries[queryId].observableQuery;
+
+    if (!observableQuery) {
+      throw new Error(`ObservableQuery with this id doesn't exist: ${queryId}`);
+    }
+
+    const queryOptions = observableQuery.options;
+
+    let fragments = queryOptions.fragments;
+    let queryDefinition = getQueryDefinition(queryOptions.query);
+
+    if (this.queryTransformer) {
+      const doc = {
+        kind: 'Document',
+        definitions: [
+          queryDefinition,
+            ...(fragments || []),
+        ],
+      };
+
+      const transformedDoc = applyTransformers(doc, [this.queryTransformer]);
+
+      queryDefinition = getQueryDefinition(transformedDoc);
+      fragments = getFragmentDefinitions(transformedDoc);
+    }
+
+    const previousResult = readSelectionSetFromStore({
+      // In case of an optimistic change, apply reducer on top of the
+      // results including previous optimistic updates. Otherwise, apply it
+      // on top of the real data only.
+      store: isOptimistic ? this.getDataWithOptimisticResults() : this.getApolloState().data,
+      rootId: 'ROOT_QUERY',
+      selectionSet: queryDefinition.selectionSet,
+      variables: queryOptions.variables,
+      returnPartialData: queryOptions.returnPartialData || queryOptions.noFetch,
+      fragmentMap: createFragmentMap(fragments || []),
+    });
+
+    return {
+      previousResult,
+      queryVariables: queryOptions.variables,
+      querySelectionSet: queryDefinition.selectionSet,
+      queryFragments: fragments,
+    };
+  }
+
   private collectResultBehaviorsFromUpdateQueries(
     updateQueries: MutationQueryReducersMap,
     mutationResult: Object,
@@ -505,67 +558,42 @@ export class QueryManager {
     }
     const resultBehaviors = [];
 
-    const observableQueriesByName: { [name: string]: ObservableQuery[] } = {};
-    Object.keys(this.observableQueries).forEach((key) => {
-      const observableQuery = this.observableQueries[key].observableQuery;
+    const quieryIdsByName: { [name: string]: string[] } = {};
+    Object.keys(this.observableQueries).forEach((queryId) => {
+      const observableQuery = this.observableQueries[queryId].observableQuery;
       const queryName = getQueryDefinition(observableQuery.options.query).name.value;
 
-      observableQueriesByName[queryName] =
-        observableQueriesByName[queryName] || [];
-      observableQueriesByName[queryName].push(observableQuery);
+      quieryIdsByName[queryName] =
+        quieryIdsByName[queryName] || [];
+      quieryIdsByName[queryName].push(queryId);
     });
 
     Object.keys(updateQueries).forEach((queryName) => {
       const reducer = updateQueries[queryName];
-      const queries = observableQueriesByName[queryName];
+      const queries = quieryIdsByName[queryName];
       if (!queries) {
         // XXX should throw an error?
         return;
       }
 
-      queries.forEach((observableQuery) => {
-        const queryOptions = observableQuery.options;
-
-        let fragments = queryOptions.fragments;
-        let queryDefinition = getQueryDefinition(queryOptions.query);
-
-        if (this.queryTransformer) {
-          const doc = {
-            kind: 'Document',
-            definitions: [
-              queryDefinition,
-              ...(fragments || []),
-            ],
-          };
-
-          const transformedDoc = applyTransformers(doc, [this.queryTransformer]);
-
-          queryDefinition = getQueryDefinition(transformedDoc);
-          fragments = getFragmentDefinitions(transformedDoc);
-        }
-
-        const previousResult = readSelectionSetFromStore({
-          // In case of an optimistic change, apply reducer on top of the
-          // results including previous optimistic updates. Otherwise, apply it
-          // on top of the real data only.
-          store: isOptimistic ? this.getDataWithOptimisticResults() : this.getApolloState().data,
-          rootId: 'ROOT_QUERY',
-          selectionSet: queryDefinition.selectionSet,
-          variables: queryOptions.variables,
-          returnPartialData: queryOptions.returnPartialData || queryOptions.noFetch,
-          fragmentMap: createFragmentMap(fragments),
-        });
+      queries.forEach((queryId) => {
+        const {
+          previousResult,
+          queryVariables,
+          querySelectionSet,
+          queryFragments,
+        } = this.getQueryWithPreviousResult(queryId, isOptimistic);
 
         resultBehaviors.push({
           type: 'QUERY_RESULT',
           newResult: reducer(previousResult, {
             mutationResult,
             queryName,
-            queryVariables: queryOptions.variables,
+            queryVariables,
           }),
-          queryVariables: queryOptions.variables,
-          querySelectionSet: queryDefinition.selectionSet,
-          queryFragments: fragments,
+          queryVariables,
+          querySelectionSet,
+          queryFragments,
         });
       });
     });

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -502,11 +502,11 @@ export class QueryManager {
   }
 
   public getQueryWithPreviousResult(queryId: string, isOptimistic = false) {
-    const observableQuery = this.observableQueries[queryId].observableQuery;
-
-    if (!observableQuery) {
+    if (!this.observableQueries[queryId]) {
       throw new Error(`ObservableQuery with this id doesn't exist: ${queryId}`);
     }
+
+    const observableQuery = this.observableQueries[queryId].observableQuery;
 
     const queryOptions = observableQuery.options;
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,5 +1,7 @@
 import {
   GraphQLResult,
+  SelectionSet,
+  FragmentDefinition,
 } from 'graphql';
 
 import {
@@ -108,6 +110,18 @@ export function isMutationErrorAction(action: ApolloAction): action is MutationE
   return action.type === 'APOLLO_MUTATION_ERROR';
 }
 
+export interface UpdateQueryResultAction {
+  type: 'APOLLO_UPDATE_QUERY_RESULT';
+  queryVariables: any;
+  querySelectionSet: SelectionSet;
+  queryFragments: FragmentDefinition[];
+  newResult: Object;
+}
+
+export function isUpdateQueryResultAction(action: ApolloAction): action is UpdateQueryResultAction {
+  return action.type === 'APOLLO_UPDATE_QUERY_RESULT';
+}
+
 export interface StoreResetAction {
   type: 'APOLLO_STORE_RESET';
   observableQueryIds: string[];
@@ -126,4 +140,5 @@ export type ApolloAction =
   MutationInitAction |
   MutationResultAction |
   MutationErrorAction |
+  UpdateQueryResultAction |
   StoreResetAction;

--- a/src/data/diffAgainstStore.ts
+++ b/src/data/diffAgainstStore.ts
@@ -328,7 +328,7 @@ function diffFieldAgainstStore({
   if (! has(storeObj, storeFieldKey)) {
     if (throwOnMissingField && included) {
       throw new ApolloError({
-        errorMessage: `Can't find field ${storeFieldKey} on object ${JSON.stringify(storeObj)}.
+        errorMessage: `Can't find field ${storeFieldKey} on object (${rootId}) ${JSON.stringify(storeObj, null, 2)}.
 Perhaps you want to use the \`returnPartialData\` option?`,
         extraInfo: {
           isFieldError: true,

--- a/src/data/mutationResults.ts
+++ b/src/data/mutationResults.ts
@@ -13,9 +13,14 @@ import isArray = require('lodash.isarray');
 import cloneDeep = require('lodash.clonedeep');
 import assign = require('lodash.assign');
 
+import { replaceQueryResults } from './replaceQueryResults';
+
+import {
+  writeSelectionSetToStore,
+} from './writeToStore';
+
 import {
   FragmentMap,
-  createFragmentMap,
 } from '../queries/getFromAST';
 
 import {
@@ -27,10 +32,6 @@ import {
 import {
   ApolloReducerConfig,
 } from '../store';
-
-import {
-  writeSelectionSetToStore,
-} from './writeToStore';
 
 // Mutation behavior types, these can be used in the `resultBehaviors` argument to client.mutate
 
@@ -265,28 +266,11 @@ function mutationResultArrayDeleteReducer(state: NormalizedCache, {
   }) as NormalizedCache;
 }
 
-function mutationResultQueryResultReducer(state: NormalizedCache, {
+export function mutationResultQueryResultReducer(state: NormalizedCache, {
   behavior,
   config,
 }: MutationBehaviorReducerArgs) {
-  const {
-    queryVariables,
-    newResult,
-    queryFragments,
-    querySelectionSet,
-  } = behavior as MutationQueryResultBehavior;
-
-  const clonedState = assign({}, state) as NormalizedCache;
-
-  return writeSelectionSetToStore({
-    result: newResult,
-    dataId: 'ROOT_QUERY',
-    selectionSet: querySelectionSet,
-    variables: queryVariables,
-    store: clonedState,
-    dataIdFromObject: config.dataIdFromObject,
-    fragmentMap: createFragmentMap(queryFragments),
-  });
+  return replaceQueryResults(state, behavior as MutationQueryResultBehavior, config);
 }
 
 export type MutationQueryReducer = (previousResult: Object, options: {

--- a/src/data/replaceQueryResults.ts
+++ b/src/data/replaceQueryResults.ts
@@ -1,0 +1,46 @@
+import {
+  NormalizedCache,
+} from './store';
+
+import {
+  SelectionSet,
+  FragmentDefinition,
+} from 'graphql';
+
+import {
+  writeSelectionSetToStore,
+} from './writeToStore';
+
+import {
+  createFragmentMap,
+} from '../queries/getFromAST';
+
+import {
+  ApolloReducerConfig,
+} from '../store';
+
+import assign = require('lodash.assign');
+
+export function replaceQueryResults(state: NormalizedCache, {
+  queryVariables,
+  querySelectionSet,
+  queryFragments,
+  newResult,
+}: {
+  queryVariables: any;
+  querySelectionSet: SelectionSet;
+  queryFragments: FragmentDefinition[];
+  newResult: Object;
+}, config: ApolloReducerConfig) {
+  const clonedState = assign({}, state) as NormalizedCache;
+
+  return writeSelectionSetToStore({
+    result: newResult,
+    dataId: 'ROOT_QUERY',
+    selectionSet: querySelectionSet,
+    variables: queryVariables,
+    store: clonedState,
+    dataIdFromObject: config.dataIdFromObject,
+    fragmentMap: createFragmentMap(queryFragments),
+  });
+}

--- a/src/data/store.ts
+++ b/src/data/store.ts
@@ -2,6 +2,7 @@ import {
   ApolloAction,
   isQueryResultAction,
   isMutationResultAction,
+  isUpdateQueryResultAction,
   isStoreResetAction,
 } from '../actions';
 
@@ -32,6 +33,10 @@ import {
   defaultMutationBehaviorReducers,
   MutationBehaviorReducerArgs,
 } from './mutationResults';
+
+import {
+  replaceQueryResults,
+} from './replaceQueryResults';
 
 export interface NormalizedCache {
   [dataId: string]: StoreObject;
@@ -146,6 +151,8 @@ export function data(
 
       return newState;
     }
+  } else if (isUpdateQueryResultAction(constAction)) {
+    return replaceQueryResults(previousState, constAction, config) as NormalizedCache;
   } else if (isStoreResetAction(action)) {
     // If we are resetting the store, we no longer need any of the data that is currently in
     // the store so we can just throw it all away.

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,6 +137,7 @@ this in the docs: http://docs.apollostack.com/`);
       fragmentDefinitionsMap[fragmentName] = [fragmentDefinition];
     }
   });
+
   return fragments.concat(fragmentDefinitions);
 }
 

--- a/src/watchQueryOptions.ts
+++ b/src/watchQueryOptions.ts
@@ -12,3 +12,8 @@ export interface WatchQueryOptions {
   pollInterval?: number;
   fragments?: FragmentDefinition[];
 }
+
+export interface FetchMoreQueryOptions {
+  query?: Document;
+  variables?: { [key: string]: any };
+}

--- a/test/fetchMore.ts
+++ b/test/fetchMore.ts
@@ -1,0 +1,89 @@
+import * as chai from 'chai';
+const { assert } = chai;
+
+import mockNetworkInterface from './mocks/mockNetworkInterface';
+import ApolloClient, { addTypename, createFragment } from '../src';
+
+import assign = require('lodash.assign');
+import clonedeep = require('lodash.clonedeep');
+
+import gql from 'graphql-tag';
+
+describe('fetchMore on an observable query', () => {
+  const query = gql`
+    query Comment($repoName: String!, $start: Int!, $limit: Int!) {
+      entry(repoFullName: $repoName) {
+        comments(start: $start, limit: $limit) {
+          text
+        }
+      }
+    }
+  `;
+  const variables = {
+    repoName: 'org/repo',
+    start: 0,
+    limit: 10,
+  };
+  const variablesMore = assign({}, variables, { start: 10 });
+
+  const result = {
+    data: {
+      entry: {
+        comments: [],
+      },
+    },
+  };
+  for (let i = 1; i <= 10; i++) {
+    result.data.entry.comments.push({ text: `comment ${i}` });
+  }
+
+  let client: ApolloClient;
+  let networkInterface;
+
+  function setup(...mockedResponses) {
+    networkInterface = mockNetworkInterface({
+      request: {
+        query,
+        variables,
+      },
+      result,
+    }, ...mockedResponses);
+
+    client = new ApolloClient({
+      networkInterface,
+    });
+
+    const obsHandle = client.watchQuery({
+      query,
+      variables,
+    });
+    obsHandle.subscribe({
+      next(result) {
+        // do nothing
+      }
+    });
+
+    return Promise.resolve(obsHandle);
+  };
+
+  it('basic fetchMore results merging', () => {
+    return setup({
+      request: {
+        query,
+        variables: variablesMore,
+      },
+      result,
+    }).then((watchedQuery) => {
+      return watchedQuery.fetchMore({
+        variables: variablesMore,
+      }).then(() => {
+        return watchedQuery;
+      });
+    }).then((watchedQuery) => {
+      return watchedQuery.result();
+    }).then((result) => {
+      console.log(result);
+      assert.equal(result, 'asdf');
+    });
+  });
+});

--- a/test/fetchMore.ts
+++ b/test/fetchMore.ts
@@ -19,12 +19,23 @@ describe('fetchMore on an observable query', () => {
       }
     }
   `;
+  const query2 = gql`
+    query NewComments($start: Int!, $limit: Int!) {
+      comments(start: $start, limit: $limit) {
+        text
+      }
+    }
+  `;
   const variables = {
     repoName: 'org/repo',
     start: 0,
     limit: 10,
   };
   const variablesMore = assign({}, variables, { start: 10, limit: 10 });
+  const variables2 = {
+    start: 10,
+    limit: 20,
+  };
 
   const result = {
     data: {
@@ -34,17 +45,24 @@ describe('fetchMore on an observable query', () => {
     },
   };
   const resultMore = clonedeep(result);
+  const result2 = {
+    data: {
+      comments: [],
+    },
+  };
   for (let i = 1; i <= 10; i++) {
     result.data.entry.comments.push({ text: `comment ${i}` });
   }
   for (let i = 11; i <= 20; i++) {
     resultMore.data.entry.comments.push({ text: `comment ${i}` });
+    result2.data.comments.push({ text: `new comment ${i}` });
   }
 
   let latestResult = null;
 
   let client: ApolloClient;
   let networkInterface;
+  let sub;
 
   function setup(...mockedResponses) {
     networkInterface = mockNetworkInterface({
@@ -63,7 +81,7 @@ describe('fetchMore on an observable query', () => {
       query,
       variables,
     });
-    obsHandle.subscribe({
+    sub = obsHandle.subscribe({
       next(queryResult) {
         // do nothing
         latestResult = queryResult;
@@ -73,7 +91,13 @@ describe('fetchMore on an observable query', () => {
     return Promise.resolve(obsHandle);
   };
 
+  function unsetup() {
+    sub.unsubscribe();
+    sub = null;
+  }
+
   it('basic fetchMore results merging', () => {
+    latestResult = null;
     return setup({
       request: {
         query,
@@ -95,6 +119,38 @@ describe('fetchMore on an observable query', () => {
       for (let i = 1; i <= 20; i++) {
         assert.equal(comments[i - 1].text, `comment ${i}`);
       }
+      unsetup();
+    });
+  });
+
+  it('fetching more with a different query', () => {
+    latestResult = null;
+    return setup({
+      request: {
+        query: query2,
+        variables: variables2,
+      },
+      result: result2,
+    }).then((watchedQuery) => {
+      return watchedQuery.fetchMore({
+        query: query2,
+        variables: variables2,
+        updateQuery: (prev, options) => {
+          const state = clonedeep(prev) as any;
+          state.entry.comments = [...state.entry.comments, ...(options.fetchMoreResult as any).data.comments];
+          return state;
+        },
+      });
+    }).then(() => {
+      const comments = latestResult.data.entry.comments;
+      assert.lengthOf(comments, 20);
+      for (let i = 1; i <= 10; i++) {
+        assert.equal(comments[i - 1].text, `comment ${i}`);
+      }
+      for (let i = 11; i <= 20; i++) {
+        assert.equal(comments[i - 1].text, `new comment ${i}`);
+      }
+      unsetup();
     });
   });
 });

--- a/test/mocks/mockNetworkInterface.ts
+++ b/test/mocks/mockNetworkInterface.ts
@@ -71,7 +71,7 @@ export class MockNetworkInterface implements NetworkInterface {
       const responses = this.mockedResponsesByKey[key];
 
       if (!responses || responses.length === 0) {
-        throw new Error('No more mocked responses for the query: ' + print(request.query));
+        throw new Error(`No more mocked responses for the query: ${print(request.query)}, variables: ${JSON.stringify(request.variables)}`);
       }
 
       const { result, error, delay } = responses.shift();

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -24,5 +24,6 @@ import './batching';
 import './scheduler';
 import './mutationResults';
 import './optimistic';
+import './fetchMore';
 import './scopeQuery';
 import './errors';


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md with your change
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

Design:
- `fetchMore` method on an observable query
- allows to fetch the same query, or a new query with any amended variables, fragments, etc
- the results of the `fetchMore` query always are fetched from the server
- the reducer function passed into `fetchMore` is responsible for merging the new result into the existing query results