### PR TITLE
Enable stricter typescript compiler options

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 - 2016 Meteor Development Group, Inc.
+Copyright (c) 2015 - 2016 Meteor Development Group, Inc, Google Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 - 2016 Meteor Development Group, Inc, Google Inc.
+Copyright (c) 2015 - 2016 Meteor Development Group, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/AUTHORS
+++ b/src/AUTHORS
@@ -8,6 +8,7 @@ Clément Prévost <prevostclement@gmail.com>
 David Alan Hjelle <dahjelle+github.com@thehjellejar.com>
 Dhaivat Pandya <dhaivat@meteor.com>
 Dhaivat Pandya <dhaivatpandya@gmail.com>
+Google Inc.
 Ian Grayson <ian133@gmail.com>
 Ian MacLeod <ian@nevir.net>
 James Baxley <james.baxley@newspring.cc>

--- a/src/ObservableQuery.ts
+++ b/src/ObservableQuery.ts
@@ -157,7 +157,7 @@ export class ObservableQuery extends Observable<ApolloQueryResult> {
           if (error) {
             throw new Error(JSON.stringify(error));
           } else {
-             const mapFn = (previousResult, { queryVariables }) => {
+             const mapFn = (previousResult: any, { queryVariables }: {queryVariables: any }) => {
               return reducer(
                 previousResult, {
                   subscriptionResult: result,

--- a/src/ObservableQuery.ts
+++ b/src/ObservableQuery.ts
@@ -111,7 +111,7 @@ export class ObservableQuery extends Observable<ApolloQueryResult> {
       return Promise.resolve()
         .then(() => {
           const qid = this.queryManager.generateQueryId();
-          let combinedOptions = null;
+          let combinedOptions: any = null;
 
           if (fetchMoreOptions.query) {
             // fetch a new query
@@ -133,7 +133,7 @@ export class ObservableQuery extends Observable<ApolloQueryResult> {
         })
         .then((fetchMoreResult) => {
           const reducer = fetchMoreOptions.updateQuery;
-          const mapFn = (previousResult, { queryVariables }) => {
+          const mapFn = (previousResult: any, { queryVariables }: {queryVariables: any }) => {
             return reducer(
               previousResult, {
                 fetchMoreResult,

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -177,9 +177,9 @@ export class QueryManager {
 
     // this.store is usually the fake store we get from the Redux middleware API
     // XXX for tests, we sometimes pass in a real Redux store into the QueryManager
-    if ((<any>this.store)['subscribe']) {
+    if ((this.store as any)['subscribe']) {
       let currentStoreData: any;
-      (<any>this.store)['subscribe'](() => {
+      (this.store as any)['subscribe'](() => {
         let previousStoreData = currentStoreData || {};
         const previousStoreHasData = Object.keys(previousStoreData).length;
         currentStoreData = this.getApolloState();

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -177,9 +177,9 @@ export class QueryManager {
 
     // this.store is usually the fake store we get from the Redux middleware API
     // XXX for tests, we sometimes pass in a real Redux store into the QueryManager
-    if (this.store['subscribe']) {
-      let currentStoreData;
-      this.store['subscribe'](() => {
+    if ((<any>this.store)['subscribe']) {
+      let currentStoreData: any;
+      (<any>this.store)['subscribe'](() => {
         let previousStoreData = currentStoreData || {};
         const previousStoreHasData = Object.keys(previousStoreData).length;
         currentStoreData = this.getApolloState();
@@ -585,7 +585,7 @@ export class QueryManager {
     if (!updateQueries) {
       return [];
     }
-    const resultBehaviors = [];
+    const resultBehaviors: any[] = [];
 
     Object.keys(updateQueries).forEach((queryName) => {
       const reducer = updateQueries[queryName];
@@ -755,7 +755,7 @@ export class QueryManager {
           return result;
         }).then(() => {
 
-          let resultFromStore;
+          let resultFromStore: any;
           try {
             // ensure result is combined with data already in store
             // this will throw an error if there are missing fields in
@@ -819,7 +819,7 @@ export class QueryManager {
     let minimizedQueryString = queryString;
     let minimizedQuery = querySS;
     let minimizedQueryDoc = queryDoc;
-    let storeResult;
+    let storeResult: any;
 
     // If this is not a force fetch, we want to diff the query against the
     // store before we fetch it from the network interface.

--- a/src/afterware.ts
+++ b/src/afterware.ts
@@ -4,5 +4,5 @@ export interface AfterwareResponse {
 }
 
 export interface AfterwareInterface {
-  applyAfterware(response: AfterwareResponse, next: Function);
+  applyAfterware(response: AfterwareResponse, next: Function): any;
 }

--- a/src/batching.ts
+++ b/src/batching.ts
@@ -70,9 +70,9 @@ export class QueryBatcher {
 
   // Consumes the queue. Called on a polling interval.
   // Returns a list of promises (one for each query).
-  public consumeQueue(): Promise<GraphQLResult>[] {
+  public consumeQueue(): Promise<GraphQLResult>[] | undefined {
     if (this.queuedRequests.length < 1) {
-      return;
+      return undefined;
     }
 
     const requests: Request[] = this.queuedRequests.map((queuedRequest) => {
@@ -84,8 +84,8 @@ export class QueryBatcher {
     });
 
     const promises: Promise<GraphQLResult>[] = [];
-    const resolvers = [];
-    const rejecters = [];
+    const resolvers: any[] = [];
+    const rejecters: any[] = [];
     this.queuedRequests.forEach((fetchRequest, index) => {
       promises.push(fetchRequest.promise);
       resolvers.push(fetchRequest.resolve);

--- a/src/batching/queryMerging.ts
+++ b/src/batching/queryMerging.ts
@@ -166,7 +166,7 @@ export function unpackDataForRequest({
         currIndex += 1;
       }
 
-      const childData = isNull(data) ? null : (<any>data)[stringKey];
+      const childData = isNull(data) ? null : (data as any)[stringKey];
       let resData = childData;
       if (field.selectionSet && field.selectionSet.selections.length > 0) {
         const fieldOpts = {
@@ -210,7 +210,7 @@ export function unpackDataForRequest({
       }
 
       if (!isUndefined(childData)) {
-        (<any>unpackedData)[realName] = resData;
+        (unpackedData as any)[realName] = resData;
       }
     } else if (selection.kind === 'InlineFragment') {
       // If this is an inline fragment, then we recursively resolve the fields within the

--- a/src/batching/queryMerging.ts
+++ b/src/batching/queryMerging.ts
@@ -166,7 +166,7 @@ export function unpackDataForRequest({
         currIndex += 1;
       }
 
-      const childData = isNull(data) ? null : data[stringKey];
+      const childData = isNull(data) ? null : (<any>data)[stringKey];
       let resData = childData;
       if (field.selectionSet && field.selectionSet.selections.length > 0) {
         const fieldOpts = {
@@ -186,10 +186,10 @@ export function unpackDataForRequest({
           currIndex = selectionRet.newIndex;
           resData = childData;
         } else if (isArray(childData)) {
-          const resUnpacked = [];
+          const resUnpacked: any[] = [];
           let newIndex = 0;
 
-          childData.forEach((dataObject) => {
+          childData.forEach((dataObject: any) => {
             const selectionRet = unpackDataForRequest(assign(fieldOpts, {
               data: dataObject,
               startIndex: currIndex,
@@ -210,7 +210,7 @@ export function unpackDataForRequest({
       }
 
       if (!isUndefined(childData)) {
-        unpackedData[realName] = resData;
+        (<any>unpackedData)[realName] = resData;
       }
     } else if (selection.kind === 'InlineFragment') {
       // If this is an inline fragment, then we recursively resolve the fields within the

--- a/src/data/diffAgainstStore.ts
+++ b/src/data/diffAgainstStore.ts
@@ -196,7 +196,7 @@ export function diffSelectionSetAgainstStore({
         pushMissingField(selection);
       }
       if (included && fieldResult !== undefined) {
-        (<any>result)[resultFieldKey] = fieldResult;
+        (result as any)[resultFieldKey] = fieldResult;
       }
     } else if (isInlineFragment(selection)) {
       const typename = selection.typeCondition.name.value;

--- a/src/data/diffAgainstStore.ts
+++ b/src/data/diffAgainstStore.ts
@@ -196,7 +196,7 @@ export function diffSelectionSetAgainstStore({
         pushMissingField(selection);
       }
       if (included && fieldResult !== undefined) {
-        result[resultFieldKey] = fieldResult;
+        (<any>result)[resultFieldKey] = fieldResult;
       }
     } else if (isInlineFragment(selection)) {
       const typename = selection.typeCondition.name.value;
@@ -279,8 +279,8 @@ export function diffSelectionSetAgainstStore({
 
   // Set this to true if we don't have enough information at this level to generate a refetch
   // query, so we need to merge the selection set with the parent, rather than appending
-  let isMissing;
-  let missingSelectionSets;
+  let isMissing: any;
+  let missingSelectionSets: any;
 
   // If we weren't able to resolve some selections from the store, construct them into
   // a query we can fetch from the server
@@ -373,7 +373,7 @@ Perhaps you want to use the \`returnPartialData\` option?`,
   }
 
   if (isArray(storeValue)) {
-    let isMissing;
+    let isMissing: any;
 
     const result = storeValue.map((id) => {
       // null value in array
@@ -426,7 +426,7 @@ interface FieldDiffResult {
   isMissing?: 'true';
 }
 
-function collectUsedVariablesFromSelectionSet(selectionSet: SelectionSet) {
+function collectUsedVariablesFromSelectionSet(selectionSet: SelectionSet): any[] {
   return uniq(flatten(selectionSet.selections.map((selection) => {
     if (isField(selection)) {
       return collectUsedVariablesFromField(selection);
@@ -441,7 +441,7 @@ function collectUsedVariablesFromSelectionSet(selectionSet: SelectionSet) {
 }
 
 function collectUsedVariablesFromField(field: Field) {
-  let variables = [];
+  let variables: any[] = [];
 
   if (field.arguments) {
     variables = flatten(field.arguments.map((arg) => {
@@ -484,7 +484,7 @@ export function removeUnusedVariablesFromQuery (
   queryDef.variableDefinitions = diffedVariableDefinitions;
 }
 
-function uniq(array) {
+function uniq(array: any[]): any[] {
   return array.filter(
     (item, index, arr) =>
       arr.indexOf(item) === index);

--- a/src/data/mutationResults.ts
+++ b/src/data/mutationResults.ts
@@ -179,7 +179,7 @@ function mutationResultDeleteReducer(state: NormalizedCache, {
   return newState;
 }
 
-function removeRefsFromStoreObj(storeObj, dataId) {
+function removeRefsFromStoreObj(storeObj: any, dataId: any) {
   let affected = false;
 
   const cleanedObj = mapValues(storeObj, (value, key) => {
@@ -211,7 +211,7 @@ function removeRefsFromStoreObj(storeObj, dataId) {
 
 // Remove any occurrences of dataId in an arbitrarily nested array, and make sure that the old array
 // === the new array if nothing was changed
-export function cleanArray(originalArray, dataId) {
+export function cleanArray(originalArray: any[], dataId: any): any[] {
   if (originalArray.length && isArray(originalArray[0])) {
     // Handle arbitrarily nested arrays
     let modified = false;

--- a/src/data/scopeQuery.ts
+++ b/src/data/scopeQuery.ts
@@ -85,7 +85,7 @@ function getMatchingFields(
   pathSegment: string,
   fragmentMap: FragmentMap
 ): Field[] {
-  let matching = [];
+  let matching: any[] = [];
 
   currSelSet.selections.forEach((selection) => {
     if (isField(selection)) {

--- a/src/data/storeUtils.ts
+++ b/src/data/storeUtils.ts
@@ -44,24 +44,24 @@ function isList(value: Value): value is ListValue {
 
 function valueToObjectRepresentation(argObj: Object, name: Name, value: Value, variables?: Object) {
   if (isNumberValue(value)) {
-    (<any>argObj)[name.value] = Number(value.value);
+    (argObj as any)[name.value] = Number(value.value);
   } else if (isScalarValue(value)) {
-    (<any>argObj)[name.value] = value.value;
+    (argObj as any)[name.value] = value.value;
   } else if (isObject(value)) {
     const nestedArgObj = {};
     value.fields.map((obj) => valueToObjectRepresentation(nestedArgObj, obj.name, obj.value, variables));
-    (<any>argObj)[name.value] = nestedArgObj;
+    (argObj as any)[name.value] = nestedArgObj;
   } else if (isVariable(value)) {
     if (! variables || !(value.name.value in variables)) {
       throw new Error(`The inline argument "${value.name.value}" is expected as a variable but was not provided.`);
     }
-    const variableValue = (<any>variables)[value.name.value];
-    (<any>argObj)[name.value] = variableValue;
+    const variableValue = (variables as any)[value.name.value];
+    (argObj as any)[name.value] = variableValue;
   } else if (isList(value)) {
-    (<any>argObj)[name.value] = value.values.map((listValue) => {
+    (argObj as any)[name.value] = value.values.map((listValue) => {
       const nestedArgArrayObj = {};
       valueToObjectRepresentation(nestedArgArrayObj, name, listValue, variables);
-      return (<any>nestedArgArrayObj)[name.value];
+      return (nestedArgArrayObj as any)[name.value];
     });
   } else {
     throw new Error(`The inline argument "${name.value}" of kind "${value.kind}" is not supported.

--- a/src/data/storeUtils.ts
+++ b/src/data/storeUtils.ts
@@ -44,24 +44,24 @@ function isList(value: Value): value is ListValue {
 
 function valueToObjectRepresentation(argObj: Object, name: Name, value: Value, variables?: Object) {
   if (isNumberValue(value)) {
-    argObj[name.value] = Number(value.value);
+    (<any>argObj)[name.value] = Number(value.value);
   } else if (isScalarValue(value)) {
-    argObj[name.value] = value.value;
+    (<any>argObj)[name.value] = value.value;
   } else if (isObject(value)) {
     const nestedArgObj = {};
     value.fields.map((obj) => valueToObjectRepresentation(nestedArgObj, obj.name, obj.value, variables));
-    argObj[name.value] = nestedArgObj;
+    (<any>argObj)[name.value] = nestedArgObj;
   } else if (isVariable(value)) {
     if (! variables || !(value.name.value in variables)) {
       throw new Error(`The inline argument "${value.name.value}" is expected as a variable but was not provided.`);
     }
-    const variableValue = variables[value.name.value];
-    argObj[name.value] = variableValue;
+    const variableValue = (<any>variables)[value.name.value];
+    (<any>argObj)[name.value] = variableValue;
   } else if (isList(value)) {
-    argObj[name.value] = value.values.map((listValue) => {
+    (<any>argObj)[name.value] = value.values.map((listValue) => {
       const nestedArgArrayObj = {};
       valueToObjectRepresentation(nestedArgArrayObj, name, listValue, variables);
-      return nestedArgArrayObj[name.value];
+      return (<any>nestedArgArrayObj)[name.value];
     });
   } else {
     throw new Error(`The inline argument "${name.value}" of kind "${value.kind}" is not supported.

--- a/src/data/writeToStore.ts
+++ b/src/data/writeToStore.ts
@@ -83,12 +83,12 @@ export function writeFragmentToStore({
   const parsedFragment: FragmentDefinition = getFragmentDefinition(fragment);
   const selectionSet: SelectionSet = parsedFragment.selectionSet;
 
-  if (!(<any>result)['id']) {
+  if (!(result as any)['id']) {
     throw new Error('Result must have id when writing fragment to store.');
   }
 
   return writeSelectionSetToStore({
-    dataId: (<any>result)['id'],
+    dataId: (result as any)['id'],
     result,
     selectionSet,
     store,

--- a/src/data/writeToStore.ts
+++ b/src/data/writeToStore.ts
@@ -83,12 +83,12 @@ export function writeFragmentToStore({
   const parsedFragment: FragmentDefinition = getFragmentDefinition(fragment);
   const selectionSet: SelectionSet = parsedFragment.selectionSet;
 
-  if (!result['id']) {
+  if (!(<any>result)['id']) {
     throw new Error('Result must have id when writing fragment to store.');
   }
 
   return writeSelectionSetToStore({
-    dataId: result['id'],
+    dataId: (<any>result)['id'],
     result,
     selectionSet,
     store,
@@ -299,7 +299,7 @@ function writeFieldToStore({
   dataIdFromObject: IdGetter,
   fragmentMap?: FragmentMap,
 }) {
-  let storeValue;
+  let storeValue: any;
 
   const storeFieldName: string = storeKeyNameFromField(field, variables);
   // specifies if we need to merge existing keys in the store
@@ -321,7 +321,7 @@ function writeFieldToStore({
     // this is an array with sub-objects
     const thisIdList: Array<string> = [];
 
-    value.forEach((item, index) => {
+    value.forEach((item: any, index: any) => {
       if (isNull(item)) {
         thisIdList.push(null);
       } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -272,7 +272,7 @@ export default class ApolloClient {
     return (store: ApolloStore) => {
       this.setStore(store);
 
-      return (next) => (action) => {
+      return (next: any) => (action: any) => {
         const returnValue = next(action);
         this.queryManager.broadcastNewStore(store.getState());
         return returnValue;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,5 +6,5 @@ export interface MiddlewareRequest {
 }
 
 export interface MiddlewareInterface {
-  applyMiddleware(request: MiddlewareRequest, next: Function);
+  applyMiddleware(request: MiddlewareRequest, next: Function): void;
 }

--- a/src/networkInterface.ts
+++ b/src/networkInterface.ts
@@ -39,7 +39,7 @@ export interface NetworkInterface {
 }
 
 export interface SubscriptionNetworkInterface extends NetworkInterface {
-  subscribe(request: Request, handler: (error, result) => void): number;
+  subscribe(request: Request, handler: (error: any, result: any) => void): number;
   unsubscribe(id: Number): void;
 }
 

--- a/src/networkInterface.ts
+++ b/src/networkInterface.ts
@@ -47,8 +47,8 @@ export interface HTTPNetworkInterface extends BatchedNetworkInterface {
   _opts: RequestInit;
   _middlewares: MiddlewareInterface[];
   _afterwares: AfterwareInterface[];
-  use(middlewares: MiddlewareInterface[]);
-  useAfter(afterwares: AfterwareInterface[]);
+  use(middlewares: MiddlewareInterface[]): any;
+  useAfter(afterwares: AfterwareInterface[]): any;
 }
 
 export interface RequestAndOptions {
@@ -70,13 +70,13 @@ export function addQueryMerging(networkInterface: NetworkInterface): BatchedNetw
       // If we a have a single request, there is no point doing any merging
       // at all.
       if (requests.length === 1) {
-        return this.query(requests[0]).then((result) => {
+        return this.query(requests[0]).then((result: any) => {
           return Promise.resolve([result]);
         });
       }
 
       const composedRequest = mergeRequests(requests);
-      return this.query(composedRequest).then((composedResult) => {
+      return this.query(composedRequest).then((composedResult: any) => {
         return unpackMergedResult(composedResult, requests);
       });
     },
@@ -112,7 +112,7 @@ export function createNetworkInterface(uri: string, opts: RequestInit = {}): HTT
     options,
   }: RequestAndOptions): Promise<RequestAndOptions> {
     return new Promise((resolve, reject) => {
-      const queue = (funcs, scope) => {
+      const queue = (funcs: MiddlewareInterface[], scope: any) => {
         const next = () => {
           if (funcs.length > 0) {
             const f = funcs.shift();
@@ -137,7 +137,7 @@ export function createNetworkInterface(uri: string, opts: RequestInit = {}): HTT
     options,
   }: ResponseAndOptions): Promise<ResponseAndOptions> {
     return new Promise((resolve, reject) => {
-      const queue = (funcs, scope) => {
+      const queue = (funcs: any[], scope: any) => {
         const next = () => {
           if (funcs.length > 0) {
             const f = funcs.shift();

--- a/src/optimistic-data/store.ts
+++ b/src/optimistic-data/store.ts
@@ -24,13 +24,13 @@ export type OptimisticStore = {
   data: NormalizedCache,
 }[];
 
-const optimisticDefaultState = [];
+const optimisticDefaultState: any[] = [];
 
 export function optimistic(
   previousState = optimisticDefaultState,
-  action,
-  store,
-  config
+  action: any,
+  store: any,
+  config: any
 ): OptimisticStore {
   if (isMutationInitAction(action) && action.optimisticResponse) {
     const fakeMutationResultAction = {

--- a/src/queryPrinting.ts
+++ b/src/queryPrinting.ts
@@ -62,9 +62,9 @@ export function queryDefinition({
     variableDefinitions = null,
     name = null,
 }: QueryDefinitionOptions): OperationDefinition {
-  const selections = [];
+  const selections: any[] = [];
 
-  missingSelectionSets.forEach((missingSelectionSet: SelectionSetWithRoot, ii) => {
+  missingSelectionSets.forEach((missingSelectionSet: SelectionSetWithRoot, ii: any) => {
     if (missingSelectionSet.id === 'CANNOT_REFETCH') {
       throw new Error('diffAgainstStore did not merge selection sets correctly');
     }

--- a/src/store.ts
+++ b/src/store.ts
@@ -55,7 +55,7 @@ export interface ApolloStore {
   getState: () => any;
 }
 
-const crashReporter = store => next => action => {
+const crashReporter = (store: any) => (next: any) => (action: any) => {
   try {
     return next(action);
   } catch (err) {
@@ -74,7 +74,7 @@ export function createApolloReducer(config: ApolloReducerConfig): Function {
       // Note that we are passing the queries into this, because it reads them to associate
       // the query ID in the result with the actual query
       data: data(state.data, action, state.queries, state.mutations, config),
-      optimistic: [],
+      optimistic: [] as any,
     };
 
     // Note, we need to have the results of the
@@ -103,7 +103,7 @@ export function createApolloStore({
   config?: ApolloReducerConfig,
   reportCrashes?: boolean,
 } = {}): ApolloStore {
-  const enhancers = [];
+  const enhancers: any[] = [];
 
   if (reportCrashes === undefined) {
     reportCrashes = true;

--- a/src/util/errorHandling.ts
+++ b/src/util/errorHandling.ts
@@ -1,4 +1,4 @@
-export function tryFunctionOrLogError (f) {
+export function tryFunctionOrLogError (f: Function) {
   try {
     return f();
   } catch (e) {

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -71,10 +71,11 @@ import {
 describe('QueryManager', () => {
 
   // Standard "get id from object" method.
-  const dataIdFromObject = (object) => {
+  const dataIdFromObject = (object: any) => {
     if (object.__typename && object.id) {
       return object.__typename + '__' + object.id;
     }
+    return undefined;
   };
 
   // Helper method that serves as the constructor method for
@@ -157,7 +158,7 @@ describe('QueryManager', () => {
     query: Document,
     data: Object,
     variables?: Object,
-    done
+    done: any
   }) => {
     assertWithObserver({
       query,
@@ -204,7 +205,7 @@ describe('QueryManager', () => {
     mutation: Document,
     data: Object,
     variables?: Object,
-    done
+    done: any
   }) => {
     mockMutation(opts).then(({ result }) => {
       assert.deepEqual(result.data, opts.data);
@@ -446,8 +447,8 @@ describe('QueryManager', () => {
 
   it('uses console.error to log unhandled errors', (done) => {
     const oldError = console.error;
-    let printed;
-    console.error = (...args) => {
+    let printed: any;
+    console.error = (...args: any[]) => {
       printed = args;
     };
 
@@ -1338,7 +1339,7 @@ describe('QueryManager', () => {
       },
     };
 
-    function testReducer (state = false, action) {
+    function testReducer (state = false, action: any): boolean {
       if (action.type === 'TOGGLE') {
         return true;
       }
@@ -1381,6 +1382,7 @@ describe('QueryManager', () => {
         }
         assert.equal(handleCount, 2);
         done();
+        return undefined;
       },
     });
 
@@ -2130,7 +2132,7 @@ describe('QueryManager', () => {
 
       queryManager.resetStore();
       const currentState = queryManager.getApolloState();
-      const expectedState = {
+      const expectedState: any = {
         data: {},
         mutations: {},
         queries: {},
@@ -2464,7 +2466,7 @@ describe('QueryManager', () => {
         __typename: 'Author',
       },
     };
-    const reducerConfig = { dataIdFromObject: (x) => '$' + dataIdFromObject(x) };
+    const reducerConfig = { dataIdFromObject: (x: any) => '$' + dataIdFromObject(x) };
     const store = createApolloStore({ config: reducerConfig, reportCrashes: false });
     createQueryManager({
       networkInterface: mockNetworkInterface({
@@ -3112,7 +3114,7 @@ function testDiffing(
   });
 
   const steps = queryArray.map(({ query, fullResponse, variables }) => {
-    return (cb) => {
+    return (cb: Function) => {
       queryManager.query({
         query,
         variables,

--- a/test/client.ts
+++ b/test/client.ts
@@ -328,7 +328,7 @@ describe('client', () => {
       result: { data },
     });
 
-    const initialState = {
+    const initialState: any = {
       apollo: {
         queries: {
           '0': {
@@ -924,8 +924,8 @@ describe('client', () => {
     };
 
 
-    let networkInterface;
-    let clock;
+    let networkInterface: any;
+    let clock: any;
     beforeEach(() => {
       networkInterface = mockNetworkInterface({
         request: { query },

--- a/test/fetchMore.ts
+++ b/test/fetchMore.ts
@@ -26,7 +26,7 @@ describe('updateQuery on a simple query', () => {
   };
 
   it('triggers new result from updateQuery', () => {
-    let latestResult = null;
+    let latestResult: any = null;
     const networkInterface = mockNetworkInterface({
       request: { query },
       result,
@@ -90,7 +90,7 @@ describe('fetchMore on an observable query', () => {
     limit: 20,
   };
 
-  const result = {
+  const result: any = {
     data: {
       entry: {
         comments: [],
@@ -98,7 +98,7 @@ describe('fetchMore on an observable query', () => {
     },
   };
   const resultMore = clonedeep(result);
-  const result2 = {
+  const result2: any = {
     data: {
       comments: [],
     },
@@ -111,13 +111,13 @@ describe('fetchMore on an observable query', () => {
     result2.data.comments.push({ text: `new comment ${i}` });
   }
 
-  let latestResult = null;
+  let latestResult: any = null;
 
   let client: ApolloClient;
-  let networkInterface;
-  let sub;
+  let networkInterface: any;
+  let sub: any;
 
-  function setup(...mockedResponses) {
+  function setup(...mockedResponses: any[]) {
     networkInterface = mockNetworkInterface({
       request: {
         query,

--- a/test/fixtures/redux-todomvc/actions.ts
+++ b/test/fixtures/redux-todomvc/actions.ts
@@ -1,25 +1,25 @@
 import * as types from './types';
 
-export function addTodo(text) {
+export function addTodo(text: any): any {
   return { type: types.ADD_TODO, text };
 }
 
-export function deleteTodo(id) {
+export function deleteTodo(id: any): any {
   return { type: types.DELETE_TODO, id };
 }
 
-export function editTodo(id, text) {
+export function editTodo(id: any, text: any): any {
   return { type: types.EDIT_TODO, id, text };
 }
 
-export function completeTodo(id) {
+export function completeTodo(id: any): any {
   return { type: types.COMPLETE_TODO, id };
 }
 
-export function completeAll() {
+export function completeAll(): any {
   return { type: types.COMPLETE_ALL };
 }
 
-export function clearCompleted() {
+export function clearCompleted(): any {
   return { type: types.CLEAR_COMPLETED };
 }

--- a/test/fixtures/redux-todomvc/reducers.ts
+++ b/test/fixtures/redux-todomvc/reducers.ts
@@ -18,7 +18,7 @@ const initialState = [
   },
 ];
 
-function todos(state = initialState, action): any {
+function todos(state = initialState, action: any): any {
   switch (action.type) {
     case ADD_TODO:
       return [

--- a/test/graphqlSubscriptions.ts
+++ b/test/graphqlSubscriptions.ts
@@ -25,16 +25,16 @@ describe('GraphQL Subscriptions', () => {
     name => ({ result: { user: { name: name } }, delay: 10 })
   );
 
-  let sub1;
-  let options;
-  let watchQueryOptions;
-  let sub2;
-  let commentsQuery;
-  let commentsVariables;
-  let commentsSub;
-  let commentsResult;
-  let commentsResultMore;
-  let commentsWatchQueryOptions;
+  let sub1: any;
+  let options: any;
+  let watchQueryOptions: any;
+  let sub2: any;
+  let commentsQuery: any;
+  let commentsVariables: any;
+  let commentsSub: any;
+  let commentsResult: any;
+  let commentsResultMore: any;
+  let commentsWatchQueryOptions: any;
   beforeEach(() => {
 
     sub1 = {
@@ -65,7 +65,7 @@ describe('GraphQL Subscriptions', () => {
       variables: {
           name: 'Changping Chen',
         },
-      handler: (error, result) => {
+      handler: (error: any, result: any) => {
         // do nothing
       },
     };
@@ -154,7 +154,7 @@ describe('GraphQL Subscriptions', () => {
       reduxRootKey: 'apollo',
       store: createApolloStore(),
     });
-    options.handler = (error, result) => {
+    options.handler = (error: any, result: any) => {
       assert.deepEqual(result, results[0].result);
       done();
     };
@@ -170,7 +170,7 @@ describe('GraphQL Subscriptions', () => {
       reduxRootKey: 'apollo',
       store: createApolloStore(),
     });
-    options.handler = (error, result) => {
+    options.handler = (error: any, result: any) => {
       assert.deepEqual(result, results[numResults].result);
       numResults++;
       if (numResults === 4) {
@@ -201,7 +201,7 @@ describe('GraphQL Subscriptions', () => {
       const graphQLSubscriptionOptions = {
         subscription: commentsSub,
         variables: commentsVariables,
-        updateFunction: (prev, updateOptions) => {
+        updateFunction: (prev: any, updateOptions: any) => {
           const state = clonedeep(prev) as any;
           // prev is that data field of the query result
           // updateOptions.subscriptionResult is the result entry from the subscription result
@@ -213,7 +213,7 @@ describe('GraphQL Subscriptions', () => {
 
       obsHandle.subscribe({
         next(result) {
-          let expectedComments = [];
+          let expectedComments: any[] = [];
           for (let i = 1; i <= 11; i++) {
             expectedComments.push({ text: `comment ${i}` });
           }

--- a/test/mockNetworkInterface.ts
+++ b/test/mockNetworkInterface.ts
@@ -40,7 +40,7 @@ describe('MockSubscriptionNetworkInterface', () => {
     },
     delay: 50,
   };
-  let sub1;
+  let sub1: any;
 
   beforeEach(() => {
 
@@ -180,7 +180,7 @@ describe('MockSubscriptionNetworkInterface', () => {
   });
 
   it('correctly fires multiple results', (done) => {
-    let allResults = [];
+    let allResults: any[] = [];
     const networkInterface = mockSubscriptionNetworkInterface([sub1]);
     networkInterface.subscribe(
       {

--- a/test/mocks/mockNetworkInterface.ts
+++ b/test/mocks/mockNetworkInterface.ts
@@ -112,7 +112,7 @@ export class MockNetworkInterface implements NetworkInterface {
 export class MockSubscriptionNetworkInterface extends MockNetworkInterface implements SubscriptionNetworkInterface {
   public mockedSubscriptionsByKey: { [key: string ]: MockedSubscription[] } = {};
   public mockedSubscriptionsById: { [id: number]: MockedSubscription} = {};
-  public handlersById: {[id: number]: (error, result) => void} = {};
+  public handlersById: {[id: number]: (error: any, result: any) => void} = {};
   public subId: number;
 
   constructor(mockedSubscriptions: MockedSubscription[], mockedResponses: MockedResponse[]) {
@@ -142,7 +142,7 @@ export class MockSubscriptionNetworkInterface extends MockNetworkInterface imple
     mockedSubs.push(mockedSubscription);
   }
 
-  public subscribe(request: Request, handler: (error, result) => void): number {
+  public subscribe(request: Request, handler: (error: any, result: any) => void): number {
      const parsedRequest: ParsedRequest = {
         query: request.query,
         variables: request.variables,

--- a/test/mutationResults.ts
+++ b/test/mutationResults.ts
@@ -41,7 +41,7 @@ describe('mutation results', () => {
     }
   `;
 
-  const result = {
+  const result: any = {
     data: {
       __typename: 'Query',
       todoList: {
@@ -94,7 +94,7 @@ describe('mutation results', () => {
   };
 
   let client: ApolloClient;
-  let networkInterface;
+  let networkInterface: any;
 
   type CustomMutationBehavior = {
     type: 'CUSTOM_MUTATION_RESULT',
@@ -116,7 +116,7 @@ describe('mutation results', () => {
     return state;
   }
 
-  function setup(...mockedResponses) {
+  function setup(...mockedResponses: any[]) {
     networkInterface = mockNetworkInterface({
       request: { query },
       result,
@@ -647,7 +647,7 @@ describe('mutation results', () => {
 
     it('error handling in reducer functions', () => {
       const oldError = console.error;
-      const errors = [];
+      const errors: any[] = [];
       console.error = (msg) => {
         errors.push(msg);
       };

--- a/test/optimistic.ts
+++ b/test/optimistic.ts
@@ -48,7 +48,7 @@ describe('optimistic mutation results', () => {
     }
   `;
 
-  const result = {
+  const result: any = {
     data: {
       __typename: 'Query',
       todoList: {
@@ -101,7 +101,7 @@ describe('optimistic mutation results', () => {
   };
 
   let client: ApolloClient;
-  let networkInterface;
+  let networkInterface: any;
 
   type CustomMutationBehavior = {
     type: 'CUSTOM_MUTATION_RESULT',
@@ -123,7 +123,7 @@ describe('optimistic mutation results', () => {
     return state;
   }
 
-  function setup(...mockedResponses) {
+  function setup(...mockedResponses: any[]) {
     networkInterface = mockNetworkInterface({
       request: { query },
       result,
@@ -566,7 +566,7 @@ describe('optimistic mutation results', () => {
       });
     });
     it('can run 2 mutations concurrently and handles all intermediate states well', () => {
-      function checkBothMutationsAreApplied(expectedText1, expectedText2) {
+      function checkBothMutationsAreApplied(expectedText1: any, expectedText2: any) {
         const dataInStore = client.queryManager.getDataWithOptimisticResults();
         assert.equal((dataInStore['TodoList5'] as any).todos.length, 5);
         assert.property(dataInStore, 'Todo99');
@@ -908,9 +908,9 @@ describe('optimistic mutation - githunt comments', () => {
   };
 
   let client: ApolloClient;
-  let networkInterface;
+  let networkInterface: any;
 
-  function setup(...mockedResponses) {
+  function setup(...mockedResponses: any[]) {
     networkInterface = mockNetworkInterface({
       request: {
         query: applyTransformers(query, [addTypename]),

--- a/test/queryMerging.ts
+++ b/test/queryMerging.ts
@@ -1094,7 +1094,7 @@ describe('Query merging', () => {
             name
           }
         }`;
-      const result = {
+      const result: any = {
         author: null,
         person: {
           name: 'John Smith',
@@ -1124,7 +1124,7 @@ describe('Query merging', () => {
           firstName
           lastName
         }`;
-      const result = {
+      const result: any = {
         author: null,
         person: {
           name: 'John Smith',
@@ -1175,7 +1175,7 @@ describe('Query merging', () => {
           firstName
           lastName
         }`;
-      const result = {
+      const result: any = {
         author: {
           firstName: null,
           lastName: 'Smith',

--- a/test/readFromStore.ts
+++ b/test/readFromStore.ts
@@ -107,7 +107,7 @@ describe('reading from the store', () => {
   });
 
   it('runs a nested fragment', () => {
-    const result = {
+    const result: any = {
       id: 'abcd',
       stringField: 'This is a string!',
       numberField: 5,
@@ -158,7 +158,7 @@ describe('reading from the store', () => {
   });
 
   it('runs a nested fragment with an array without IDs', () => {
-    const result = {
+    const result: any = {
       id: 'abcd',
       stringField: 'This is a string!',
       numberField: 5,
@@ -221,7 +221,7 @@ describe('reading from the store', () => {
   });
 
   it('runs a nested fragment with an array without IDs and a null', () => {
-    const result = {
+    const result: any = {
       id: 'abcd',
       stringField: 'This is a string!',
       numberField: 5,
@@ -276,7 +276,7 @@ describe('reading from the store', () => {
   });
 
   it('runs a nested fragment with an array with IDs and a null', () => {
-    const result = {
+    const result: any = {
       id: 'abcd',
       stringField: 'This is a string!',
       numberField: 5,
@@ -383,7 +383,7 @@ describe('reading from the store', () => {
   });
 
   it('runs a nested fragment where the reference is null', () => {
-    const result = {
+    const result: any = {
       id: 'abcd',
       stringField: 'This is a string!',
       numberField: 5,
@@ -419,7 +419,7 @@ describe('reading from the store', () => {
   });
 
   it('runs an array of non-objects', () => {
-    const result = {
+    const result: any = {
       id: 'abcd',
       stringField: 'This is a string!',
       numberField: 5,
@@ -455,7 +455,7 @@ describe('reading from the store', () => {
   });
 
   it('runs an array of non-objects with null', () => {
-    const result = {
+    const result: any = {
       id: 'abcd',
       stringField: 'This is a string!',
       numberField: 5,

--- a/test/roundtrip.ts
+++ b/test/roundtrip.ts
@@ -269,7 +269,7 @@ describe('roundtrip', () => {
   });
 });
 
-function storeRoundtrip(query: Document, result, variables = {}) {
+function storeRoundtrip(query: Document, result: any, variables = {}) {
   const fragmentMap = createFragmentMap(getFragmentDefinitions(query));
   const store = writeQueryToStore({
     result,

--- a/test/scheduler.ts
+++ b/test/scheduler.ts
@@ -364,7 +364,7 @@ describe('QueryScheduler', () => {
     scheduler.addQueryOnInterval(queryId, queryOptions);
     assert.equal(Object.keys(scheduler.intervalQueries).length, 1);
     assert.equal(Object.keys(scheduler.intervalQueries)[0], queryOptions.pollInterval.toString());
-    const queries = scheduler.intervalQueries[queryOptions.pollInterval.toString()];
+    const queries = (<any>scheduler.intervalQueries)[queryOptions.pollInterval.toString()];
     assert.equal(queries.length, 1);
     assert.equal(queries[0], queryId);
   });
@@ -434,7 +434,7 @@ describe('QueryScheduler', () => {
     assert.equal(keys.length, 1);
     assert.equal(keys[0], interval);
 
-    const queryIds = scheduler.intervalQueries[keys[0]];
+    const queryIds = (<any>scheduler.intervalQueries)[keys[0]];
     assert.equal(queryIds.length, 2);
     assert.deepEqual(scheduler.registeredQueries[queryIds[0]], queryOptions1);
     assert.deepEqual(scheduler.registeredQueries[queryIds[1]], queryOptions2);

--- a/test/scopeQuery.ts
+++ b/test/scopeQuery.ts
@@ -255,8 +255,8 @@ describe('scoping selection set', () => {
   });
 });
 
-function extractMainSelectionSet(doc) {
-  let mainDefinition;
+function extractMainSelectionSet(doc: any) {
+  let mainDefinition: any;
 
   try {
     mainDefinition = getQueryDefinition(doc);
@@ -287,7 +287,7 @@ function scope(doc: Document, path: (string | number)[]) {
   });
 }
 
-function testScope(firstDoc, secondDoc, path) {
+function testScope(firstDoc: any, secondDoc: any, path: any) {
   assert.equal(
     print(scope(firstDoc, path)).trim(),
     print(secondDoc).trim()

--- a/test/store.ts
+++ b/test/store.ts
@@ -41,7 +41,7 @@ describe('createApolloStore', () => {
   });
 
   it('can be rehydrated from the server', () => {
-    const initialState = {
+    const initialState: any = {
       apollo: {
         queries: {
           'test.0': true,
@@ -74,7 +74,7 @@ describe('createApolloStore', () => {
       },
     };
 
-    const emptyState = {
+    const emptyState: any = {
       queries: { },
       mutations: { },
       data: { },
@@ -94,7 +94,7 @@ describe('createApolloStore', () => {
   });
 
   it('can reset itself and keep the observable query ids', () => {
-    const initialState = {
+    const initialState: any = {
       apollo: {
         queries: {
           'test.0': true,
@@ -109,7 +109,7 @@ describe('createApolloStore', () => {
       },
     };
 
-    const emptyState = {
+    const emptyState: any = {
       queries: {
         'test.0': true,
       },

--- a/test/store.ts
+++ b/test/store.ts
@@ -41,7 +41,7 @@ describe('createApolloStore', () => {
   });
 
   it('can be rehydrated from the server', () => {
-    const initialState: any = {
+    const initialState = {
       apollo: {
         queries: {
           'test.0': true,
@@ -50,7 +50,7 @@ describe('createApolloStore', () => {
         data: {
           'test.0': true,
         },
-        optimistic: [],
+        optimistic: ([] as any[]),
       },
     };
 
@@ -74,11 +74,11 @@ describe('createApolloStore', () => {
       },
     };
 
-    const emptyState: any = {
+    const emptyState = {
       queries: { },
       mutations: { },
       data: { },
-      optimistic: [],
+      optimistic: ([] as any[]),
     };
 
     const store = createApolloStore({
@@ -94,7 +94,7 @@ describe('createApolloStore', () => {
   });
 
   it('can reset itself and keep the observable query ids', () => {
-    const initialState: any = {
+    const initialState = {
       apollo: {
         queries: {
           'test.0': true,
@@ -105,17 +105,17 @@ describe('createApolloStore', () => {
           'test.0': true,
           'test.1': true,
         },
-        optimistic: [],
+        optimistic: ([] as any[]),
       },
     };
 
-    const emptyState: any = {
+    const emptyState = {
       queries: {
         'test.0': true,
       },
       mutations: {},
       data: {},
-      optimistic: [],
+      optimistic: ([] as any[]),
     };
 
     const store = createApolloStore({

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -5,7 +5,7 @@ import 'isomorphic-fetch';
 
 process.env.NODE_ENV = 'test';
 
-declare function require(name: string);
+declare function require(name: string): any;
 require('source-map-support').install();
 
 import './writeToStore';

--- a/test/writeToStore.ts
+++ b/test/writeToStore.ts
@@ -40,7 +40,7 @@ describe('writing to the store', () => {
       }
     `;
 
-    const result = {
+    const result: any = {
       id: 'abcd',
       stringField: 'This is a string!',
       numberField: 5,
@@ -65,7 +65,7 @@ describe('writing to the store', () => {
       }
     `;
 
-    const result = {
+    const result: any = {
       id: 'abcd',
       aliasedField: 'This is a string!',
       numberField: 5,
@@ -98,7 +98,7 @@ describe('writing to the store', () => {
       }
     `;
 
-    const result = {
+    const result: any = {
       id: 'abcd',
       aliasedField1: 'The arg was 1!',
       aliasedField2: 'The arg was 2!',
@@ -138,7 +138,7 @@ describe('writing to the store', () => {
       stringArg: 'This is a string!',
     };
 
-    const result = {
+    const result: any = {
       id: 'abcd',
       stringField: 'Heyo',
       numberField: 5,
@@ -177,7 +177,7 @@ describe('writing to the store', () => {
       }
     `;
 
-    const result = {
+    const result: any = {
       id: 'abcd',
       stringField: 'This is a string!',
       numberField: 5,
@@ -221,7 +221,7 @@ describe('writing to the store', () => {
       }
     `;
 
-    const result = {
+    const result: any = {
       id: 'abcd',
       stringField: 'This is a string!',
       numberField: 5,
@@ -263,7 +263,7 @@ describe('writing to the store', () => {
       }
     `;
 
-    const result = {
+    const result: any = {
       id: 'abcd',
       stringField: 'This is a string!',
       numberField: 5,
@@ -306,7 +306,7 @@ describe('writing to the store', () => {
       }
     `;
 
-    const result = {
+    const result: any = {
       id: 'abcd',
       stringField: 'This is a string!',
       numberField: 5,
@@ -356,7 +356,7 @@ describe('writing to the store', () => {
       }
     `;
 
-    const result = {
+    const result: any = {
       id: 'abcd',
       stringField: 'This is a string!',
       numberField: 5,
@@ -402,7 +402,7 @@ describe('writing to the store', () => {
       }
     `;
 
-    const result = {
+    const result: any = {
       id: 'abcd',
       stringField: 'This is a string!',
       numberField: 5,
@@ -453,7 +453,7 @@ describe('writing to the store', () => {
       }
     `;
 
-    const result = {
+    const result: any = {
       id: 'abcd',
       stringField: 'This is a string!',
       numberField: 5,
@@ -495,7 +495,7 @@ describe('writing to the store', () => {
       }
     `;
 
-    const result = {
+    const result: any = {
       id: 'abcd',
       stringField: 'This is a string!',
       numberField: 5,
@@ -534,7 +534,7 @@ describe('writing to the store', () => {
       }
     `;
 
-    const result = {
+    const result: any = {
       id: 'abcd',
       stringField: 'This is a string!',
       numberField: 5,
@@ -570,7 +570,7 @@ describe('writing to the store', () => {
       }
     `;
 
-    const result = {
+    const result: any = {
       id: 'abcd',
       numberField: 5,
       nullField: null,
@@ -590,7 +590,7 @@ describe('writing to the store', () => {
       }
     `;
 
-    const result2 = {
+    const result2: any = {
       id: 'abcd',
       stringField: 'This is a string!',
       nullField: null,
@@ -624,7 +624,7 @@ describe('writing to the store', () => {
       }
     `;
 
-    const result = {
+    const result: any = {
       id: 'abcd',
       stringField: 'This is a string!',
       numberField: 5,
@@ -652,7 +652,7 @@ describe('writing to the store', () => {
       }
     `;
 
-    const result = {
+    const result: any = {
       people_one: {
         id: 'abcd',
         stringField: 'This is a string!',
@@ -758,7 +758,7 @@ describe('writing to the store', () => {
       }
     `;
 
-    const result = {
+    const result: any = {
       some_mutation: {
         id: 'id',
       },
@@ -767,7 +767,7 @@ describe('writing to the store', () => {
       },
     };
 
-    const variables = {
+    const variables: any = {
       nil: null,
       in: {
         id: '5',
@@ -813,10 +813,11 @@ describe('writing to the store', () => {
   });
 
   describe('type escaping', () => {
-    const dataIdFromObject = (object) => {
+    const dataIdFromObject = (object: any) => {
       if (object.__typename && object.id) {
         return object.__typename + '__' + object.id;
       }
+      return undefined;
     };
 
     it('should correctly escape generated ids', () => {
@@ -944,10 +945,11 @@ describe('writing to the store', () => {
         __typename: 'Author',
       },
     };
-    const dataIdFromObject = (object) => {
+    const dataIdFromObject = (object: any) => {
       if (object.__typename && object.id) {
         return object.__typename + '__' + object.id;
       }
+      return undefined;
     };
     const queryWithoutId = gql`
       query {
@@ -1021,7 +1023,7 @@ describe('writing to the store', () => {
       },
     ];
 
-    const result = { mut: { id: '1' } };
+    const result: any = { mut: { id: '1' } };
 
     function isOperationDefinition(value: Node): value is OperationDefinition {
       return value.kind === 'OperationDefinition';
@@ -1052,7 +1054,7 @@ describe('writing to the store', () => {
         ...notARealFragment
         fortuneCookie
       }`;
-    const result = {
+    const result: any = {
       fortuneCookie: 'Star Wars unit tests are boring',
     };
     assert.throws(() => {
@@ -1073,7 +1075,7 @@ describe('writing to the store', () => {
       }
     `;
 
-    const result = {
+    const result: any = {
       id: 'abcd',
       stringField: 'This is a string!',
       numberField: 5,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,11 +5,13 @@
     "moduleResolution": "node",
     "sourceMap": true,
     "declaration": true,
-    "noImplicitAny": false,
     "rootDir": ".",
     "outDir": "lib",
     "allowSyntheticDefaultImports": true,
-    "removeComments": true
+    "removeComments": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
   },
   "files": [
     "typings/main/index.d.ts",


### PR DESCRIPTION
Enables the following ts compiler options:
- noImplicitAny
- noImplicitReturns
- noFallthroughCasesInSwitch

This makes it easier to integrate apollo-client in other source trees with stricter compiler options. As a nice side effect, forgetting to type something becomes harder. This PR also adds the missing type annotations to make sure that tests keep passing.