### PR TITLE
Apollo reducers can't crash the Redux store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Expect active development and potentially significant breaking changes in the `0
 ### vNEXT
 - Fix: Warn but do not fail when refetchQueries includes an unknown query name [PR #700](https://github.com/apollostack/apollo-client/pull/700)
 - Fix: avoid field error on mutations after a query cancellation or a query failure by enforcing returnPartialData during previous data retrieval before applying a mutation update. [PR #696](https://github.com/apollostack/apollo-client/pull/696) and [Issue #647](https://github.com/apollostack/apollo-client/issues/647).
+- Prevent Redux from crashing when an uncatched apollo error is raised in an Apollo reducer. [PR #724](https://github.com/apollostack/apollo-client/pull/724)
 
 ### v0.4.19
 - Fix: set default reduxRootKey for backwards-compatibility when using ApolloClient as middleware  [PR #688](https://github.com/apollostack/apollo-client/pull/688)

--- a/src/QueryManager.ts
+++ b/src/QueryManager.ts
@@ -881,6 +881,11 @@ export class QueryManager {
           } catch (e) {}
           /* tslint:enable */
 
+          const {reducerError} = this.getApolloState();
+          if (reducerError) {
+            throw reducerError;
+          }
+
           // return a chainable promise
           this.removeFetchQueryPromise(requestId);
           resolve({ data: resultFromStore, loading: false });

--- a/src/store.ts
+++ b/src/store.ts
@@ -44,6 +44,7 @@ export interface Store {
   queries: QueryStore;
   mutations: MutationStore;
   optimistic: OptimisticStore;
+  reducerError: Error;
 }
 
 /**
@@ -68,42 +69,38 @@ const crashReporter = (store: any) => (next: any) => (action: any) => {
   }
 };
 
-/**
- * This utility wraps the operation done by the reducer with the intent of catching thrown errors
- * and avoid crashing the redux state.
- */
-function safeReducer(reducer: Function, state: any, ...args: any[]): any {
-  try {
-    return reducer(state, ...args);
-  } catch (err) {
-    console.error('Caught an exception in Apollo Reducer!', err);
-    console.error(err.stack);
-    return state;
-  }
-}
-
 export function createApolloReducer(config: ApolloReducerConfig): Function {
   return function apolloReducer(state = {} as Store, action: ApolloAction) {
-    const newState = {
-      queries: safeReducer(queries, state.queries, action),
-      mutations: safeReducer(mutations, state.mutations, action),
+    let newState = state;
+    try {
+      newState = {
+        queries: queries(state.queries, action),
+        mutations: mutations(state.mutations, action),
 
-      // Note that we are passing the queries into this, because it reads them to associate
-      // the query ID in the result with the actual query
-      data: safeReducer(data, state.data, action, state.queries, state.mutations, config),
-      optimistic: [] as any,
-    };
+        // Note that we are passing the queries into this, because it reads them to associate
+        // the query ID in the result with the actual query
+        data: data(state.data, action, state.queries, state.mutations, config),
+        optimistic: [] as any,
+        reducerError: null,
+      };
 
-    // Note, we need to have the results of the
-    // APOLLO_MUTATION_INIT action to simulate
-    // the APOLLO_MUTATION_RESULT action. That's
-    // why we pass in newState
-    newState.optimistic = safeReducer(optimistic,
-      state.optimistic,
-      action,
-      newState,
-      config
-    );
+      // Note, we need to have the results of the
+      // APOLLO_MUTATION_INIT action to simulate
+      // the APOLLO_MUTATION_RESULT action. That's
+      // why we pass in newState
+      newState.optimistic = optimistic(
+        state.optimistic,
+        action,
+        newState,
+        config
+      );
+    } catch (reducerError) {
+      newState = Object.assign({}, state, {
+        reducerError,
+      });
+    }
+
+
 
     return newState;
   };

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -2266,6 +2266,7 @@ describe('QueryManager', () => {
         mutations: {},
         queries: {},
         optimistic: [],
+        reducerError: null,
       };
 
       assert.deepEqual(currentState, expectedState);

--- a/test/client.ts
+++ b/test/client.ts
@@ -161,6 +161,7 @@ describe('client', () => {
           mutations: {},
           data: {},
           optimistic: [],
+          reducerError: null,
         },
       }
     );
@@ -455,6 +456,7 @@ describe('client', () => {
           },
         },
         optimistic: [],
+        reducerError: null,
       },
     };
 

--- a/test/store.ts
+++ b/test/store.ts
@@ -84,6 +84,7 @@ describe('createApolloStore', () => {
       mutations: { },
       data: { },
       optimistic: ([] as any[]),
+      reducerError: (null as Error),
     };
 
     const store = createApolloStore({
@@ -122,6 +123,7 @@ describe('createApolloStore', () => {
       mutations: {},
       data: {},
       optimistic: ([] as any[]),
+      reducerError: (null as Error),
     };
 
     const store = createApolloStore({

--- a/test/store.ts
+++ b/test/store.ts
@@ -21,6 +21,7 @@ describe('createApolloStore', () => {
         mutations: {},
         data: {},
         optimistic: [],
+        reducerError: (null as Error),
       }
     );
   });
@@ -37,6 +38,7 @@ describe('createApolloStore', () => {
         mutations: {},
         data: {},
         optimistic: [],
+        reducerError: (null as Error),
       }
     );
   });
@@ -52,6 +54,7 @@ describe('createApolloStore', () => {
           'test.0': true,
         },
         optimistic: ([] as any[]),
+        reducerError: (null as Error),
       },
     };
 
@@ -72,6 +75,7 @@ describe('createApolloStore', () => {
         data: {
           'test.0': true,
         },
+        reducerError: (null as Error),
       },
     };
 
@@ -107,6 +111,7 @@ describe('createApolloStore', () => {
           'test.1': true,
         },
         optimistic: ([] as any[]),
+        reducerError: (null as Error),
       },
     };
 
@@ -144,16 +149,8 @@ describe('createApolloStore', () => {
           'test.1': true,
         },
         optimistic: ([] as any[]),
+        reducerError: (null as Error),
       },
-    };
-
-    const emptyState = {
-      queries: {
-        'test.0': true,
-      },
-      mutations: {},
-      data: {},
-      optimistic: ([] as any[]),
     };
 
     const store = createApolloStore({
@@ -184,11 +181,24 @@ describe('createApolloStore', () => {
       requestId: 1,
     });
 
+    assert.equal(
+      store.getState().apollo.reducerError.message,
+      'Cannot read property \'selections\' of undefined'
+    );
+
     store.dispatch({
       type: 'APOLLO_STORE_RESET',
       observableQueryIds: ['test.0'],
     });
 
-    assert.deepEqual(store.getState().apollo, emptyState);
+    assert.deepEqual(store.getState().apollo, {
+      queries: {
+        'test.0': true,
+      },
+      mutations: {},
+      data: {},
+      optimistic: ([] as any[]),
+      reducerError: (null as Error),
+    });
   });
 });


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:
- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
- [x] Add your name and email to the AUTHORS file (optional)
- [x] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion

We prevent throwing inside the reducer by wrapping it in a try/catch block. The error will still be reported to the user in the console though.
