### PR TITLE
Fixed bugs with query merging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 3 to 6 months), to signal the start of a more stable API.
 
 ### vNEXT
-- Fixed an issue with named fragments in batched queries. [PR #509](https://github.com/apollostack/apollo-client/pull/509) and [Issue #https://github.com/apollostack/apollo-client/issues/501](https://github.com/apollostack/apollo-client/issues/501).
+- Fixed an issue with named fragments in batched queries. [PR #509](https://github.com/apollostack/apollo-client/pull/509) and [Issue #501](https://github.com/apollostack/apollo-client/issues/501).
+- Fixed a couple of issues within query merging that caused issues with null values or arrays in responses. [PR #523](https://github.com/apollostack/apollo-client/pull/523).
 
 ### v0.4.11
 

--- a/src/batching/queryMerging.ts
+++ b/src/batching/queryMerging.ts
@@ -166,7 +166,8 @@ export function unpackDataForRequest({
         currIndex += 1;
       }
 
-      let childData = isNull(data) ? null : data[stringKey];
+      const childData = isNull(data) ? null : data[stringKey];
+      let resData = childData;
       if (field.selectionSet && field.selectionSet.selections.length > 0) {
         const fieldOpts = {
           request,
@@ -183,11 +184,12 @@ export function unpackDataForRequest({
             startIndex: currIndex,
           }) as UnpackOptions);
           currIndex = selectionRet.newIndex;
+          resData = childData;
         } else if (isArray(childData)) {
           const resUnpacked = [];
           let newIndex = 0;
 
-          data[stringKey].forEach((dataObject) => {
+          childData.forEach((dataObject) => {
             const selectionRet = unpackDataForRequest(assign(fieldOpts, {
               data: dataObject,
               startIndex: currIndex,
@@ -198,17 +200,17 @@ export function unpackDataForRequest({
           });
 
           currIndex = newIndex;
-          childData = resUnpacked;
+          resData = resUnpacked;
         } else {
           const selectionRet = unpackDataForRequest(assign(fieldOpts, { startIndex: currIndex }) as UnpackOptions);
           // Create keys for internal fragments
-          childData = selectionRet.unpackedData;
+          resData = selectionRet.unpackedData;
           currIndex = selectionRet.newIndex;
         }
       }
 
       if (!isUndefined(childData)) {
-        unpackedData[realName] = childData;
+        unpackedData[realName] = resData;
       }
     } else if (selection.kind === 'InlineFragment') {
       // If this is an inline fragment, then we recursively resolve the fields within the

--- a/src/batching/queryMerging.ts
+++ b/src/batching/queryMerging.ts
@@ -59,6 +59,7 @@ import assign = require('lodash.assign');
 import cloneDeep = require('lodash.clonedeep');
 import isArray = require('lodash.isarray');
 import isNull = require('lodash.isnull');
+import isUndefined = require('lodash.isundefined');
 
 // Merges requests together.
 // NOTE: This is pretty much the only function from this file that should be
@@ -178,7 +179,6 @@ export function unpackDataForRequest({
         };
 
         if (isNull(childData)) {
-          childData = null;
           const selectionRet = unpackDataForRequest(assign(fieldOpts, {
             startIndex: currIndex,
           }) as UnpackOptions);
@@ -206,7 +206,10 @@ export function unpackDataForRequest({
           currIndex = selectionRet.newIndex;
         }
       }
-      unpackedData[realName] = childData;
+
+      if (!isUndefined(childData)) {
+        unpackedData[realName] = childData;
+      }
     } else if (selection.kind === 'InlineFragment') {
       // If this is an inline fragment, then we recursively resolve the fields within the
       // inline fragment.

--- a/test/queryMerging.ts
+++ b/test/queryMerging.ts
@@ -1189,5 +1189,26 @@ describe('Query merging', () => {
       });
       assert.deepEqual(unpackedData, result);
     });
+
+    it('should work with directives', () => {
+      const query = gql`
+        query authorNames {
+          author {
+            firstName @skip(if: true)
+            lastName
+          }
+        }`;
+      const result = {
+        author: {
+          lastName: 'Pandya',
+        },
+      };
+      const { unpackedData } = unpackQueryResult(query, {
+        '___authorNames___requestIndex_0___fieldIndex_0': {
+          lastName: 'Pandya',
+        },
+      });
+      assert.deepEqual(unpackedData, result);
+    });
   });
 });

--- a/test/queryMerging.ts
+++ b/test/queryMerging.ts
@@ -1163,5 +1163,31 @@ describe('Query merging', () => {
       });
       assert.deepEqual(unpackedData, result);
     });
+
+    it('should work with a null response for a fragment field', () => {
+      const query = gql`
+        query authorNames {
+          author {
+            ...authorInfo
+          }
+        }
+        fragment authorInfo on Author {
+          firstName
+          lastName
+        }`;
+      const result = {
+        author: {
+          firstName: null,
+          lastName: 'Smith',
+        },
+      };
+      const { unpackedData } = unpackQueryResult(query, {
+        '___authorNames___requestIndex_0___fieldIndex_0': {
+          '___authorNames___requestIndex_0___fieldIndex_1': null,
+          '___authorNames___requestIndex_0___fieldIndex_2': 'Smith',
+        },
+      });
+      assert.deepEqual(unpackedData, result);
+    });
   });
 });


### PR DESCRIPTION
From @amandajliu's work w/ GitHunt, we discovered that there were some issues with the way query merging handled arrays and null values in the response. This PR fixes those issues.

TODO:

- [x] Update CHANGELOG.md with your change
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
