### PR TITLE
Central update queries system from observable and subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 3 to 6 months), to signal the start of a more stable API.
 
-### vNEXT
+### vNext
+
+- Add a way to massively update queriy states when a subscription or an observable yields some new data. Discussed in [Issue #644](https://github.com/apollostack/apollo-client/issues/644), addressed in [PR #649](https://github.com/apollostack/apollo-client/pull/649)
+
+### v0.4.15
 
 - Options set in middleware can override the fetch query in the network layer. [Issue #627](https://github.com/apollostack/apollo-client/issues/627) and [PR #628](https://github.com/apollostack/apollo-client/pull/628).
 - Make `returnPartialData` work better with fragments. [PR #580](https://github.com/apollostack/apollo-client/pull/580)

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -107,6 +107,14 @@ export interface SubscriptionOptions {
   fragments?: FragmentDefinition[];
 };
 
+export interface QueryUpdateReducersMap {
+  [queryName: string]: (previousQueryResult: any, options: {
+    updateData: any,
+    queryName: string,
+    queryVariables: Object,
+  }) => any;
+};
+
 export class QueryManager {
   public pollingTimers: {[queryId: string]: NodeJS.Timer | any}; //oddity in Typescript
   public scheduler: QueryScheduler;
@@ -306,13 +314,7 @@ export class QueryManager {
   // Updates some store queries using some arbitrary data and an updateQueries reducers map
   public updateQueriesWithData(
     updateData: Object,
-    updateQueries: {
-      [queryName: string]: (previousQueryResult: any, options: {
-        updateData: any,
-        queryName: string,
-        queryVariables: Object,
-      }) => any,
-    }
+    updateQueries: QueryUpdateReducersMap
   ): void {
     Object.keys(updateQueries).forEach((queryName) => {
       const reducer = updateQueries[queryName];

--- a/src/index.ts
+++ b/src/index.ts
@@ -401,6 +401,28 @@ export default class ApolloClient {
   };
 
   /**
+   * Updates some store queries using some arbitrary data and an updateQueries reducers map
+   *
+   * This system is not made to be used by a final user but by a subscription system for injecting
+   * subscription results.
+   *
+   * @param updateData The data to inject in the updateQueries reducers
+   * @param updateQueries Reducers updating the store with the arbitrary data
+   */
+  public updateQueriesWithData(
+    updateData: Object,
+    updateQueries: {
+      [queryName: string]: (previousQueryResult: any, options: {
+        updateData: any,
+        queryName: string,
+        queryVariables: Object,
+      }) => any,
+    }
+  ): void {
+    this.queryManager.updateQueriesWithData(updateData, updateQueries);
+  }
+
+  /**
    * This initializes the Redux store that we use as a reactive cache.
    */
   public initStore() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -448,7 +448,7 @@ export default class ApolloClient {
   public updateQueriesFromSubscription(
     options: SubscriptionOptions,
     updateQueries: QueryUpdateReducersMap,
-  ): Observable<any> {
+  ): void {
     this.updateQueriesFromObservable(this.subscribe(options), updateQueries);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import {
 import {
   QueryManager,
   SubscriptionOptions,
+  QueryUpdateReducersMap,
 } from './QueryManager';
 
 import {
@@ -410,16 +411,31 @@ export default class ApolloClient {
    * @param updateQueries Reducers updating the store with the arbitrary data
    */
   public updateQueriesWithData(
-    updateData: Object,
-    updateQueries: {
-      [queryName: string]: (previousQueryResult: any, options: {
-        updateData: any,
-        queryName: string,
-        queryVariables: Object,
-      }) => any,
-    }
+    updateData: any,
+    updateQueries: QueryUpdateReducersMap,
   ): void {
     this.queryManager.updateQueriesWithData(updateData, updateQueries);
+  }
+
+  /**
+   * Updates some store queries using some arbitrary data observable and an updateQueries reducers
+   * map.
+   *
+   * This system is not made to be used by a final user but by a subscription system for injecting
+   * subscription results.
+   *
+   * @param updateDataObservable The data observable to inject in the updateQueries reducers
+   * @param updateQueries Reducers updating the store with the arbitrary data
+   */
+  public updateQueriesFromObservable(
+    updateDataObservable: Observable<any>,
+    updateQueries: QueryUpdateReducersMap,
+  ): void {
+    updateDataObservable.subscribe({
+      next: (updateData) => {
+        this.updateQueriesWithData(updateData, updateQueries);
+      },
+    });
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -439,6 +439,20 @@ export default class ApolloClient {
   }
 
   /**
+   * Update the store when a subscription fires new data merging the data using an updateQueries
+   * reducer map.
+   *
+   * @param options Subscription options
+   * @param updateQueries Reducers updating the store with the subscription data
+   */
+  public updateQueriesFromSubscription(
+    options: SubscriptionOptions,
+    updateQueries: QueryUpdateReducersMap,
+  ): Observable<any> {
+    this.updateQueriesFromObservable(this.subscribe(options), updateQueries);
+  }
+
+  /**
    * This initializes the Redux store that we use as a reactive cache.
    */
   public initStore() {

--- a/test/client.ts
+++ b/test/client.ts
@@ -47,6 +47,10 @@ import {
 } from '../src/QueryManager';
 
 import {
+  Observable,
+} from '../src/util/Observable';
+
+import {
   createNetworkInterface,
   HTTPNetworkInterface,
   Request,
@@ -1695,11 +1699,7 @@ describe('client', () => {
         result: 3,
       };
       const updateQueries = {
-        addQuery: (prev: any, {updateData}: {
-          updateData: any,
-          queryName: string,
-          queryVariables: Object,
-        }) => ({
+        addQuery: (prev: any, {updateData}: any) => ({
           result: prev.result + updateData.result,
         }),
       };
@@ -1720,6 +1720,61 @@ describe('client', () => {
             assert.deepEqual(result.data, data);
             client.updateQueriesWithData(arbitraryData, updateQueries);
           } else if (yieldedValues === 2) {
+            assert.deepEqual(result.data, finalData);
+            done();
+          }
+        },
+      });
+    });
+
+    it('should allow arbitrary updates on one query via an observable', (done) => {
+      const query = gql`
+        query addQuery{
+          result
+        }`;
+      const data = {
+        result: 1,
+      };
+      const arbitraryData1 = {
+        result: 1,
+      };
+      const arbitraryData2 = {
+        result: 2,
+      };
+      const finalData = {
+        result: 4,
+      };
+      const updateQueries = {
+        addQuery: (prev: any, {updateData}: any) => ({
+          result: prev.result + updateData.result,
+        }),
+      };
+      const networkInterface = mockNetworkInterface({
+        request: { query },
+        result: { data },
+      });
+      const client = new ApolloClient({
+        networkInterface,
+      });
+
+      let yieldedValues = 0;
+
+      client.watchQuery({ query }).subscribe({
+        next(result) {
+          yieldedValues += 1;
+          if (yieldedValues === 1) {
+            assert.deepEqual(result.data, data);
+            const dataObservable = new Observable<any>(observer => {
+              process.nextTick(() => {
+                observer.next(arbitraryData1);
+                process.nextTick(() => {
+                  observer.next(arbitraryData2);
+                });
+              });
+              return () => undefined;
+            });
+            client.updateQueriesFromObservable(dataObservable, updateQueries);
+          } else if (yieldedValues === 3) {
             assert.deepEqual(result.data, finalData);
             done();
           }


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

Prototype to address one point in #644.

The goal is to provide the following APIs:

## `updateQueriesFromSubscription`

Allows updating queries (via a map of query reducers) when a subscription yields data:

```js
const updateQueriesWithCommentsSubscription = {
  feedQuery(currentQueryState, {updateData}) {
    return /* a new queryState with the comment inside */;
  },
  notifications(currentQueryState, {updateData}) {
    return /* a new queryState with the comment added */;
  },
};

client.updateQueriesFromSubscription({
  query: gql`
    subscription comments($repoName: String!) {
      newComments(repoName: $repoName) {
        content
        postedBy {
          username
        }
        postedAt
      }
    }
  `,
}, updateQueriesWithCommentsSubscription);
```

This high-level subscriptions api is just a simple wrapper around:

## `updateQueriesFromObservable`

Given an observable emitting some data, reduce the queries:

```js
client.updateQueriesFromObservable(observable, updateQueries);
```

This, is also a simple wrapper around:

## `updateQueriesWithData`

A simple way to trigger query reducers by yielding data for them:

```js
client.updateQueriesWithData(updateData, updateQueries);
```

This is based on the query updating mechanism that already exists with `updateQuery` on the observable queries.

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
- [x] Add your name and email to the AUTHORS file (optional)
