### PR TITLE
Remove unused variables from queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 3 to 6 months), to signal the start of a more stable API.
 
 ### vNEXT
-- Fixed an issue with named fragments in batched queries. [PR #509](https://github.com/apollostack/apollo-client/pull/509) and [Issue #https://github.com/apollostack/apollo-client/issues/501](https://github.com/apollostack/apollo-client/issues/501).
+- Fixed an issue with named fragments in batched queries. [PR #509](https://github.com/apollostack/apollo-client/pull/509) and [Issue #501](https://github.com/apollostack/apollo-client/issues/501).
+- Fixed an issue with unused variables in queries after diffing queries against information available in the store. [PR #518](https://github.com/apollostack/apollo-client/pull/518) and [Issue #496](https://github.com/apollostack/apollo-client/issues/496).
 
 ### v0.4.11
 

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -57,7 +57,7 @@ import {
 
 import {
   diffSelectionSetAgainstStore,
-  removeUnusedVariablesFromDiffedQuery,
+  removeUnusedVariablesFromQuery,
 } from './data/diffAgainstStore';
 
 import {
@@ -692,7 +692,7 @@ export class QueryManager {
         fragmentMap,
       });
 
-      removeUnusedVariablesFromDiffedQuery(diffedQuery);
+      removeUnusedVariablesFromQuery(diffedQuery);
     }
 
     return {

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -57,6 +57,7 @@ import {
 
 import {
   diffSelectionSetAgainstStore,
+  removeUnusedVariablesFromDiffedQuery,
 } from './data/diffAgainstStore';
 
 import {
@@ -690,6 +691,8 @@ export class QueryManager {
         name: queryDef.name,
         fragmentMap,
       });
+
+      removeUnusedVariablesFromDiffedQuery(diffedQuery);
     }
 
     return {
@@ -698,7 +701,7 @@ export class QueryManager {
     };
   }
 
-  // Takes a request id, query id, a query document and information asscoaiated with the query
+  // Takes a request id, query id, a query document and information associated with the query
   // (e.g. variables, fragment map, etc.) and send it to the network interface. Returns
   // a promise for the result associated with that request.
   private fetchRequest({

--- a/src/data/diffAgainstStore.ts
+++ b/src/data/diffAgainstStore.ts
@@ -27,6 +27,7 @@ import {
   Selection,
   FragmentDefinition,
   OperationDefinition,
+  Variable,
 } from 'graphql';
 
 import {
@@ -445,7 +446,7 @@ function collectUsedVariablesFromField(field: Field) {
   if (field.arguments) {
     variables = flatten(field.arguments.map((arg) => {
       if (arg.value.kind === 'Variable') {
-        return [(arg.value as any).name.value];
+        return [(arg.value as Variable).name.value];
       }
 
       return [];

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -3478,7 +3478,7 @@ function testDiffing(
   config: {
     dataIdFromObject?: IdGetter,
   },
-  done: () => void
+  done: (err?: Error) => void
 ) {
   const mockedResponses = queryArray.map(({
     diffedQuery,
@@ -3508,21 +3508,11 @@ function testDiffing(
       }).then((result) => {
         assert.deepEqual(result.data, fullResponse);
         cb();
-      }).catch((err) => {
-        /* tslint:disable */
-        console.log(err.graphQLErrors);
-        console.log(err.networkError);
-        /* tslint:enable */
-        throw err;
       });
     };
   });
 
   series(steps, (err, res) => {
-    if (err) {
-      throw err;
-    }
-
-    done();
+    done(err);
   });
 }


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Update CHANGELOG.md with your change
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

After diffing queries, removing parts that could be queried from the store,
some variables in the query can become unused, causing errors pointing
out unused variables.

This patch, walks the query and fragments asts and filters out the variables
no longer used.