### PR TITLE
Remove unused networkInterface argument in fetchQuery

### DIFF
--- a/src/AUTHORS
+++ b/src/AUTHORS
@@ -17,6 +17,7 @@ Jonas Helfer <helfer@users.noreply.github.com>
 Jonas Helfer <jonas@helfer.email>
 Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Louis DeScioli <louis@grovelabs.io>
+Marc-Andre Giroux <mgiroux0@gmail.com>
 Martijn Walraven <martijn@martijnwalraven.com>
 Maxime Quandalle <maxime@quandalle.com>
 Oleksandr Stubailo <sashko@Oleksandrs-MacBook-Pro.local>

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -408,7 +408,7 @@ export class QueryManager {
   }
 
   public fetchQuery(queryId: string, options: WatchQueryOptions): Promise<ApolloQueryResult> {
-    return this.fetchQueryOverInterface(queryId, options, this.networkInterface);
+    return this.fetchQueryOverInterface(queryId, options);
   }
 
   public generateQueryId() {
@@ -745,7 +745,6 @@ export class QueryManager {
     querySS,
     options,
     fragmentMap,
-    networkInterface,
   }: {
     requestId: number,
     queryId: string,
@@ -753,7 +752,6 @@ export class QueryManager {
     querySS: SelectionSetWithRoot,
     options: WatchQueryOptions,
     fragmentMap: FragmentMap,
-    networkInterface: NetworkInterface,
   }): Promise<GraphQLResult> {
     const {
       variables,
@@ -826,8 +824,7 @@ export class QueryManager {
 
   private fetchQueryOverInterface(
     queryId: string,
-    options: WatchQueryOptions,
-    networkInterface: NetworkInterface
+    options: WatchQueryOptions
   ): Promise<ApolloQueryResult> {
     const {
       variables,
@@ -922,7 +919,6 @@ export class QueryManager {
         querySS: minimizedQuery,
         options,
         fragmentMap,
-        networkInterface,
       });
     }
 


### PR DESCRIPTION
👋 Was walking through the code base and noticed the `networkInterface` arg passed to `fetchQueryOverInterface` was in fact never used in that fn.

It seems like the only place where it ends up being used is in the `QueryBatcher`, which already has a reference to the `networkInterface`.

All tests and linters still pass so I assume it was indeed not needed.

TODO:
- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
- [x] Add your name and email to the AUTHORS file (optional)

