### PR TITLE
Refetch queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Expect active development and potentially significant breaking changes in the `0
 
 - Fixed issue with `fragments` array for `updateQueries`. [PR #475](https://github.com/apollostack/apollo-client/pull/475) and [Issue #470](https://github.com/apollostack/apollo-client/issues/470).
 - Add a new experimental feature to observable queries called `fetchMore`. It allows application developers to update the results of a query in the store by issuing new queries. We are currently testing this feature internally and we will document it once it is stable.
-- Added an `invalidateQueries` option to `mutate`. The point is to just refetch certain queries on a mutation rather than having to manually specify how the result should be incorporated for each of them with `updateQueries`. [PR #482](https://github.com/apollostack/apollo-client/pull/482) and [Issue #448](https://github.com/apollostack/apollo-client/issues/448).
+- Added an `refetchQueries` option to `mutate`. The point is to just refetch certain queries on a mutation rather than having to manually specify how the result should be incorporated for each of them with `updateQueries`. [PR #482](https://github.com/apollostack/apollo-client/pull/482) and [Issue #448](https://github.com/apollostack/apollo-client/issues/448).
 
 ### v0.4.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 3 to 6 months), to signal the start of a more stable API.
 
 ### vNEXT
+- Added an `refetchQueries` option to `mutate`. The point is to just refetch certain queries on a mutation rather than having to manually specify how the result should be incorporated for each of them with `updateQueries`. [PR #482](https://github.com/apollostack/apollo-client/pull/482) and [Issue #448](https://github.com/apollostack/apollo-client/issues/448).
 
 ### v0.4.10
 
@@ -13,7 +14,6 @@ Expect active development and potentially significant breaking changes in the `0
 
 - Fixed issue with `fragments` array for `updateQueries`. [PR #475](https://github.com/apollostack/apollo-client/pull/475) and [Issue #470](https://github.com/apollostack/apollo-client/issues/470).
 - Add a new experimental feature to observable queries called `fetchMore`. It allows application developers to update the results of a query in the store by issuing new queries. We are currently testing this feature internally and we will document it once it is stable.
-- Added an `refetchQueries` option to `mutate`. The point is to just refetch certain queries on a mutation rather than having to manually specify how the result should be incorporated for each of them with `updateQueries`. [PR #482](https://github.com/apollostack/apollo-client/pull/482) and [Issue #448](https://github.com/apollostack/apollo-client/issues/448).
 
 ### v0.4.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Expect active development and potentially significant breaking changes in the `0
 
 - Fixed issue with `fragments` array for `updateQueries`. [PR #475](https://github.com/apollostack/apollo-client/pull/475) and [Issue #470](https://github.com/apollostack/apollo-client/issues/470).
 - Add a new experimental feature to observable queries called `fetchMore`. It allows application developers to update the results of a query in the store by issuing new queries. We are currently testing this feature internally and we will document it once it is stable.
+- Added an `invalidateQueries` option to `mutate`. The point is to just refetch certain queries on a mutation rather than having to manually specify how the result should be incorporated for each of them with `updateQueries`. [PR #482](https://github.com/apollostack/apollo-client/pull/482) and [Issue #448](https://github.com/apollostack/apollo-client/issues/448).
 
 ### v0.4.8
 

--- a/src/ObservableQuery.ts
+++ b/src/ObservableQuery.ts
@@ -29,7 +29,7 @@ export class ObservableQuery extends Observable<ApolloQueryResult> {
   public stopPolling: () => void;
   public startPolling: (p: number) => void;
   public options: WatchQueryOptions;
-  private queryId: string;
+  public queryId: string;
   private scheduler: QueryScheduler;
   private queryManager: QueryManager;
 

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -127,7 +127,7 @@ export class QueryManager {
   } };
 
   // A map going from the name of a query to an observer issued for it by watchQuery. This is
-  // generally used to refetches for invalidateQueries and to update mutation results through
+  // generally used to refetches for refetchQueries and to update mutation results through
   // updateQueries.
   private queryIdsByName: { [queryName: string]: string[] };
 
@@ -199,7 +199,7 @@ export class QueryManager {
     fragments = [],
     optimisticResponse,
     updateQueries,
-    invalidateQueries = [],
+    refetchQueries = [],
   }: {
     mutation: Document,
     variables?: Object,
@@ -207,6 +207,7 @@ export class QueryManager {
     fragments?: FragmentDefinition[],
     optimisticResponse?: Object,
     updateQueries?: MutationQueryReducersMap,
+    refetchQueries?: string[],
   }): Promise<ApolloQueryResult> {
     const mutationId = this.generateQueryId();
 
@@ -269,7 +270,7 @@ export class QueryManager {
             ],
           });
 
-          invalidateQueries.forEach((name) => { this.refetchQueryByName(name); });
+          refetchQueries.forEach((name) => { this.refetchQueryByName(name); });
           resolve(result);
         })
         .catch((err) => {

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -199,10 +199,7 @@ export class QueryManager {
     fragments = [],
     optimisticResponse,
     updateQueries,
-<<<<<<< HEAD
-=======
     invalidateQueries = [],
->>>>>>> 0a013b1... moved observableQueriesByName construction out of the updateQueries code'
   }: {
     mutation: Document,
     variables?: Object,
@@ -272,6 +269,7 @@ export class QueryManager {
             ],
           });
 
+          invalidateQueries.forEach((name) => { this.refetchQueryByName(name); });
           resolve(result);
         })
         .catch((err) => {
@@ -795,6 +793,14 @@ export class QueryManager {
     // return a chainable promise
     return new Promise((resolve) => {
       resolve({ data: initialResult });
+    });
+  }
+
+  // Refetches a query given that query's name. Refetches
+  // all ObservableQuery instances associated with the query name.
+  private refetchQueryByName(queryName: string) {
+    this.queryIdsByName[queryName].forEach((queryId) => {
+      this.observableQueries[queryId].observableQuery.refetch();
     });
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -258,6 +258,7 @@ export default class ApolloClient {
     fragments?: FragmentDefinition[],
     optimisticResponse?: Object,
     updateQueries?: MutationQueryReducersMap,
+    invalidateQueries?: string[],
   }): Promise<ApolloQueryResult> => {
     this.initStore();
     return this.queryManager.mutate(options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -258,7 +258,7 @@ export default class ApolloClient {
     fragments?: FragmentDefinition[],
     optimisticResponse?: Object,
     updateQueries?: MutationQueryReducersMap,
-    invalidateQueries?: string[],
+    refetchQueries?: string[],
   }): Promise<ApolloQueryResult> => {
     this.initStore();
     return this.queryManager.mutate(options);

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -1,5 +1,3 @@
-import * as _ from 'lodash';
-
 import {
   QueryManager,
 } from '../src/QueryManager';

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -3174,7 +3174,6 @@ describe('QueryManager', () => {
     }, 120);
   });
 
-<<<<<<< HEAD
   describe('loading state', () => {
     it('should be passed as false if we are not watching a query', (done) => {
       const query = gql`

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -3174,6 +3174,7 @@ describe('QueryManager', () => {
     }, 120);
   });
 
+<<<<<<< HEAD
   describe('loading state', () => {
     it('should be passed as false if we are not watching a query', (done) => {
       const query = gql`
@@ -3284,7 +3285,7 @@ describe('QueryManager', () => {
     });
   });
 
-  describe('invalidateQueries', () => {
+  describe('refetchQueries', () => {
     it('should refetch the right query when a result is successfully returned', (done) => {
       const mutation = gql`
         mutation changeAuthorName {
@@ -3341,7 +3342,7 @@ describe('QueryManager', () => {
         next(result) {
           if (resultsReceived === 0) {
             assert.deepEqual(result.data, data);
-            queryManager.mutate({ mutation, invalidateQueries: ['getAuthors'] });
+            queryManager.mutate({ mutation, refetchQueries: ['getAuthors'] });
           } else if (resultsReceived === 1) {
             assert.deepEqual(result.data, secondReqData);
             done();


### PR DESCRIPTION
Added an `invalidateQueries` option to `client.mutate` as per #448. 

TODO:
- [x] Update CHANGELOG.md with your change
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

Rebased on top of Slava's PR #472.