### PR TITLE
[WIP] Typedoc documentation for ApolloClient features

### DIFF
--- a/src/data/readFromStore.ts
+++ b/src/data/readFromStore.ts
@@ -21,6 +21,24 @@ import {
 //   printAST,
 // } from './debug';
 
+/**
+ * Resolves the result of a query solely from the store (i.e. never hits the server).
+ *
+ * @param store The {@link NormalizedCache} used by Apollo for the `data` portion of the store.
+ *
+ * @param query The query document to resolve from the data available in the store.
+ *
+ * @param variables A map from the name of a variable to its value. These variables can be
+ * referenced by the query document.
+ *
+ * @param returnPartialData If set to true, the query will be resolved even if all of the data
+ * needed to resolve the query is not found in the store. The data keys that are not found will not
+ * be present in the returned object. If set to false, an error will be thrown if there are fields
+ * that cannot be resolved from the store.
+ *
+ * @param fragmentMap A map from the name of a fragment to its fragment definition. These fragments
+ * can be referenced within the query document.
+ */
 export function readQueryFromStore({
   store,
   query,

--- a/src/data/store.ts
+++ b/src/data/store.ts
@@ -38,6 +38,10 @@ import {
   replaceQueryResults,
 } from './replaceQueryResults';
 
+/**
+ * This is a normalized representation of the Apollo query result cache. Briefly, it consists of
+ * a flatten representation of query result trees.
+ */
 export interface NormalizedCache {
   [dataId: string]: StoreObject;
 }

--- a/src/data/writeToStore.ts
+++ b/src/data/writeToStore.ts
@@ -56,10 +56,10 @@ import {
  * Convert a nested GraphQL result into a normalized store, where each object from the schema
  * appears exactly once.
  * @param  {Object} result Arbitrary nested JSON, returned from the GraphQL server
- * @param  {String} [fragment] The GraphQL fragment used to fetch the data in result
- * @param  {SelectionSet} [selectionSet] The parsed selection set for the subtree of the query this
+ * @param  {String} fragment The GraphQL fragment used to fetch the data in result
+ * @param  {SelectionSet} selectionSet The parsed selection set for the subtree of the query this
  *                                       result represents
- * @param  {Object} [store] The store to merge into
+ * @param  {Object} store The store to merge into
  * @return {Object} The resulting store
  */
 export function writeFragmentToStore({
@@ -97,6 +97,24 @@ export function writeFragmentToStore({
   });
 }
 
+/**
+ * Writes the result of a query to the store.
+ *
+ * @param query The query document whose result we are writing to the store.
+ *
+ * @param result The result object returned for the query document.
+ *
+ * @param store The {@link NormalizedCache} used by Apollo for the `data` portion of the store.
+ *
+ * @param variables A map from the name of a variable to its value. These variables can be
+ * referenced by the query document.
+ *
+ * @param dataIdFromObject A function that returns an object identifier given a particular result
+ * object. See the store documentation for details and an example of this function.
+ *
+ * @param fragmentMap A map from the name of a fragment to its fragment definition. These fragments
+ * can be referenced within the query document.
+ */
 export function writeQueryToStore({
   result,
   query,

--- a/src/index.ts
+++ b/src/index.ts
@@ -288,9 +288,33 @@ export default class ApolloClient {
    * See [here](https://medium.com/apollo-stack/the-concepts-of-graphql-bc68bd819be3#.3mb0cbcmc) for
    * a description of store reactivity.
    *
-   * @param options An object of type {@link WatchQueryOptions} that allows us to describe how this
-   * query should be treated e.g. whether it is a polling query, whether it should hit the server
-   * at all or just resolve from the cache, etc.
+   * `watchQuery` takes an object of options, with the following keys and values:
+   *
+   * @param query A GraphQL document that consists of a single query to be sent down to the
+   * server.
+   *
+   * @param pollInterval The time interval (in milliseconds) on which this query should be
+   * refetched from the server.
+   *
+   * @param returnPartialData This specifies whether {@link Observer} instances for this query
+   * should be updated with partial results. For example, when a portion of a query can be resolved
+   * entirely from the cache, that result will be delivered to the Observer first and the
+   * rest of the result (as provided by the server) will be returned later.
+   *
+   * @param variables A map going from variable name to variable value, where the variables are used
+   * within the GraphQL query.
+   *
+   * @param fragments A list of fragments that are returned by {@link createFragment} which can be
+   * referenced from the query document.
+   *
+   * @param forceFetch Specifies whether the client should diff the query against the cache and only
+   * fetch the portions of it that aren't already available (it does this when forceFetch is
+   * false) or it should just fetch the entire query from the server and update the cache
+   * accordingly (it does this when forceFetch is true).
+   *
+   * @param noFetch If this is set to true, the query is resolved *only* within information
+   * available in the cache (i.e. we never hit the server). If a particular field is not available
+   * in the cache, it will not be available in the result.
    */
   public watchQuery(options: WatchQueryOptions): ObservableQuery {
     this.initStore();

--- a/src/index.ts
+++ b/src/index.ts
@@ -184,7 +184,7 @@ export default class ApolloClient {
   public batchInterval: number;
 
   /**
-  * Constructs an instance.
+  * Constructs an instance of {@link ApolloClient}.
   *
   * @param networkInterface The {@link NetworkInterface} over which GraphQL documents will be sent
   * to a GraphQL spec-compliant server.
@@ -271,6 +271,27 @@ export default class ApolloClient {
     this.setStore = this.setStore.bind(this);
   }
 
+  /**
+   * This watches the results of the query according to the options specified and
+   * returns an {@link ObservableQuery}. We can subscribe to this {@link ObservableQuery} and
+   * receive updated results through a GraphQL observer.
+   * <p /><p />
+   * Note that this method is not an implementation of GraphQL subscriptions. Rather,
+   * it uses Apollo's store in order to reactively deliver updates to your query results.
+   * <p /><p />
+   * For example, suppose you call watchQuery on a GraphQL query that fetches an person's
+   * first name and last name and this person has a particular object identifer, provided by
+   * dataIdFromObject. Later, a different query fetches that same person's
+   * first and last name and his/her first name has now changed. Then, any observers associated
+   * with the results of the first query will be updated with a new result object.
+   * <p /><p />
+   * See [here](https://medium.com/apollo-stack/the-concepts-of-graphql-bc68bd819be3#.3mb0cbcmc) for
+   * a description of store reactivity.
+   *
+   * @param options An object of type {@link WatchQueryOptions} that allows us to describe how this
+   * query should be treated e.g. whether it is a polling query, whether it should hit the server
+   * at all or just resolve from the cache, etc.
+   */
   public watchQuery(options: WatchQueryOptions): ObservableQuery {
     this.initStore();
 
@@ -288,6 +309,15 @@ export default class ApolloClient {
     return this.queryManager.watchQuery(options);
   };
 
+  /**
+   * This resolves a single query according to the options specified and returns a
+   * {@link Promise} which is either resolved with the resulting data or rejected
+   * with an error.
+   *
+   * @param options An object of type {@link WatchQueryOptions} that allows us to describe
+   * how this query should be treated e.g. whether it is a polling query, whether it should hit the
+   * server at all or just resolve from the cache, etc.
+   */
   public query(options: WatchQueryOptions): Promise<ApolloQueryResult> {
     this.initStore();
 
@@ -305,6 +335,37 @@ export default class ApolloClient {
     return this.queryManager.query(options);
   };
 
+  /**
+   * This resolves a single mutation according to the options specified and returns a
+   * {@link Promise} which is either resolved with the resulting data or rejected with an
+   * error.
+   *
+   * It takes options as an object with the following keys and values:
+   *
+   * @param mutation A GraphQL document, often created with `gql` from the `graphql-tag` package,
+   * that contains a single mutation inside of it.
+   *
+   * @param variables An object that maps from the name of a variable as used in the mutation
+   * GraphQL document to that variable's value.
+   *
+   * @param fragments A list of fragments as returned by {@link createFragment}. These fragments
+   * can be referenced from within the GraphQL mutation document.
+   *
+   * @param optimisticResponse An object that represents the result of this mutation that will be
+   * optimistically stored before the server has actually returned a result. This is most often
+   * used for optimistic UI, where we want to be able to see the result of a mutation immediately,
+   * and update the UI later if any errors appear.
+   *
+   * @param updateQueries A {@link MutationQueryReducersMap}, which is map from query names to
+   * mutation query reducers. Briefly, this map defines how to incorporate the results of the
+   * mutation into the results of queries that are currently being watched by your application.
+   *
+   * @param refetchQueries A list of query names which will be refetched once this mutation has
+   * returned. This is often used if you have a set of queries which may be affected by a mutation
+   * and will have to update. Rather than writing a mutation query reducer (i.e. `updateQueries`)
+   * for this, you can simply refetch the queries that will be affected and achieve a consistent
+   * store once these queries return.
+   */
   public mutate(options: {
     mutation: Document,
     variables?: Object,
@@ -339,6 +400,9 @@ export default class ApolloClient {
     };
   };
 
+  /**
+   * This initializes the Redux store that we use as a reactive cache.
+   */
   public initStore() {
     if (this.store) {
       // Don't do anything if we already have a store

--- a/src/index.ts
+++ b/src/index.ts
@@ -205,8 +205,11 @@ export default class ApolloClient {
   * document. In fact, the @{addTypename} query transformer does exactly this.
   *
   * @param shouldBatch Determines whether multiple queries should be batched together in a single
-  * roundtrip. Note that if this is set to true, the {@link NetworkInterface} should implement
-  * {@link BatchedNetworkInterface}. Every time a query is fetched, it is placed into the queue of
+  * roundtrip.
+  * <p />
+  *
+  * Note that if this is set to true, the [[NetworkInterface]] should implement
+  * [[BatchedNetworkInterface]]. Every time a query is fetched, it is placed into the queue of
   * the batcher. At the end of each batcher time interval, the query batcher batches together
   * (if shouldBatch is true) each of the queries in the queue and sends them to the server.
   * This happens transparently: each query will still receive exactly the result it asked for,

--- a/src/index.ts
+++ b/src/index.ts
@@ -184,44 +184,44 @@ export default class ApolloClient {
   public batchInterval: number;
 
   /**
-  * Constructs an instance of {@link ApolloClient}.
-  *
-  * @param networkInterface The {@link NetworkInterface} over which GraphQL documents will be sent
-  * to a GraphQL spec-compliant server.
-  *
-  * @param reduxRootKey The root key within the Redux store in which data fetched from the server
-  * will be stored.
-  *
-  * @param initialState The initial state assigned to the store.
-  *
-  * @param dataIdFromObject A function that returns a object identifier given a particular result
-    object.
-  *
-  * @param queryTransformer A function that takes a {@link SelectionSet} and modifies it in place
-  * in some way. The query transformer is then applied to the every GraphQL document before it is
-  * sent to the server.
-  *
-  * For example, a query transformer can add the __typename field to every level of a GraphQL
-  * document. In fact, the @{addTypename} query transformer does exactly this.
-  *
-  * @param shouldBatch Determines whether multiple queries should be batched together in a single
-  * roundtrip.
-  * <p />
-  *
-  * Note that if this is set to true, the [[NetworkInterface]] should implement
-  * [[BatchedNetworkInterface]]. Every time a query is fetched, it is placed into the queue of
-  * the batcher. At the end of each batcher time interval, the query batcher batches together
-  * (if shouldBatch is true) each of the queries in the queue and sends them to the server.
-  * This happens transparently: each query will still receive exactly the result it asked for,
-  * regardless of whether or not it is batched.
-  *
-  * @param ssrMode Determines whether this is being run in Server Side Rendering (SSR) mode.
-  *
-  * @param ssrForceFetchDelay Determines the time interval before we force fetch queries for a
-  * server side render.
-  *
-  * @param batchInterval The time interval on which the query batcher operates.
-  **/
+   * Constructs an instance of {@link ApolloClient}.
+   *
+   * @param networkInterface The {@link NetworkInterface} over which GraphQL documents will be sent
+   * to a GraphQL spec-compliant server.
+   *
+   * @param reduxRootKey The root key within the Redux store in which data fetched from the server
+   * will be stored.
+   *
+   * @param initialState The initial state assigned to the store.
+   *
+   * @param dataIdFromObject A function that returns a object identifier given a particular result
+   * object.
+   *
+   * @param queryTransformer A function that takes a {@link SelectionSet} and modifies it in place
+   * in some way. The query transformer is then applied to the every GraphQL document before it is
+   * sent to the server.
+   *
+   * For example, a query transformer can add the __typename field to every level of a GraphQL
+   * document. In fact, the @{addTypename} query transformer does exactly this.
+   *
+   * @param shouldBatch Determines whether multiple queries should be batched together in a single
+   * roundtrip.
+   * <p />
+   *
+   * Note that if this is set to true, the [[NetworkInterface]] should implement
+   * [[BatchedNetworkInterface]]. Every time a query is fetched, it is placed into the queue of
+   * the batcher. At the end of each batcher time interval, the query batcher batches together
+   * (if shouldBatch is true) each of the queries in the queue and sends them to the server.
+   * This happens transparently: each query will still receive exactly the result it asked for,
+   * regardless of whether or not it is batched.
+   *
+   * @param ssrMode Determines whether this is being run in Server Side Rendering (SSR) mode.
+   *
+   * @param ssrForceFetchDelay Determines the time interval before we force fetch queries for a
+   * server side render.
+   *
+   * @param batchInterval The time interval on which the query batcher operates.
+   */
   constructor({
     networkInterface,
     reduxRootKey,
@@ -408,6 +408,9 @@ export default class ApolloClient {
     return this.queryManager.startGraphQLSubscription(options);
   }
 
+  /**
+   * Returns a reducer function configured according to the `reducerConfig` instance variable.
+   */
   public reducer(): Function {
     return createApolloReducer(this.reducerConfig);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,7 +144,7 @@ this in the docs: http://docs.apollostack.com/`);
     }
   });
 
-  return fragments.concat(fragmentDefinitions);
+  return (fragments as FragmentDefinition[]).concat(fragmentDefinitions);
 }
 
 // This function disables the warnings printed about fragment names. One place where this chould be
@@ -164,11 +164,11 @@ export function clearFragmentDefinitions() {
 }
 
 /**
-* This is the primary Apollo Client class. It is used to send GraphQL documents (i.e. queries
-* and mutations) to a GraphQL spec-compliant server over a {@link NetworkInterface} instance,
-* receive results from the server and cache the results in a Redux store. It also delivers updates
-* to GraphQL queries through {@link Observable} instances.
-**/
+ * This is the primary Apollo Client class. It is used to send GraphQL documents (i.e. queries
+ * and mutations) to a GraphQL spec-compliant server over a {@link NetworkInterface} instance,
+ * receive results from the server and cache the results in a Redux store. It also delivers updates
+ * to GraphQL queries through {@link Observable} instances.
+ */
 export default class ApolloClient {
   public networkInterface: NetworkInterface;
   public store: ApolloStore;

--- a/src/index.ts
+++ b/src/index.ts
@@ -163,7 +163,12 @@ export function clearFragmentDefinitions() {
   fragmentDefinitionsMap = {};
 }
 
-
+/**
+* This is the primary Apollo Client class. It is used to send GraphQL documents (i.e. queries
+* and mutations) to a GraphQL spec-compliant server over a {@link NetworkInterface} instance,
+* receive results from the server and cache the results in a Redux store. It also delivers updates
+* to GraphQL queries through {@link Observable} instances.
+**/
 export default class ApolloClient {
   public networkInterface: NetworkInterface;
   public store: ApolloStore;
@@ -178,6 +183,42 @@ export default class ApolloClient {
   public fieldWithArgs: (fieldName: string, args?: Object) => string;
   public batchInterval: number;
 
+  /**
+  * Constructs an instance.
+  *
+  * @param networkInterface The {@link NetworkInterface} over which GraphQL documents will be sent
+  * to a GraphQL spec-compliant server.
+  *
+  * @param reduxRootKey The root key within the Redux store in which data fetched from the server
+  * will be stored.
+  *
+  * @param initialState The initial state assigned to the store.
+  *
+  * @param dataIdFromObject A function that returns a object identifier given a particular result
+    object.
+  *
+  * @param queryTransformer A function that takes a {@link SelectionSet} and modifies it in place
+  * in some way. The query transformer is then applied to the every GraphQL document before it is
+  * sent to the server.
+  *
+  * For example, a query transformer can add the __typename field to every level of a GraphQL
+  * document. In fact, the @{addTypename} query transformer does exactly this.
+  *
+  * @param shouldBatch Determines whether multiple queries should be batched together in a single
+  * roundtrip. Note that if this is set to true, the {@link NetworkInterface} should implement
+  * {@link BatchedNetworkInterface}. Every time a query is fetched, it is placed into the queue of
+  * the batcher. At the end of each batcher time interval, the query batcher batches together
+  * (if shouldBatch is true) each of the queries in the queue and sends them to the server.
+  * This happens transparently: each query will still receive exactly the result it asked for,
+  * regardless of whether or not it is batched.
+  *
+  * @param ssrMode Determines whether this is being run in Server Side Rendering (SSR) mode.
+  *
+  * @param ssrForceFetchDelay Determines the time interval before we force fetch queries for a
+  * server side render.
+  *
+  * @param batchInterval The time interval on which the query batcher operates.
+  **/
   constructor({
     networkInterface,
     reduxRootKey,

--- a/src/networkInterface.ts
+++ b/src/networkInterface.ts
@@ -17,6 +17,18 @@ import {
   unpackMergedResult,
 } from './batching/queryMerging';
 
+/**
+ * This is an interface that describes an GraphQL document to be sent
+ * to the server.
+ *
+ * @param query The GraphQL document to be sent to the server. Note that this can
+ * be a mutation document or a query document.
+ *
+ * @param variables An object that maps from variable names to variable values. These variables
+ * can be referenced within the GraphQL document.
+ *
+ * @param operationName The name of the query or mutation, extracted from the GraphQL document.
+ */
 export interface Request {
   debugName?: string;
   query?: Document;

--- a/src/queries/getFromAST.ts
+++ b/src/queries/getFromAST.ts
@@ -105,6 +105,9 @@ string in a "gql" tag? http://docs.apollostack.com/apollo-client/core.html#gql`)
   return fragmentDef as FragmentDefinition;
 }
 
+/**
+ * This is an interface that describes a map from fragment names to fragment definitions.
+ */
 export interface FragmentMap {
   [fragmentName: string]: FragmentDefinition;
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -46,7 +46,10 @@ export interface Store {
   optimistic: OptimisticStore;
 }
 
-// This is our interface on top of Redux to get types in our actions
+/**
+ * This is an interface that describes the behavior of a Apollo store, which is currently
+ * implemented through redux.
+ */
 export interface ApolloStore {
   dispatch: (action: ApolloAction) => void;
 

--- a/src/util/Observable.ts
+++ b/src/util/Observable.ts
@@ -6,6 +6,8 @@ import * as $$observable from 'symbol-observable';
 export type CleanupFunction = () => void;
 export type SubscriberFunction<T> = (observer: Observer<T>) => (Subscription | CleanupFunction);
 
+const observableValue = $$observable;
+
 function isSubscription(subscription: Function | Subscription): subscription is Subscription {
   return (<Subscription>subscription).unsubscribe !== undefined;
 }
@@ -17,7 +19,7 @@ export class Observable<T> {
     this.subscriberFunction = subscriberFunction;
   }
 
-  public [$$observable]() {
+  public [observableValue]() {
     return this;
   }
 

--- a/src/util/Observable.ts
+++ b/src/util/Observable.ts
@@ -19,7 +19,7 @@ export class Observable<T> {
     this.subscriberFunction = subscriberFunction;
   }
 
-  public [observableValue]() {
+  public [observableValue as symbol]() {
     return this;
   }
 

--- a/test/mutationResults.ts
+++ b/test/mutationResults.ts
@@ -1,7 +1,12 @@
 import { assert } from 'chai';
 import mockNetworkInterface from './mocks/mockNetworkInterface';
 import ApolloClient, { addTypename } from '../src';
-import { MutationBehaviorReducerArgs, MutationBehavior, cleanArray } from '../src/data/mutationResults';
+import {
+  MutationBehaviorReducerArgs,
+  MutationBehavior,
+  cleanArray,
+  MutationQueryReducersMap,
+} from '../src/data/mutationResults';
 import { NormalizedCache, StoreObject } from '../src/data/store';
 
 import assign = require('lodash.assign');
@@ -661,9 +666,10 @@ describe('mutation results', () => {
           mutation,
           updateQueries: {
             todoList: (prev, options) => {
-              throw new Error(`Hello... It's me.`);
+              if(1) { throw new Error(`Hello... It's me.`); }
+              return {};
             },
-          },
+          } as MutationQueryReducersMap,
         });
       })
       .then(() => {


### PR DESCRIPTION
Adding Typedoc documentation for the exposed API presented by Apollo Client.

(Unfortunately, Typedoc doesn't support Typescript 2.x yet, which means that I have had to make our code less pretty in order for it to compile on Typescript 1.x).

TODO:

- [ ] Update CHANGELOG.md with your change
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
