### PR TITLE
Failing test for subscribing twice.

### DIFF
--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -603,7 +603,7 @@ describe('QueryManager', () => {
               assert.deepEqual(result.data, data2);
               done();
             }
-          }
+          },
         });
       });
   });

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -545,7 +545,7 @@ describe('QueryManager', () => {
     });
   });
 
-  it.only('allows you to subscribe twice to the one query', (done) => {
+  it('allows you to subscribe twice to the one query', (done) => {
     const request = {
       query: gql`
         query fetchLuke($id: String) {


### PR DESCRIPTION
Because `QueryManager` uses a map of `queryResults: queryId => result`, and `queryListenerForObserver` checks diffs against query results, `next()` callbacks don't trigger for the second subscriber.

This is a particular problem as `observer.result()` internally uses a subscriber, so it's not even that unusual a use-case.