### PR TITLE
Client Reset Store Method

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "pretest": "npm run compile",
     "test": "npm run testonly --",
     "posttest": "npm run lint",
-    "filesize": "npm run compile:browser && ./scripts/filesize.js --file=./dist/index.min.js --maxGzip=37",
+    "filesize": "npm run compile:browser && ./scripts/filesize.js --file=./dist/index.min.js --maxGzip=38",
     "compile": "tsc",
     "compile:browser": "rm -rf ./dist && mkdir ./dist && browserify ./lib/src/index.js -o=./dist/index.js && npm run minify:browser",
     "minify:browser": "uglifyjs --compress --mangle --screw-ie8 -o=./dist/index.min.js -- ./dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -299,6 +299,10 @@ export default class ApolloClient {
     }));
   };
 
+  public resetStore() {
+    this.queryManager.resetStore();
+  };
+
   private setStore(store: ApolloStore) {
     // ensure existing store has apolloReducer
     if (isUndefined(store.getState()[this.reduxRootKey])) {

--- a/test/client.ts
+++ b/test/client.ts
@@ -1594,4 +1594,14 @@ describe('client', () => {
       done();
     });
   });
+
+  it('has a resetStore method which calls QueryManager', (done) => {
+    const client = new ApolloClient();
+    client.queryManager = {
+      resetStore: () => {
+        done();
+      },
+    } as QueryManager;
+    client.resetStore();
+  });
 });


### PR DESCRIPTION
This simply exposes a `resetStore` method on the client and passes the call along to the `QueryManager`.

I added a test to confirm the `QueryManager` method gets called, but wasn't sure it was necessary to re-test the store actually being reset, since that's tested in `QueryManager`. But I'm happy to add it if we do need it.

Fixes #567