### PR TITLE
replace queryTransform option with addTypename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Expect active development and potentially significant breaking changes in the `0
 
 ### vNEXT
 
+- **Breaking changes** Remove `queryTransform` option and replace it with `addTypename`, which
+is true by default and adds `__typename` to selection sets. [PR #671](https://github.com/apollostack/apollo-client/pull/671)
+
 ### v0.4.18
 
 - Fix bug with null fragments introduced in 0.4.16 [PR #683](https://github.com/apollostack/apollo-client/pull/683)

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,11 +64,6 @@ import {
 } from './data/extensions';
 
 import {
-  QueryTransformer,
-  addTypenameToSelectionSet,
-} from './queries/queryTransform';
-
-import {
   MutationBehavior,
   MutationBehaviorReducerMap,
   MutationQueryReducersMap,
@@ -101,7 +96,6 @@ export {
   createApolloReducer,
   readQueryFromStore,
   readFragmentFromStore,
-  addTypenameToSelectionSet as addTypename,
   writeQueryToStore,
   writeFragmentToStore,
   print as printAST,
@@ -211,7 +205,6 @@ export default class ApolloClient {
   public initialState: any;
   public queryManager: QueryManager;
   public reducerConfig: ApolloReducerConfig;
-  public queryTransformer: QueryTransformer;
   public resultTransformer: ResultTransformer;
   public resultComparator: ResultComparator;
   public shouldBatch: boolean;
@@ -219,6 +212,7 @@ export default class ApolloClient {
   public dataId: IdGetter;
   public fieldWithArgs: (fieldName: string, args?: Object) => string;
   public batchInterval: number;
+  public addTypename: boolean;
 
   /**
    * Constructs an instance of {@link ApolloClient}.
@@ -239,12 +233,6 @@ export default class ApolloClient {
    * @param dataIdFromObject A function that returns a object identifier given a particular result
    * object.
    *
-   * @param queryTransformer A function that takes a {@link SelectionSet} and modifies it in place
-   * in some way. The query transformer is then applied to the every GraphQL document before it is
-   * sent to the server.
-   *
-   * For example, a query transformer can add the __typename field to every level of a GraphQL
-   * document. In fact, the @{addTypename} query transformer does exactly this.
    *
    * @param shouldBatch Determines whether multiple queries should be batched together in a single
    * roundtrip.
@@ -263,6 +251,8 @@ export default class ApolloClient {
    * server side render.
    *
    * @param batchInterval The time interval on which the query batcher operates.
+   *
+   * @param addTypename Makes the client add `__typename` to every selection set in the query if set to true.
    */
   constructor({
     networkInterface,
@@ -270,7 +260,6 @@ export default class ApolloClient {
     reduxRootSelector,
     initialState,
     dataIdFromObject,
-    queryTransformer,
     resultTransformer,
     resultComparator,
     shouldBatch = false,
@@ -278,13 +267,13 @@ export default class ApolloClient {
     ssrForceFetchDelay = 0,
     mutationBehaviorReducers = {} as MutationBehaviorReducerMap,
     batchInterval,
+    addTypename = true,
   }: {
     networkInterface?: NetworkInterface,
     reduxRootKey?: string,
     reduxRootSelector?: string | ApolloStateSelector,
     initialState?: any,
     dataIdFromObject?: IdGetter,
-    queryTransformer?: QueryTransformer,
     resultTransformer?: ResultTransformer,
     resultComparator?: ResultComparator,
     shouldBatch?: boolean,
@@ -292,6 +281,7 @@ export default class ApolloClient {
     ssrForceFetchDelay?: number
     mutationBehaviorReducers?: MutationBehaviorReducerMap,
     batchInterval?: number,
+    addTypename?: boolean,
   } = {}) {
     if (reduxRootKey && reduxRootSelector) {
       throw new Error('Both "reduxRootKey" and "reduxRootSelector" are configured, but only one of two is allowed.');
@@ -321,7 +311,6 @@ export default class ApolloClient {
     this.initialState = initialState ? initialState : {};
     this.networkInterface = networkInterface ? networkInterface :
       createNetworkInterface('/graphql');
-    this.queryTransformer = queryTransformer;
     this.resultTransformer = resultTransformer;
     this.resultComparator = resultComparator;
     this.shouldBatch = shouldBatch;
@@ -329,6 +318,7 @@ export default class ApolloClient {
     this.dataId = dataIdFromObject;
     this.fieldWithArgs = storeKeyNameFromFieldNameAndArgs;
     this.batchInterval = batchInterval;
+    this.addTypename = addTypename;
 
     if (ssrForceFetchDelay) {
       setTimeout(() => this.shouldForceFetch = true, ssrForceFetchDelay);
@@ -523,11 +513,11 @@ export default class ApolloClient {
       networkInterface: this.networkInterface,
       reduxRootSelector: reduxRootSelector,
       store,
-      queryTransformer: this.queryTransformer,
       resultTransformer: this.resultTransformer,
       resultComparator: this.resultComparator,
       shouldBatch: this.shouldBatch,
       batchInterval: this.batchInterval,
+      addTypename: this.addTypename,
     });
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -214,6 +214,7 @@ export default class ApolloClient {
   public batchInterval: number;
   public addTypename: boolean;
 
+
   /**
    * Constructs an instance of {@link ApolloClient}.
    *
@@ -283,6 +284,11 @@ export default class ApolloClient {
     batchInterval?: number,
     addTypename?: boolean,
   } = {}) {
+    if (arguments && arguments[0] && arguments[0]['queryTransformer']) {
+      console.warn('The "queryTransformer" option was removed. Use the "addTypename" option ' +
+      ' to add __typename to queries');
+    }
+
     if (reduxRootKey && reduxRootSelector) {
       throw new Error('Both "reduxRootKey" and "reduxRootSelector" are configured, but only one of two is allowed.');
     }

--- a/test/client.ts
+++ b/test/client.ts
@@ -74,6 +74,16 @@ chai.use(chaiAsPromised);
 disableFragmentWarnings();
 
 describe('client', () => {
+  it('prints a warning if the queryTransformer option is passed', () => {
+    const realConsoleWarn = console.warn;
+    const warnings: string[] = [];
+    console.warn = (msg: string) => warnings.push(msg);
+    const client = new ApolloClient({ queryTransformer: 'blah'} as any);
+    console.warn = realConsoleWarn;
+    assert.isDefined(client);
+    assert(warnings.length === 1);
+  });
+
   it('does not require any arguments and creates store lazily', () => {
     const client = new ApolloClient();
 

--- a/test/client.ts
+++ b/test/client.ts
@@ -54,8 +54,6 @@ import {
   addQueryMerging,
 } from '../src/networkInterface';
 
-import { addTypenameToSelectionSet } from '../src/queries/queryTransform';
-
 import mockNetworkInterface from './mocks/mockNetworkInterface';
 
 import { getFragmentDefinitions } from '../src/queries/getFromAST';
@@ -320,6 +318,7 @@ describe('client', () => {
 
     const client = new ApolloClient({
       networkInterface,
+      addTypename: false,
     });
 
     return client.query({ query })
@@ -356,6 +355,7 @@ describe('client', () => {
 
     const client = new ApolloClient({
       networkInterface,
+      addTypename: false,
     });
 
     createStore(
@@ -444,6 +444,7 @@ describe('client', () => {
     const client = new ApolloClient({
       networkInterface,
       initialState,
+      addTypename: false,
     });
 
     return client.query({ query })
@@ -484,6 +485,7 @@ describe('client', () => {
     const client = new ApolloClient({
       reduxRootKey,
       networkInterface,
+      addTypename: false,
     });
 
     createStore(
@@ -525,6 +527,7 @@ describe('client', () => {
 
     const client = new ApolloClient({
       networkInterface,
+      addTypename: false,
     });
 
     return client.query({ query })
@@ -563,6 +566,7 @@ describe('client', () => {
 
     const client = new ApolloClient({
       networkInterface,
+      addTypename: false,
     });
 
     const handle = client.watchQuery({ query });
@@ -618,7 +622,7 @@ describe('client', () => {
 
     const client = new ApolloClient({
       networkInterface,
-      queryTransformer: addTypenameToSelectionSet,
+      addTypename: true,
     });
 
     client.query({ query }).then((actualResult) => {
@@ -668,7 +672,7 @@ describe('client', () => {
 
     const client = new ApolloClient({
       networkInterface,
-      queryTransformer: addTypenameToSelectionSet,
+      addTypename: true,
     });
     client.query({ forceFetch: true, query }).then((actualResult) => {
       assert.deepEqual(actualResult.data, transformedResult);
@@ -705,6 +709,7 @@ describe('client', () => {
       });
     const client = new ApolloClient({
       networkInterface,
+      addTypename: false,
     });
     client.mutate({ mutation }).then((actualResult) => {
       assert.deepEqual(actualResult.data, result);
@@ -736,6 +741,7 @@ describe('client', () => {
     });
     const client = new ApolloClient({
       networkInterface,
+      addTypename: false,
     });
     client.query({ forceFetch: true, query }).then((actualResult) => {
       assert.deepEqual(actualResult.data, result);
@@ -773,6 +779,7 @@ describe('client', () => {
     });
     const client = new ApolloClient({
       networkInterface,
+      addTypename: false,
     });
     client.query({ query }).then((actualResult) => {
       assert.deepEqual(actualResult.data, result);
@@ -805,6 +812,7 @@ describe('client', () => {
     });
     const client = new ApolloClient({
       networkInterface,
+      addTypename: false,
     });
     client.query({ query }).then((actualResult) => {
       assert.deepEqual(actualResult.data, result);
@@ -831,6 +839,7 @@ describe('client', () => {
       );
       const client = new ApolloClient({
         networkInterface,
+        addTypename: false,
       });
       // we need this so it doesn't print out a bunch of stuff we don't need
       // when we're trying to test an exception.
@@ -866,6 +875,7 @@ describe('client', () => {
     };
     const client = new ApolloClient({
       networkInterface,
+      addTypename: false,
     });
     client.query({ query }).then((actualResult) => {
       assert.deepEqual(actualResult.data, data);
@@ -889,6 +899,7 @@ describe('client', () => {
     };
     const client = new ApolloClient({
       networkInterface,
+      addTypename: false,
     });
     client.mutate({ mutation }).then((actualResult) => {
       assert.deepEqual(actualResult.data, data);
@@ -927,6 +938,7 @@ describe('client', () => {
 
       const client = new ApolloClient({
         networkInterface,
+        addTypename: false,
         dataIdFromObject: (obj: { id: any }) => obj.id,
       });
 
@@ -950,6 +962,7 @@ describe('client', () => {
 
       const client = new ApolloClient({
         networkInterface,
+        addTypename: false,
         dataIdFromObject: (obj: { id: any }) => obj.id,
       });
 
@@ -1016,6 +1029,7 @@ describe('client', () => {
     it('forces the query to rerun', () => {
       const client = new ApolloClient({
         networkInterface,
+        addTypename: false,
       });
 
       // Run a query first to initialize the store
@@ -1030,6 +1044,7 @@ describe('client', () => {
     it('can be disabled with ssrMode', () => {
       const client = new ApolloClient({
         networkInterface,
+        addTypename: false,
         ssrMode: true,
       });
 
@@ -1052,6 +1067,7 @@ describe('client', () => {
 
       const client = new ApolloClient({
         networkInterface,
+        addTypename: false,
         ssrForceFetchDelay: 100,
       });
 
@@ -1324,6 +1340,7 @@ describe('client', () => {
       });
       const client = new ApolloClient({
         networkInterface,
+        addTypename: false,
       });
       const fragmentDefs = createFragment(gql`
         fragment authorDetails on Author {
@@ -1366,6 +1383,7 @@ describe('client', () => {
       });
       const client = new ApolloClient({
         networkInterface,
+        addTypename: false,
       });
       const fragmentDefs = createFragment(gql`
         fragment authorDetails on Author {
@@ -1408,6 +1426,7 @@ describe('client', () => {
       });
       const client = new ApolloClient({
         networkInterface,
+        addTypename: false,
       });
       const fragmentDefs = createFragment(gql`
         fragment authorDetails on Author {
@@ -1482,6 +1501,7 @@ describe('client', () => {
       }));
       const client = new ApolloClient({
         networkInterface,
+        addTypename: false,
         shouldBatch: true,
       });
       const promise1 = client.query({ query: query1, fragments: personDetails });
@@ -1521,6 +1541,7 @@ describe('client', () => {
       });
       const client = new ApolloClient({
         networkInterface,
+        addTypename: false,
       });
       const fragmentDefs = createFragment(gql`
         fragment authorDetails on Author {
@@ -1620,6 +1641,7 @@ describe('client', () => {
         result: { data },
         error: networkError,
       }),
+      addTypename: false,
     });
 
     client.mutate({ mutation }).then((result) => {
@@ -1654,6 +1676,7 @@ describe('client', () => {
         request: { query: mutation },
         result: { data, errors },
       }),
+      addTypename: false,
     });
     client.mutate({ mutation }).then((result) => {
       done(new Error('Returned a result when it should not have.'));

--- a/test/fetchMore.ts
+++ b/test/fetchMore.ts
@@ -34,6 +34,7 @@ describe('updateQuery on a simple query', () => {
 
     const client = new ApolloClient({
       networkInterface,
+      addTypename: false,
     });
 
     const obsHandle = client.watchQuery({
@@ -128,6 +129,7 @@ describe('fetchMore on an observable query', () => {
 
     client = new ApolloClient({
       networkInterface,
+      addTypename: false,
     });
 
     const obsHandle = client.watchQuery({

--- a/test/graphqlSubscriptions.ts
+++ b/test/graphqlSubscriptions.ts
@@ -148,6 +148,7 @@ describe('GraphQL Subscriptions', () => {
     // This test calls directly through Apollo Client
     const client = new ApolloClient({
       networkInterface: network,
+      addTypename: false,
     });
 
     const sub = client.subscribe(options).subscribe({
@@ -174,6 +175,7 @@ describe('GraphQL Subscriptions', () => {
       networkInterface: network,
       reduxRootSelector: (state: any) => state.apollo,
       store: createApolloStore(),
+      addTypename: false,
     });
 
     const obs = queryManager.startGraphQLSubscription(options);
@@ -212,6 +214,7 @@ describe('GraphQL Subscriptions', () => {
       networkInterface: network,
       reduxRootSelector: (state: any) => state.apollo,
       store: createApolloStore(),
+      addTypename: false,
     });
 
     const sub = queryManager.startGraphQLSubscription(options).subscribe({

--- a/test/mutationResults.ts
+++ b/test/mutationResults.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 import mockNetworkInterface from './mocks/mockNetworkInterface';
-import ApolloClient, { addTypename } from '../src';
+import ApolloClient from '../src';
 import { MutationBehaviorReducerArgs, MutationBehavior, cleanArray } from '../src/data/mutationResults';
 import { NormalizedCache, StoreObject } from '../src/data/store';
 
@@ -124,7 +124,6 @@ describe('mutation results', () => {
 
     client = new ApolloClient({
       networkInterface,
-      queryTransformer: addTypename,
       dataIdFromObject: (obj: any) => {
         if (obj.id && obj.__typename) {
           return obj.__typename + obj.id;

--- a/test/optimistic.ts
+++ b/test/optimistic.ts
@@ -2,7 +2,7 @@ import * as chai from 'chai';
 const { assert } = chai;
 
 import mockNetworkInterface from './mocks/mockNetworkInterface';
-import ApolloClient, { addTypename, createFragment } from '../src';
+import ApolloClient, { createFragment } from '../src';
 import { MutationBehaviorReducerArgs, MutationBehavior, MutationQueryReducersMap } from '../src/data/mutationResults';
 import { NormalizedCache, StoreObject } from '../src/data/store';
 import { addFragmentsToDocument } from '../src/queries/getFromAST';
@@ -14,6 +14,7 @@ import gql from 'graphql-tag';
 
 import {
   applyTransformers,
+  addTypenameToSelectionSet,
 } from '../src/queries/queryTransform';
 
 describe('optimistic mutation results', () => {
@@ -131,7 +132,6 @@ describe('optimistic mutation results', () => {
 
     client = new ApolloClient({
       networkInterface,
-      queryTransformer: addTypename,
       dataIdFromObject: (obj: any) => {
         if (obj.id && obj.__typename) {
           return obj.__typename + obj.id;
@@ -913,13 +913,13 @@ describe('optimistic mutation - githunt comments', () => {
   function setup(...mockedResponses: any[]) {
     networkInterface = mockNetworkInterface({
       request: {
-        query: applyTransformers(query, [addTypename]),
+        query: applyTransformers(query, [addTypenameToSelectionSet]),
         variables,
       },
       result,
     }, {
       request: {
-        query: addFragmentsToDocument(applyTransformers(queryWithFragment, [addTypename]), fragment),
+        query: addFragmentsToDocument(applyTransformers(queryWithFragment, [addTypenameToSelectionSet]), fragment),
         variables,
       },
       result,
@@ -927,13 +927,13 @@ describe('optimistic mutation - githunt comments', () => {
 
     client = new ApolloClient({
       networkInterface,
-      queryTransformer: addTypename,
       dataIdFromObject: (obj: any) => {
         if (obj.id && obj.__typename) {
           return obj.__typename + obj.id;
         }
         return null;
       },
+      addTypename: true,
     });
 
     const obsHandle = client.watchQuery({
@@ -996,7 +996,7 @@ describe('optimistic mutation - githunt comments', () => {
 
     return setup({
       request: {
-        query: applyTransformers(mutation, [addTypename]),
+        query: applyTransformers(mutation, [addTypenameToSelectionSet]),
         variables: mutationVariables,
       },
       result: mutationResult,
@@ -1022,7 +1022,10 @@ describe('optimistic mutation - githunt comments', () => {
 
     return setup({
       request: {
-        query: addFragmentsToDocument(applyTransformers(mutationWithFragment, [addTypename]), fragmentWithTypenames),
+        query: addFragmentsToDocument(
+          applyTransformers(mutationWithFragment, [addTypenameToSelectionSet]),
+          fragmentWithTypenames
+        ),
         variables: mutationVariables,
       },
       result: mutationResult,

--- a/test/scheduler.ts
+++ b/test/scheduler.ts
@@ -9,6 +9,7 @@ import {
 } from '../src/store';
 import mockNetworkInterface from './mocks/mockNetworkInterface';
 import gql from 'graphql-tag';
+import { applyTransformers, addTypenameToSelectionSet } from '../src/queries/queryTransform';
 
 describe('QueryScheduler', () => {
   const defaultReduxRootSelector = (state: any) => state.apollo;
@@ -132,12 +133,14 @@ describe('QueryScheduler', () => {
     const myQuery = gql`
       query {
         someAuthorAlias: author {
+          __typename
           firstName
           lastName
         }
       }`;
     const data = {
       'someAuthorAlias': {
+        '__typename': 'Author',
         'firstName': 'John',
         'lastName': 'Smith',
       },
@@ -382,12 +385,14 @@ describe('QueryScheduler', () => {
     const query2 = gql`
     query {
       author {
+        __typename
         firstName
         lastName
       }
     }`;
     const data2 = {
       author: {
+        __typename: 'Author',
         firstName: 'Dhaivat',
         lastName: 'Pandya',
       },
@@ -452,6 +457,7 @@ describe('QueryScheduler', () => {
     }`;
     const data = {
       author: {
+        __typename: 'Author',
         firstName: 'John',
         lastName: 'Smith',
       },
@@ -459,7 +465,7 @@ describe('QueryScheduler', () => {
     const queryManager = new QueryManager({
       networkInterface: mockNetworkInterface(
         {
-          request: { query },
+          request: { query: applyTransformers(query, [addTypenameToSelectionSet]) },
           result: { data },
         }
       ),


### PR DESCRIPTION
This PR removes the queryTransform option from ApolloClient and adds a `addTypename` option, which is true by default. `addTypename` adds `__typename` to all selection sets in queries, mutations and subscriptions.

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change
- [x] Add your name and email to the AUTHORS file (optional)

