### PR TITLE
WIP: Result reducers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 3 to 6 months), to signal the start of a more stable API.
 
 ### vNEXT
-
+- ** new Feature **: Implement query reducers, which run on every query result/ mutation. [PR #766](https://github.com/apollostack/apollo-client/pull/766)
 - **Refactor**: Reimplement internal store reading in terms of the [graphql-anywhere](https://github.com/apollostack/graphql-anywhere) package, which cleanly separates the GraphQL execution logic from Apollo's specific cache format. This will allow us to make the store reading much more extensible, including enabling developers to write their own custom client-side resolvers to implement client-side computed fields, read from Redux with GraphQL, and redirect cache reads.
 - **Feature removal**: Remove query diffing functionality to make client more predictable and simplify implementation. Queries will still read from the store, and if the store does not have all of the necessary data the entire query will fetch from the server. Read justification and discussion in [Issue #615](https://github.com/apollostack/apollo-client/issues/615) [PR #693](https://github.com/apollostack/apollo-client/pull/693)
 - **Breaking change**: Move batching to network interface and split off query merging into separate package [PR #734](https://github.com/apollostack/apollo-client/pull/734)

--- a/src/ApolloClient.ts
+++ b/src/ApolloClient.ts
@@ -442,6 +442,7 @@ export default class ApolloClient {
       queryTransformer: this.queryTransformer,
       resultTransformer: this.resultTransformer,
       resultComparator: this.resultComparator,
+      reducerConfig: this.reducerConfig,
     });
   };
 }

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -16,6 +16,7 @@ export interface QueryResultAction {
   result: GraphQLResult;
   queryId: string;
   document: Document;
+  operationName: string;
   requestId: number;
 }
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -75,6 +75,7 @@ export interface MutationInitAction {
   mutationString: string;
   mutation: Document;
   variables: Object;
+  operationName: string;
   mutationId: string;
   optimisticResponse: Object;
   resultBehaviors?: MutationBehavior[];
@@ -85,10 +86,13 @@ export function isMutationInitAction(action: ApolloAction): action is MutationIn
   return action.type === 'APOLLO_MUTATION_INIT';
 }
 
+// TODO REFACOTR: simplify all these actions by providing a generic options field to all actions.
 export interface MutationResultAction {
   type: 'APOLLO_MUTATION_RESULT';
   result: GraphQLResult;
   document: Document;
+  operationName: string;
+  // XXX maybe provide variables as well?
   mutationId: string;
   resultBehaviors?: MutationBehavior[];
   extraReducers?: ApolloReducer[];

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -11,13 +11,14 @@ import {
   ApolloReducer,
 } from './store';
 
-export interface QueryResultAction {
+export type QueryResultAction = {
   type: 'APOLLO_QUERY_RESULT';
   result: GraphQLResult;
   queryId: string;
   document: Document;
   operationName: string;
   requestId: number;
+  extraReducers?: ApolloReducer[];
 }
 
 export function isQueryResultAction(action: ApolloAction): action is QueryResultAction {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -7,6 +7,10 @@ import {
   MutationBehavior,
 } from './data/mutationResults';
 
+import {
+  ApolloReducer,
+} from './store';
+
 export interface QueryResultAction {
   type: 'APOLLO_QUERY_RESULT';
   result: GraphQLResult;
@@ -74,6 +78,7 @@ export interface MutationInitAction {
   mutationId: string;
   optimisticResponse: Object;
   resultBehaviors?: MutationBehavior[];
+  extraReducers?: ApolloReducer[];
 }
 
 export function isMutationInitAction(action: ApolloAction): action is MutationInitAction {
@@ -86,6 +91,7 @@ export interface MutationResultAction {
   document: Document;
   mutationId: string;
   resultBehaviors?: MutationBehavior[];
+  extraReducers?: ApolloReducer[];
 }
 
 export function isMutationResultAction(action: ApolloAction): action is MutationResultAction {

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -805,6 +805,7 @@ export class QueryManager {
           this.store.dispatch({
             type: 'APOLLO_QUERY_RESULT',
             document,
+            operationName: getOperationName(document),
             result,
             queryId,
             requestId,

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -277,6 +277,7 @@ export class QueryManager {
       mutationString,
       mutation,
       variables,
+      operationName: getOperationName(mutation),
       mutationId,
       optimisticResponse,
       resultBehaviors: [...resultBehaviors, ...updateQueriesResultBehaviors],
@@ -297,6 +298,7 @@ export class QueryManager {
             result,
             mutationId,
             document: mutation,
+            operationName: getOperationName(mutation),
             resultBehaviors: [
                 ...resultBehaviors,
                 ...this.collectResultBehaviorsFromUpdateQueries(updateQueries, result),

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -125,6 +125,7 @@ export class QueryManager {
   private queryTransformer: QueryTransformer;
   private resultTransformer: ResultTransformer;
   private resultComparator: ResultComparator;
+  // TODO REFACTOR collect all operation-related info in one place (e.g. all these maps)
   private queryListeners: { [queryId: string]: QueryListener[] };
   private queryDocuments: { [queryId: string]: Document };
 

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -801,6 +801,20 @@ export class QueryManager {
 
       return this.networkInterface.query(request)
         .then((result: GraphQLResult) => {
+
+          const extraReducers = Object.keys(this.observableQueries).map( obsQueryId => {
+            const queryOptions = this.observableQueries[obsQueryId].observableQuery.options;
+            if (queryOptions.reducer) {
+              return createStoreReducer(
+                queryOptions.reducer,
+                queryOptions.query,
+                queryOptions.variables,
+                this.reducerConfig,
+                );
+            }
+            return null;
+          }).filter( reducer => reducer !== null );
+
           // XXX handle multiple ApolloQueryResults
           this.store.dispatch({
             type: 'APOLLO_QUERY_RESULT',
@@ -809,6 +823,7 @@ export class QueryManager {
             result,
             queryId,
             requestId,
+            extraReducers,
           });
 
           this.removeFetchQueryPromise(requestId);

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -3,6 +3,10 @@ import {
   FragmentDefinition,
 } from 'graphql';
 
+import {
+  OperationResultReducer,
+} from '../data/mutationResults';
+
 /**
  * We can change these options to an ObservableQuery
  */
@@ -37,6 +41,11 @@ export interface ModifiableWatchQueryOptions {
    * refetched from the server.
    */
   pollInterval?: number;
+
+  /**
+   * A redux reducer that lets you update the result of this query in the store based on any action (including mutation and query results)
+   */
+  reducer?: OperationResultReducer;
 }
 
 /**

--- a/src/data/mutationResults.ts
+++ b/src/data/mutationResults.ts
@@ -285,6 +285,16 @@ export type MutationQueryReducersMap = {
   [queryName: string]: MutationQueryReducer;
 };
 
+export type OperationResultReducer = (previousResult: Object, options: {
+  result: Object,
+  operationName: Object,
+  variables: Object,
+}) => Object;
+
+export type OperationResultReducerMap = {
+  [queryId: string]: OperationResultReducer;
+};
+
 // Combines all of the default reducers into a map based on the behavior type they accept
 // The behavior type is used to pick the right reducer when evaluating the result of the mutation
 export const defaultMutationBehaviorReducers: { [type: string]: MutationBehaviorReducer } = {

--- a/src/data/mutationResults.ts
+++ b/src/data/mutationResults.ts
@@ -34,6 +34,10 @@ import {
   ApolloReducerConfig,
 } from '../store';
 
+import {
+  ApolloAction,
+} from '../actions';
+
 // Mutation behavior types, these can be used in the `resultBehaviors` argument to client.mutate
 
 export type MutationBehavior =
@@ -285,11 +289,7 @@ export type MutationQueryReducersMap = {
   [queryName: string]: MutationQueryReducer;
 };
 
-export type OperationResultReducer = (previousResult: Object, options: {
-  result: Object,
-  operationName: Object,
-  variables: Object,
-}) => Object;
+export type OperationResultReducer = (previousResult: Object, action: ApolloAction) => Object;
 
 export type OperationResultReducerMap = {
   [queryId: string]: OperationResultReducer;

--- a/src/data/resultReducers.ts
+++ b/src/data/resultReducers.ts
@@ -1,0 +1,58 @@
+import {
+  Document,
+} from 'graphql';
+
+import {
+  readQueryFromStore,
+} from './readFromStore';
+
+import {
+  writeResultToStore,
+} from './writeToStore';
+
+import {
+  NormalizedCache,
+} from './store';
+
+import {
+  ApolloReducer,
+  ApolloReducerConfig,
+} from '../store';
+
+import {
+  ApolloAction,
+} from '../actions';
+
+import {
+  OperationResultReducer,
+} from './mutationResults';
+
+/**
+ * This function takes a result reducer and all other necessary information to obtain a proper
+ * redux store reducer.
+ * note: we're just passing the config to access dataIdFromObject, which writeToStore needs.
+ */
+export function createStoreReducer(
+  resultReducer: OperationResultReducer,
+  document: Document,
+  variables: Object,
+  config: ApolloReducerConfig,
+  // TODO: maybe turn the arguments into a single object argument
+): ApolloReducer {
+
+  return (store: NormalizedCache, action: ApolloAction) => {
+    const currentResult = readQueryFromStore({ store, query: document, variables });
+    const nextResult = resultReducer(currentResult, action); // action should include operation name
+    if (currentResult !== nextResult) {
+      return writeResultToStore({
+        dataId: 'ROOT_QUERY',
+        result: nextResult,
+        store,
+        document,
+        variables,
+        dataIdFromObject: config.dataIdFromObject,
+      });
+    }
+    return store;
+  };
+}

--- a/src/data/store.ts
+++ b/src/data/store.ts
@@ -130,6 +130,7 @@ export function data(
         dataIdFromObject: config.dataIdFromObject,
       });
 
+      // TODO REFACTOR: remove result behaviors
       if (constAction.resultBehaviors) {
         constAction.resultBehaviors.forEach((behavior) => {
           const args: MutationBehaviorReducerArgs = {
@@ -147,6 +148,14 @@ export function data(
           } else {
             throw new Error(`No mutation result reducer defined for type ${behavior.type}`);
           }
+        });
+      }
+
+      // XXX each reducer gets the state from the previous reducer.
+      // Maybe they should all get a clone instead and then compare at the end to make sure it's consistent.
+      if (constAction.extraReducers) {
+        constAction.extraReducers.forEach( reducer => {
+          newState = reducer(newState, constAction);
         });
       }
 

--- a/src/data/store.ts
+++ b/src/data/store.ts
@@ -102,7 +102,9 @@ export function data(
       // XXX use immutablejs instead of cloning
       const clonedState = assign({}, previousState) as NormalizedCache;
 
-      const newState = writeResultToStore({
+      // TODO REFACTOR: is writeResultToStore a good name for something that doesn't actually
+      // write to "the" store?
+      let newState = writeResultToStore({
         result: action.result.data,
         dataId: 'ROOT_QUERY', // TODO: is this correct? what am I doing here? What is dataId for??
         document: action.document,
@@ -110,6 +112,14 @@ export function data(
         store: clonedState,
         dataIdFromObject: config.dataIdFromObject,
       });
+
+      // XXX each reducer gets the state from the previous reducer.
+      // Maybe they should all get a clone instead and then compare at the end to make sure it's consistent.
+      if (action.extraReducers) {
+        action.extraReducers.forEach( reducer => {
+          newState = reducer(newState, constAction);
+        });
+      }
 
       return newState;
     }

--- a/src/optimistic-data/store.ts
+++ b/src/optimistic-data/store.ts
@@ -37,6 +37,7 @@ export function optimistic(
       type: 'APOLLO_MUTATION_RESULT',
       result: { data: action.optimisticResponse },
       document: action.mutation,
+      operationName: action.operationName,
       mutationId: action.mutationId,
       resultBehaviors: action.resultBehaviors,
       extraReducers: action.extraReducers,

--- a/src/optimistic-data/store.ts
+++ b/src/optimistic-data/store.ts
@@ -51,6 +51,8 @@ export function optimistic(
       config
     );
 
+    // TODO: apply extra reducers and resultBehaviors to optimistic store?
+
     const changedKeys = Object.keys(fakeDataResultState).filter(
       key => optimisticData[key] !== fakeDataResultState[key]);
     const patch = pick(fakeDataResultState, changedKeys);

--- a/src/optimistic-data/store.ts
+++ b/src/optimistic-data/store.ts
@@ -1,5 +1,5 @@
 import {
-  ApolloAction,
+  MutationResultAction,
   isMutationInitAction,
   isMutationResultAction,
   isMutationErrorAction,
@@ -33,13 +33,14 @@ export function optimistic(
   config: any
 ): OptimisticStore {
   if (isMutationInitAction(action) && action.optimisticResponse) {
-    const fakeMutationResultAction = {
+    const fakeMutationResultAction: MutationResultAction = {
       type: 'APOLLO_MUTATION_RESULT',
       result: { data: action.optimisticResponse },
       document: action.mutation,
       mutationId: action.mutationId,
       resultBehaviors: action.resultBehaviors,
-    } as ApolloAction;
+      extraReducers: action.extraReducers,
+    };
 
     const fakeStore = assign({}, store, { optimistic: previousState }) as Store;
     const optimisticData = getDataWithOptimisticResults(fakeStore);

--- a/src/store.ts
+++ b/src/store.ts
@@ -68,6 +68,8 @@ const crashReporter = (store: any) => (next: any) => (action: any) => {
   }
 };
 
+export type ApolloReducer = (store: NormalizedCache, action: ApolloAction) => NormalizedCache;
+
 export function createApolloReducer(config: ApolloReducerConfig): Function {
   return function apolloReducer(state = {} as Store, action: ApolloAction) {
     const newState = {

--- a/test/mutationResults.ts
+++ b/test/mutationResults.ts
@@ -594,7 +594,7 @@ describe('mutation results', () => {
     });
   });
 
-  describe('query store reducer', () => {
+  describe('result reducer', () => {
     const mutation = gql`
       mutation createTodo {
         # skipping arguments in the test since they don't matter

--- a/test/mutationResults.ts
+++ b/test/mutationResults.ts
@@ -665,6 +665,7 @@ describe('mutation results', () => {
     });
   });
 
+
   describe('query result reducers', () => {
     const mutation = gql`
       mutation createTodo {

--- a/test/mutationResults.ts
+++ b/test/mutationResults.ts
@@ -866,11 +866,8 @@ describe('mutation results', () => {
           query: filteredQuery,
           forceFetch: true, // need force-fetch to get the filteredTodos,
           reducer: (previousResult, action) => {
-            console.log(action);
             counter2++;
             if (isMutationResultAction(action) && action.result.data.createTodo.completed) {
-              console.log(action.result.data.createTodo);
-              console.log('PR', previousResult);
               const newResult = clonedeep(previousResult) as any;
               newResult.todoList.filteredTodos.unshift(action.result.data.createTodo);
               return newResult;
@@ -904,7 +901,7 @@ describe('mutation results', () => {
       })
       .then(() => {
         // TODO: improve this test. Now it just works because this query is the same as the watchQuery with the reducer.
-        return client.query({ query:filteredQuery });
+        return client.query({ query: filteredQuery });
       })
       .then((newResult: any) => {
         observableQuery2.unsubscribe();


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] call during MUTATION_RESULT
- [x] action contains operationName
- [x] call during MUTATION_INIT with optimistic result
- [x] call during QUERY_RESULT
- [x] call during SUBSCRIPTION_RESULT (-> no such action. Fix when working out subscription API)
- [x] write tests for all of the above
- [x] add a test that calls multiple query reducers.

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
- [x] Add your name and email to the AUTHORS file (optional)
- [x] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion

Things to note:
1. The reducer will run on every result, including the result of its own query.
2. The reducer (right now) does not run on subscription results (pending subscription API change), and it does not run on query results that didn't hit the server (i.e. QUERY_RESULT_CLIENT). It also doesn't run when errors are returned. We may need to update this in the future.
3. Reducers run serially. A reducer gets the store with modifications from previous reducers already applied.
4. Reducers run after writing the result to store, and after result behaviors.

This feature could use a few more tests to make sure the interactions with other features (eg. optimistic updates) is solid.