### PR TITLE
allow unknown query in refetchQueries, warn but continue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 3 to 6 months), to signal the start of a more stable API.
 
 ### vNEXT
+- Fix: Warn but do not fail when refetchQueries includes an unknown query name [PR #700](https://github.com/apollostack/apollo-client/pull/700)
 
 ### v0.4.19
 - Fix: set default reduxRootKey for backwards-compatibility when using ApolloClient as middleware  [PR #688](https://github.com/apollostack/apollo-client/pull/688)

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -996,9 +996,15 @@ export class QueryManager {
   // Refetches a query given that query's name. Refetches
   // all ObservableQuery instances associated with the query name.
   private refetchQueryByName(queryName: string) {
-    this.queryIdsByName[queryName].forEach((queryId) => {
-      this.observableQueries[queryId].observableQuery.refetch();
-    });
+    const refetchedQueries = this.queryIdsByName[queryName];
+    // Warn if the query named does not exist (misnamed, or merely not yet fetched)
+    if (!refetchedQueries) {
+      console.warn(`Warning: unknown query with name ${queryName} asked to refetch`);
+    } else {
+      refetchedQueries.forEach((queryId) => {
+        this.observableQueries[queryId].observableQuery.refetch();
+      });
+    }
   }
 
   // check to see if two results are the same, given our resultComparator

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -998,7 +998,7 @@ export class QueryManager {
   private refetchQueryByName(queryName: string) {
     const refetchedQueries = this.queryIdsByName[queryName];
     // Warn if the query named does not exist (misnamed, or merely not yet fetched)
-    if (!refetchedQueries) {
+    if (refetchedQueries === undefined) {
       console.warn(`Warning: unknown query with name ${queryName} asked to refetch`);
     } else {
       refetchedQueries.forEach((queryId) => {


### PR DESCRIPTION
Fix for bug identified in #690 and #594 (in the latter, some further API possibilities are discussed, but this addresses only the narrower case of #690).
