### PR TITLE
Transport-level query batching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Expect active development and potentially significant breaking changes in the `0
 - Fixed issue with error passing with query merging. [PR #589](https://github.com/apollostack/apollo-client/pull/589) and [Issue #551](https://github.com/apollostack/apollo-client/issues/551).
 - [Experimental] Change subscription API to `subscribe` function on Apollo Client instance, and remove `fetchMore`-style API temporarily.
 - Fixed an issue with batching and variables used in directives. [PR #584](https://github.com/apollostack/apollo-client/pull/584) and [Issue #577](https://github.com/apollostack/apollo-client/issues/577).
+- Implemented transport-level batching the way it is currently supported within Apollo Server. [PR #531](https://github.com/apollostack/apollo-client/pull/531) and [Issue #505](https://github.com/apollostack/apollo-client/issues/505).
 
 ### v0.4.13
 

--- a/src/batchedNetworkInterface.ts
+++ b/src/batchedNetworkInterface.ts
@@ -67,7 +67,7 @@ export class HTTPBatchedNetworkInterface extends HTTPFetchNetworkInterface imple
             return result.json();
           })
           .then(responses => {
-            const afterwaresPromises = responses.map((response, index) => {
+            const afterwaresPromises = responses.map((response: IResponse, index: number) => {
               return this.applyAfterwares({
                 response,
                 options: requestsAndOptions[index].options,
@@ -78,7 +78,7 @@ export class HTTPBatchedNetworkInterface extends HTTPFetchNetworkInterface imple
               response: IResponse,
               options: RequestInit,
             }[]) => {
-              const results = [];
+              const results: Array<IResponse>  = [];
               responsesAndOptions.forEach(({ response }) => {
                 results.push(response);
               });

--- a/src/batchedNetworkInterface.ts
+++ b/src/batchedNetworkInterface.ts
@@ -1,5 +1,4 @@
 import {
-  HTTPNetworkInterface,
   HTTPFetchNetworkInterface,
   RequestAndOptions,
   Request,
@@ -58,32 +57,33 @@ export class HTTPBatchedNetworkInterface extends HTTPFetchNetworkInterface {
 
     return new Promise((resolve, reject) => {
       Promise.all(middlewarePromises).then((requestsAndOptions: RequestAndOptions[]) => {
-      return this.batchedFetchFromRemoteEndpoint(requestsAndOptions)
-        .then(result => {
-          return result.json()
-        })
-        .then(responses => {
-          const afterwaresPromises = responses.map((response, index) => {
-            return this.applyAfterwares({
-              response,
-              options: requestsAndOptions[index].options,
-            });
+        return this.batchedFetchFromRemoteEndpoint(requestsAndOptions)
+          .then(result => {
+            return result.json()
           })
+          .then(responses => {
+            const afterwaresPromises = responses.map((response, index) => {
+              return this.applyAfterwares({
+                response,
+                options: requestsAndOptions[index].options,
+              });
+            })
 
-          Promise.all(afterwaresPromises).then((responsesAndOptions: {
-            response: IResponse,
-            options: RequestInit,
-          }[]) => {
-            const results = [];
-            responsesAndOptions.forEach(({ response }) => {
-              results.push(response);
+            Promise.all(afterwaresPromises).then((responsesAndOptions: {
+              response: IResponse,
+              options: RequestInit,
+            }[]) => {
+              const results = [];
+              responsesAndOptions.forEach(({ response }) => {
+                results.push(response);
+              });
+              resolve(results);
+            }).catch((error) => {
+              reject(error);
             });
-            resolve(results);
-          }).catch((error) => {
-            reject(error);
           });
-
-        });
+      }).catch((error) => {
+        reject(error);
       });
     });
   }

--- a/src/batchedNetworkInterface.ts
+++ b/src/batchedNetworkInterface.ts
@@ -1,0 +1,90 @@
+import {
+  HTTPNetworkInterface,
+  HTTPFetchNetworkInterface,
+  RequestAndOptions,
+  Request,
+  printRequest,
+} from './networkInterface';
+
+import {
+  GraphQLResult,
+} from 'graphql';
+
+import 'whatwg-fetch';
+
+import assign = require('lodash.assign');
+
+// An implementation of the network interface that operates over HTTP and batches
+// together requests over the HTTP transport. Note that this implementation will only work correctly
+// for GraphQL server implementations that support batching. If such a server is not available, you
+// should see `addQueryMerging` instead.
+export class HTTPBatchedNetworkInterface extends HTTPFetchNetworkInterface {
+  public batchedFetchFromRemoteEndpoint(
+    requestsAndOptions: RequestAndOptions[]
+  ): Promise<IResponse> {
+    const options: RequestInit = {};
+
+    // Combine all of the options given by the middleware into one object.
+    requestsAndOptions.forEach((requestAndOptions) => {
+      assign(options, requestAndOptions.options);
+    });
+
+    // Serialize the requests to strings of JSON
+    const printedRequests = requestsAndOptions.map(({ request }) => {
+      return printRequest(request);
+    });
+
+    return fetch(this._uri, assign({}, this._opts, options, {
+      body: JSON.stringify(printedRequests),
+      headers: assign({}, options.headers, {
+        Accept: '*/*',
+        'Content-Type': 'application/json',
+      }),
+      method: 'POST',
+    }));
+  };
+
+  public batchQuery(requests: Request[]): Promise<GraphQLResult[]> {
+    const options = assign({}, this._opts);
+
+    // Apply the middlewares to each of the requests
+    const middlewarePromises: Promise<RequestAndOptions>[] = [];
+    requests.forEach((request) => {
+      middlewarePromises.push(this.applyMiddlewares({
+        request,
+        options,
+      }));
+    });
+
+    return new Promise((resolve, reject) => {
+      Promise.all(middlewarePromises).then((requestsAndOptions: RequestAndOptions[]) => {
+      return this.batchedFetchFromRemoteEndpoint(requestsAndOptions)
+        .then(result => {
+          return result.json()
+        })
+        .then(responses => {
+          const afterwaresPromises = responses.map((response, index) => {
+            return this.applyAfterwares({
+              response,
+              options: requestsAndOptions[index].options,
+            });
+          })
+
+          Promise.all(afterwaresPromises).then((responsesAndOptions: {
+            response: IResponse,
+            options: RequestInit,
+          }[]) => {
+            const results = [];
+            responsesAndOptions.forEach(({ response }) => {
+              results.push(response);
+            });
+            resolve(results);
+          }).catch((error) => {
+            reject(error);
+          });
+
+        });
+      });
+    });
+  }
+}

--- a/src/batchedNetworkInterface.ts
+++ b/src/batchedNetworkInterface.ts
@@ -59,7 +59,7 @@ export class HTTPBatchedNetworkInterface extends HTTPFetchNetworkInterface {
       Promise.all(middlewarePromises).then((requestsAndOptions: RequestAndOptions[]) => {
         return this.batchedFetchFromRemoteEndpoint(requestsAndOptions)
           .then(result => {
-            return result.json()
+            return result.json();
           })
           .then(responses => {
             const afterwaresPromises = responses.map((response, index) => {
@@ -67,7 +67,7 @@ export class HTTPBatchedNetworkInterface extends HTTPFetchNetworkInterface {
                 response,
                 options: requestsAndOptions[index].options,
               });
-            })
+            });
 
             Promise.all(afterwaresPromises).then((responsesAndOptions: {
               response: IResponse,

--- a/src/batchedNetworkInterface.ts
+++ b/src/batchedNetworkInterface.ts
@@ -3,6 +3,7 @@ import {
   RequestAndOptions,
   Request,
   printRequest,
+  BatchedNetworkInterface,
 } from './networkInterface';
 
 import {
@@ -17,7 +18,11 @@ import assign = require('lodash.assign');
 // together requests over the HTTP transport. Note that this implementation will only work correctly
 // for GraphQL server implementations that support batching. If such a server is not available, you
 // should see `addQueryMerging` instead.
-export class HTTPBatchedNetworkInterface extends HTTPFetchNetworkInterface {
+export class HTTPBatchedNetworkInterface extends HTTPFetchNetworkInterface implements BatchedNetworkInterface {
+  constructor(uri: string, opts: RequestInit) {
+    super(uri, opts);
+  };
+
   public batchedFetchFromRemoteEndpoint(
     requestsAndOptions: RequestAndOptions[]
   ): Promise<IResponse> {

--- a/src/networkInterface.ts
+++ b/src/networkInterface.ts
@@ -230,8 +230,24 @@ export class HTTPFetchNetworkInterface implements NetworkInterface {
   }
 }
 
-export function createNetworkInterface(uri: string, opts: RequestInit = {}): HTTPNetworkInterface {
-  // createNetworkInterface has batching ability by default, which is not used unless the
-  // `shouldBatch` option is passed to apollo-clietn
-  return addQueryMerging(new HTTPFetchNetworkInterface(uri, opts)) as HTTPNetworkInterface;
+// This import has to be placed here due to a bug in TypeScript:
+// https://github.com/Microsoft/TypeScript/issues/21
+import {
+  HTTPBatchedNetworkInterface,
+} from './batchedNetworkInterface';
+
+
+export function createNetworkInterface(
+  uri: string,
+  opts: RequestInit = {},
+  transportBatching = false
+): HTTPNetworkInterface {
+  if (transportBatching) {
+    // We can use transport batching rather than query merging.
+    return new HTTPBatchedNetworkInterface(uri, opts) as HTTPNetworkInterface;
+  } else {
+    // createNetworkInterface has batching ability by default through query merging,
+    // which is not used unless the `shouldBatch` option is passed to apollo-client.
+    return addQueryMerging(new HTTPFetchNetworkInterface(uri, opts)) as HTTPNetworkInterface;
+  }
 }

--- a/src/networkInterface.ts
+++ b/src/networkInterface.ts
@@ -98,7 +98,7 @@ export function printRequest(request: Request): PrintedRequest {
   return printedRequest;
 }
 
-export class HTTPFetchNetworkInterface implements HTTPNetworkInterface {
+export class HTTPFetchNetworkInterface implements NetworkInterface {
   public _uri: string;
   public _opts: RequestInit;
   public _middlewares: MiddlewareInterface[];

--- a/test/batchedNetworkInterface.ts
+++ b/test/batchedNetworkInterface.ts
@@ -48,8 +48,8 @@ describe('HTTPBatchedNetworkInterface', () => {
     batchedNetworkInterface.use(middlewares);
     batchedNetworkInterface.useAfter(afterwares);
 
-    const printedRequests = [];
-    const resultList = [];
+    const printedRequests: Array<any> = [];
+    const resultList: Array<any> = [];
     requestResultPairs.forEach(({ request, result }) => {
       printedRequests.push(printRequest(request));
       resultList.push(result);
@@ -205,7 +205,7 @@ describe('HTTPBatchedNetworkInterface', () => {
   it('middleware should be able to modify requests/options', () => {
     const changeMiddleware: MiddlewareInterface = {
       applyMiddleware({ options }, next) {
-        options.headers['Content-Length'] = '18';
+        (options as any).headers['Content-Length'] = '18';
         next();
       },
     };

--- a/test/batchedNetworkInterface.ts
+++ b/test/batchedNetworkInterface.ts
@@ -1,0 +1,167 @@
+import { assert } from 'chai';
+
+import { HTTPBatchedNetworkInterface } from '../src/batchedNetworkInterface';
+
+import {
+  Request,
+  printRequest,
+} from '../src/networkInterface';
+
+import { GraphQLResult } from 'graphql';
+
+import 'whatwg-fetch';
+
+import gql from 'graphql-tag';
+
+// This is a hack to let Typescript let us tack stuff onto the global scope.
+interface Window {
+  fetch: any;
+}
+
+export interface MockedIResponse {
+  json(): Promise<JSON>;
+}
+
+export interface MockedFetchResponse {
+  url: string;
+  opts: RequestInit;
+  result: MockedIResponse;
+  delay?: number;
+}
+
+export function createMockedIResponse(result: Object): MockedIResponse {
+  return {
+    json() {
+      return Promise.resolve(result);
+    },
+  };
+}
+
+export class MockFetch {
+  private mockedResponsesByKey : { [key: string]: MockedFetchResponse[] };
+
+  constructor(...mockedResponses: MockedFetchResponse[]) {
+    this.mockedResponsesByKey = {};
+
+    mockedResponses.forEach((mockedResponse) => {
+      this.addMockedResponse(mockedResponse);
+    });
+  }
+
+  public addMockedResponse(mockedResponse: MockedFetchResponse) {
+    const key = this.fetchParamsToKey(mockedResponse.url, mockedResponse.opts);
+    let mockedResponses = this.mockedResponsesByKey[key];
+
+    if (!mockedResponses) {
+      mockedResponses = [];
+      this.mockedResponsesByKey[key] = mockedResponses;
+    }
+
+    mockedResponses.push(mockedResponse);
+  }
+
+  public fetch(url: string, opts: RequestInit) {
+    const key = this.fetchParamsToKey(url, opts);
+    const responses = this.mockedResponsesByKey[key];
+
+    if (!responses || responses.length === 0) {
+      throw new Error(`No more mocked fetch responses for the params ${url} and ${opts}`);
+    }
+
+    const { result, delay } = responses.shift();
+
+    if (!result) {
+      throw new Error(`Mocked fetch response should contain a result.`);
+    }
+
+    return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        resolve(result);
+      }, delay ? delay: 0);
+    });
+  }
+
+  public fetchParamsToKey(url: string, opts: RequestInit): string {
+    return JSON.stringify({
+      url,
+      opts,
+    });
+  }
+
+  // Returns a "fetch" function equivalent that mocks the given responses.
+  // The function by returned by this should be tacked onto the global scope
+  // inorder to test functions that use "fetch".
+  public getFetch() {
+    return this.fetch.bind(this);
+  }
+}
+
+
+describe('HTTPBatchedNetworkInterface', () => {
+  // Helper method that tests a roundtrip given a particular set of requests to the
+  // batched network interface and the
+  const assertRoundtrip = (...requestResultPairs: {
+    request: Request,
+    result: GraphQLResult,
+  }[]) => {
+    const url = 'http://fake.com/graphql';
+    const opts = {};
+
+    const batchedNetworkInterface = new HTTPBatchedNetworkInterface(url, opts);
+    const printedRequests = [];
+    const resultList = [];
+    requestResultPairs.forEach(({ request, result }) => {
+      printedRequests.push(printRequest(request));
+      resultList.push(result);
+    });
+
+    const mockedFetch = new MockFetch({
+      url,
+      opts: {
+        body: JSON.stringify(printedRequests),
+        headers:  {
+          Accept: '*/*',
+          'Content-Type': 'application/json',
+        },
+        method: 'POST',
+      },
+      result: createMockedIResponse(resultList),
+    });
+    fetch = mockedFetch.getFetch();
+
+    return batchedNetworkInterface.batchQuery(requestResultPairs.map(({ request }) => request))
+      .then((results) => {
+        assert.deepEqual(results, resultList);
+      });
+  };
+
+  it('should construct itself correctly', () => {
+    const url = 'http://notreal.com/graphql';
+    const opts = {};
+    const batchedNetworkInterface = new HTTPBatchedNetworkInterface(url, opts);
+    assert(batchedNetworkInterface);
+    assert.equal(batchedNetworkInterface._uri, url);
+    assert.deepEqual(batchedNetworkInterface._opts, opts);
+    assert(batchedNetworkInterface.batchQuery);
+  });
+
+  it('should correctly return the result for a single request', () => {
+    const query = gql`
+      query {
+        author {
+          firstName
+          lastName
+        }
+      }`;
+    const result = {
+      data: {
+        firstName: 'John',
+        lastName: 'Smith',
+      },
+    };
+    return assertRoundtrip({
+      request: { query },
+      result,
+    });
+  });
+});

--- a/test/batchedNetworkInterface.ts
+++ b/test/batchedNetworkInterface.ts
@@ -1,6 +1,5 @@
 import { assert } from 'chai';
 
-import assign = require('lodash.assign');
 import merge = require('lodash.merge');
 
 import { HTTPBatchedNetworkInterface } from '../src/batchedNetworkInterface';
@@ -144,7 +143,7 @@ describe('HTTPBatchedNetworkInterface', () => {
   describe('errors', () => {
     it('should return errors thrown by fetch', (done) => {
       const err = new Error('Error of some kind thrown by fetch.');
-      const fetchFunc = () => { throw err };
+      const fetchFunc = () => { throw err; };
       assertRoundtrip({
         requestResultPairs: [{
           request: { query: authorQuery },
@@ -205,7 +204,7 @@ describe('HTTPBatchedNetworkInterface', () => {
 
   it('middleware should be able to modify requests/options', () => {
     const changeMiddleware: MiddlewareInterface = {
-      applyMiddleware({ request, options }, next) {
+      applyMiddleware({ options }, next) {
         options.headers['Content-Length'] = '18';
         next();
       },

--- a/test/client.ts
+++ b/test/client.ts
@@ -1660,7 +1660,11 @@ describe('client', () => {
       },
       result: createMockedIResponse([firstResult, secondResult]),
     });
-    const networkInterface = createNetworkInterface('http://not-a-real-url.com', {}, true);
+    const networkInterface = createNetworkInterface({
+      uri: 'http://not-a-real-url.com',
+      opts: {},
+      transportBatching: true,
+    });
     networkInterface.batchQuery([
       {
         query: firstQuery,

--- a/test/client.ts
+++ b/test/client.ts
@@ -1618,10 +1618,13 @@ describe('client', () => {
         }
       }`;
     const firstResult = {
-      author: {
-        firstName: 'John',
-        lastName: 'Smith',
+      data: {
+        author: {
+          firstName: 'John',
+          lastName: 'Smith',
+        },
       },
+      loading: false,
     };
     const secondQuery = gql`
       query {
@@ -1630,8 +1633,10 @@ describe('client', () => {
         }
       }`;
     const secondResult = {
-      person: {
-        name: 'Jane Smith',
+      data: {
+        person: {
+          name: 'Jane Smith',
+        },
       },
     };
     const url = 'http://not-a-real-url.com';

--- a/test/mocks/mockFetch.ts
+++ b/test/mocks/mockFetch.ts
@@ -1,0 +1,86 @@
+import 'whatwg-fetch';
+
+// This is an implementation of a mocked window.fetch implementation similar in
+// structure to the MockedNetworkInterface.
+
+export interface MockedIResponse {
+  json(): Promise<JSON>;
+}
+
+export interface MockedFetchResponse {
+  url: string;
+  opts: RequestInit;
+  result: MockedIResponse;
+  delay?: number;
+}
+
+export function createMockedIResponse(result: Object): MockedIResponse {
+  return {
+    json() {
+      return Promise.resolve(result);
+    },
+  };
+}
+
+export class MockFetch {
+  private mockedResponsesByKey: { [key: string]: MockedFetchResponse[] };
+
+  constructor(...mockedResponses: MockedFetchResponse[]) {
+    this.mockedResponsesByKey = {};
+
+    mockedResponses.forEach((mockedResponse) => {
+      this.addMockedResponse(mockedResponse);
+    });
+  }
+
+  public addMockedResponse(mockedResponse: MockedFetchResponse) {
+    const key = this.fetchParamsToKey(mockedResponse.url, mockedResponse.opts);
+    let mockedResponses = this.mockedResponsesByKey[key];
+
+    if (!mockedResponses) {
+      mockedResponses = [];
+      this.mockedResponsesByKey[key] = mockedResponses;
+    }
+
+    mockedResponses.push(mockedResponse);
+  }
+
+  public fetch(url: string, opts: RequestInit) {
+    const key = this.fetchParamsToKey(url, opts);
+    const responses = this.mockedResponsesByKey[key];
+
+    if (!responses || responses.length === 0) {
+      throw new Error(`No more mocked fetch responses for the params ${url} and ${opts}`);
+    }
+
+    const { result, delay } = responses.shift();
+
+    if (!result) {
+      throw new Error(`Mocked fetch response should contain a result.`);
+    }
+
+    return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        resolve(result);
+      }, delay ? delay : 0);
+    });
+  }
+
+  public fetchParamsToKey(url: string, opts: RequestInit): string {
+    return JSON.stringify({
+      url,
+      opts,
+    });
+  }
+
+  // Returns a "fetch" function equivalent that mocks the given responses.
+  // The function by returned by this should be tacked onto the global scope
+  // inorder to test functions that use "fetch".
+  public getFetch() {
+    return this.fetch.bind(this);
+  }
+}
+
+export function createMockFetch(...mockedResponses: MockedFetchResponse[]) {
+  return new MockFetch(...mockedResponses).getFetch();
+}

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -29,3 +29,4 @@ import './scopeQuery';
 import './errors';
 import './mockNetworkInterface';
 import './graphqlSubscriptions';
+import './batchedNetworkInterface';


### PR DESCRIPTION
Adds transport-level query batching support to Apollo Client (see #505).

TODO:

- [x] Update CHANGELOG.md with your change
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
