### PR TITLE
Fix #647 - Read store in returnPartialData mode if the previous queries failed or were cancelled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Expect active development and potentially significant breaking changes in the `0
 
 ### vNEXT
 - Fix: Warn but do not fail when refetchQueries includes an unknown query name [PR #700](https://github.com/apollostack/apollo-client/pull/700)
+- Fix: avoid field error on mutations after a query cancellation or a query failure by enforcing returnPartialData during previous data retrieval before applying a mutation update. [PR #696](https://github.com/apollostack/apollo-client/pull/696) and [Issue #647](https://github.com/apollostack/apollo-client/issues/647).
 
 ### v0.4.19
 - Fix: set default reduxRootKey for backwards-compatibility when using ApolloClient as middleware  [PR #688](https://github.com/apollostack/apollo-client/pull/688)

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -648,6 +648,16 @@ export class QueryManager {
       fragments = getFragmentDefinitions(transformedDoc);
     }
 
+    const queryState = this.getApolloState().queries[queryId];
+
+    // If the previous query, for some reason, did not complete correctly, we run the
+    // readSelectionSet in returnPartialData in order to avoid field reading errors
+    const forcePartialData =
+      queryState.loading ||
+      queryState.stopped ||
+      !!queryState.networkError ||
+      !!queryState.graphQLErrors;
+
     const previousResult = readSelectionSetFromStore({
       // In case of an optimistic change, apply reducer on top of the
       // results including previous optimistic updates. Otherwise, apply it
@@ -656,7 +666,7 @@ export class QueryManager {
       rootId: 'ROOT_QUERY',
       selectionSet: queryDefinition.selectionSet,
       variables: queryOptions.variables,
-      returnPartialData: queryOptions.returnPartialData || queryOptions.noFetch,
+      returnPartialData: forcePartialData || queryOptions.returnPartialData || queryOptions.noFetch,
       fragmentMap: createFragmentMap(fragments || []),
     });
 

--- a/src/queries/store.ts
+++ b/src/queries/store.ts
@@ -35,6 +35,7 @@ export interface QueryStoreValue {
   minimizedQuery: SelectionSetWithRoot;
   variables: Object;
   loading: boolean;
+  stopped: boolean;
   networkError: Error;
   graphQLErrors: GraphQLError[];
   forceFetch: boolean;
@@ -66,6 +67,7 @@ export function queries(
       minimizedQuery: action.minimizedQuery,
       variables: action.variables,
       loading: true,
+      stopped: false,
       networkError: null,
       graphQLErrors: null,
       forceFetch: action.forceFetch,
@@ -129,7 +131,10 @@ export function queries(
   } else if (isQueryStopAction(action)) {
     const newState = assign({}, previousState) as QueryStore;
 
-    delete newState[action.queryId];
+    newState[action.queryId] = assign({}, previousState[action.queryId], {
+      loading: false,
+      stopped: true,
+    }) as QueryStoreValue;
 
     return newState;
   } else if (isStoreResetAction(action)) {

--- a/test/client.ts
+++ b/test/client.ts
@@ -429,6 +429,7 @@ describe('client', () => {
             minimizedQuery: null,
             variables: undefined,
             loading: false,
+            stopped: false,
             networkError: null,
             graphQLErrors: null,
             forceFetch: false,


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

Fixes #647 

- [x] Define stopped queries as `stopped` instead of deleting them
- [x] When resolving a stopped or failed query in an update scenario, enable returnPartialData for resolution
- [x] Test the case when a more previous query failed

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
- [x] Add your name and email to the AUTHORS file (optional)
- [x] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion
