### PR TITLE
Removes lodash.isarray dependency in favor of Array.isArray

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "lodash.has": "^4.3.1",
     "lodash.identity": "^3.0.0",
     "lodash.includes": "^4.1.2",
-    "lodash.isarray": "^4.0.0",
     "lodash.isboolean": "^3.0.3",
     "lodash.isequal": "^4.2.0",
     "lodash.isnull": "^3.0.0",

--- a/src/data/debug.ts
+++ b/src/data/debug.ts
@@ -1,11 +1,10 @@
 // For development only!
-import isArray = require('lodash.isarray');
 import isObject = require('lodash.isobject');
 import omit = require('lodash.omit');
 import mapValues = require('lodash.mapvalues');
 
 export function stripLoc(obj: Object) {
-  if (isArray(obj)) {
+  if (Array.isArray(obj)) {
     return obj.map(stripLoc);
   }
 

--- a/src/data/mutationResults.ts
+++ b/src/data/mutationResults.ts
@@ -10,7 +10,6 @@ import {
 } from 'graphql';
 
 import mapValues = require('lodash.mapvalues');
-import isArray = require('lodash.isarray');
 import cloneDeep = require('lodash.clonedeep');
 import assign = require('lodash.assign');
 
@@ -189,7 +188,7 @@ function removeRefsFromStoreObj(storeObj: any, dataId: any) {
       return null;
     }
 
-    if (isArray(value)) {
+    if (Array.isArray(value)) {
       const filteredArray = cleanArray(value, dataId);
 
       if (filteredArray !== value) {
@@ -213,7 +212,7 @@ function removeRefsFromStoreObj(storeObj: any, dataId: any) {
 // Remove any occurrences of dataId in an arbitrarily nested array, and make sure that the old array
 // === the new array if nothing was changed
 export function cleanArray(originalArray: any[], dataId: any): any[] {
-  if (originalArray.length && isArray(originalArray[0])) {
+  if (originalArray.length && Array.isArray(originalArray[0])) {
     // Handle arbitrarily nested arrays
     let modified = false;
     const filteredArray = originalArray.map((nestedArray) => {

--- a/src/data/writeToStore.ts
+++ b/src/data/writeToStore.ts
@@ -1,4 +1,3 @@
-import isArray = require('lodash.isarray');
 import isNull = require('lodash.isnull');
 import isUndefined = require('lodash.isundefined');
 import isObject = require('lodash.isobject');
@@ -284,7 +283,7 @@ function writeFieldToStore({
       type: 'json',
       json: value,
     };
-  } else if (isArray(value)) {
+  } else if (Array.isArray(value)) {
     // this is an array with sub-objects
     const thisIdList: Array<string> = [];
 

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -15,11 +15,6 @@ declare module 'lodash.isequal' {
   export = main.isEqual;
 }
 
-declare module 'lodash.isarray' {
-  import main = require('lodash');
-  export = main.isArray;
-}
-
 declare module 'lodash.isnull' {
   import main = require('lodash');
   export = main.isNull;


### PR DESCRIPTION
Removed `lodash.isarray` from codebase to stop npm warning on install. Switched with `Array.isArray`

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change
- [ ] Add your name and email to the AUTHORS file (optional)
- [ ] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion

