### PR TITLE
Extend original variables in refetch and fetchMore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ Expect active development and potentially significant breaking changes in the `0
 - Fixed issue with alias names in batched queries. [PR #493](https://github.com/apollostack/apollo-client/pull/493) and [Issue #490](https://github.com/apollostack/apollo-client/issues).
 - Add loading state tracking within Apollo Client in order to simplify the handling of loading state within the view layers. [Issue #342](https://github.com/apollostack/apollo-client/issues/342) and [PR #467](https://github.com/apollostack/apollo-client/pull/467)
 
+- Fixed the way new variables extend the original arguments when passed to methods `fetchMore` and `refetch`. [PR #497](https://github.com/apollostack/apollo-client/pull/497).
+
 ### v0.4.9
 
 - Fixed issue with `fragments` array for `updateQueries`. [PR #475](https://github.com/apollostack/apollo-client/pull/475) and [Issue #470](https://github.com/apollostack/apollo-client/issues/470).
-- Add a new experimental feature to observable queries called `fetchMore`. It allows application developers to update the results of a query in the store by issuing new queries. We are currently testing this feature internally and we will document it once it is stable.
+- Add a new experimental feature to observable queries called `fetchMore`. It allows application developers to update the results of a query in the store by issuing new queries. We are currently testing this feature internally and we will document it once it is stable. [PR #472](https://github.com/apollostack/apollo-client/pull/472).
 
 ### v0.4.8
 

--- a/src/ObservableQuery.ts
+++ b/src/ObservableQuery.ts
@@ -86,15 +86,17 @@ export class ObservableQuery extends Observable<ApolloQueryResult> {
     this.queryId = queryId;
 
     this.refetch = (variables?: any) => {
-      // If no new variables passed, use existing variables
-      variables = variables || this.options.variables;
+      // Extend variables if available
+      variables = variables || this.options.variables ?
+        assign({}, this.options.variables, variables) : undefined;
+
       if (this.options.noFetch) {
         throw new Error('noFetch option should not use query refetch.');
       }
       // Use the same options as before, but with new variables and forceFetch true
       return this.queryManager.fetchQuery(this.queryId, assign(this.options, {
         forceFetch: true,
-        variables: assign({}, this.options.variables, variables),
+        variables,
       }) as WatchQueryOptions);
     };
 
@@ -109,8 +111,11 @@ export class ObservableQuery extends Observable<ApolloQueryResult> {
             combinedOptions = fetchMoreOptions;
           } else {
             // fetch the same query with a possibly new variables
+            const variables = this.options.variables || fetchMoreOptions.variables ?
+              assign({}, this.options.variables, fetchMoreOptions.variables) : undefined;
+
             combinedOptions = assign({}, this.options, fetchMoreOptions, {
-              variables: assign({}, this.options.variables, fetchMoreOptions.variables),
+              variables,
             });
           }
 

--- a/src/ObservableQuery.ts
+++ b/src/ObservableQuery.ts
@@ -109,8 +109,9 @@ export class ObservableQuery extends Observable<ApolloQueryResult> {
             combinedOptions = fetchMoreOptions;
           } else {
             // fetch the same query with a possibly new variables
-            combinedOptions =
-              assign({}, this.options, fetchMoreOptions);
+            combinedOptions = assign({}, this.options, fetchMoreOptions, {
+              variables: assign({}, this.options.variables, fetchMoreOptions.variables),
+            });
           }
 
           combinedOptions = assign({}, combinedOptions, {

--- a/src/ObservableQuery.ts
+++ b/src/ObservableQuery.ts
@@ -94,7 +94,7 @@ export class ObservableQuery extends Observable<ApolloQueryResult> {
       // Use the same options as before, but with new variables and forceFetch true
       return this.queryManager.fetchQuery(this.queryId, assign(this.options, {
         forceFetch: true,
-        variables,
+        variables: assign({}, this.options.variables, variables),
       }) as WatchQueryOptions);
     };
 

--- a/test/fetchMore.ts
+++ b/test/fetchMore.ts
@@ -106,7 +106,7 @@ describe('fetchMore on an observable query', () => {
       result: resultMore,
     }).then((watchedQuery) => {
       return watchedQuery.fetchMore({
-        variables: variablesMore,
+        variables: { start: 10 }, // rely on the fact that the original variables had limit: 10
         updateQuery: (prev, options) => {
           const state = clonedeep(prev) as any;
           state.entry.comments = [...state.entry.comments, ...(options.fetchMoreResult as any).data.entry.comments];


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Update CHANGELOG.md with your change
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

------

This is kinda a bug that wasn't caught by the original test suite for `fetchMore`. I will add another test for this.