### PR TITLE
Fix issue #636

### DIFF
--- a/src/queries/getFromAST.ts
+++ b/src/queries/getFromAST.ts
@@ -34,6 +34,10 @@ string in a "gql" tag? http://docs.apollostack.com/apollo-client/core.html#gql`)
   }
 
   const definitionTypes = doc.definitions.map((definition) => {
+    if (definition.kind !== 'OperationDefinition' && definition.kind !== 'FragmentDefinition') {
+      throw new Error(`Schema type definitions not allowed in queries. Found: "${definition.kind}"`);
+    }
+
     return definition.kind;
   });
   const typeCounts = countBy(definitionTypes, identity);

--- a/test/getFromAST.ts
+++ b/test/getFromAST.ts
@@ -207,4 +207,25 @@ describe('AST utility functions', () => {
     const operationName = getOperationName(query);
     assert.equal(operationName, 'nameOfMutation');
   });
+
+  it('should throw if type definitions found in document', () => {
+    const queryWithFragments = gql`
+      fragment authorDetails on Author {
+        firstName
+        lastName
+      }
+
+      query($search: AuthorSearchInputType) {
+        author(search: $search) {
+          ...authorDetails
+        }
+      }
+
+      input AuthorSearchInputType {
+        firstName: String
+      }`;
+    assert.throws(() => {
+      getQueryDefinition(queryWithFragments);
+    }, 'Schema type definitions not allowed in queries. Found: "InputObjectTypeDefinition"');
+  });
 });

--- a/test/getFromAST.ts
+++ b/test/getFromAST.ts
@@ -209,7 +209,7 @@ describe('AST utility functions', () => {
   });
 
   it('should throw if type definitions found in document', () => {
-    const queryWithFragments = gql`
+    const queryWithTypeDefination = gql`
       fragment authorDetails on Author {
         firstName
         lastName
@@ -225,7 +225,7 @@ describe('AST utility functions', () => {
         firstName: String
       }`;
     assert.throws(() => {
-      getQueryDefinition(queryWithFragments);
+      getQueryDefinition(queryWithTypeDefination);
     }, 'Schema type definitions not allowed in queries. Found: "InputObjectTypeDefinition"');
   });
 });


### PR DESCRIPTION
Throws an error if type definitions detected in queries other than "OperationDefinition" and "FragmentDefinition".

TODO:
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
