### PR TITLE
refetch should only modify variables on original query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Expect active development and potentially significant breaking changes in the `0
 - **Breaking change**: Move batching to network interface and split off query merging into separate package [PR #734](https://github.com/apollostack/apollo-client/pull/734)
 - **Feature removal**: No more `(read|diff)(Fragment|SelectionSet)FromStore`.
 - **Feature removal**: No more `write(Fragment|SelectionSet)ToStore`.
+- Fix: refetch only updates original query variable options
 
 ### v0.4.20
 - Fix: Warn but do not fail when refetchQueries includes an unknown query name [PR #700](https://github.com/apollostack/apollo-client/pull/700)

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -121,11 +121,15 @@ export class ObservableQuery extends Observable<ApolloQueryResult> {
       if (this.options.noFetch) {
         throw new Error('noFetch option should not use query refetch.');
       }
-      // Use the same options as before, but with new variables and forceFetch true
-      return this.queryManager.fetchQuery(this.queryId, assign(this.options, {
-        forceFetch: true,
+      // Update the existing options with new variables
+      assign(this.options, {
         variables: this.variables,
-      }) as WatchQueryOptions)
+      });
+      // Override forceFetch for this call only
+      const combinedOptions = assign({}, this.options, {
+        forceFetch: true,
+      });
+      return this.queryManager.fetchQuery(this.queryId, combinedOptions)
       .then(result => this.queryManager.transformResult(result));
     };
 


### PR DESCRIPTION
I noticed recently when using refetch that requests kept being made when other changes caused a component to rerender. This was traced back to the refetch method incorrectly changing the options on the query to set forceFetch to be true versus having it only apply to the manual refetch call.

TODO:

- [X] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [X] Make sure all of the significant new logic is covered by tests
- [X] Rebase your changes on master so that they can be merged easily
- [X] Make sure all tests and linter rules pass
- [X] Update CHANGELOG.md with your change
- [X] Add your name and email to the AUTHORS file (optional)
- [X] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion

