### PR TITLE
Return errors from `currentResult`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 3 to 6 months), to signal the start of a more stable API.
 
 ### v0.5.0 (in preview)
+- Fix an issue with `observableQuery.currentResult()` when the query had returned an error.
 
 #### v0.5.0-1 first preview
 - **new Feature**: Add fetchMore-style subscribeToMore function which updates a query result based on a subscription. [PR #797](https://github.com/apollostack/apollo-client/pull/797)

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -25,6 +25,12 @@ import { tryFunctionOrLogError } from '../util/errorHandling';
 import assign = require('lodash.assign');
 import isEqual = require('lodash.isequal');
 
+export type ApolloCurrentResult = {
+  data: any;
+  loading: boolean;
+  error?: ApolloError;
+}
+
 export interface FetchMoreOptions {
   updateQuery: (previousQueryResult: Object, options: {
     fetchMoreResult: Object,
@@ -101,9 +107,18 @@ export class ObservableQuery extends Observable<ApolloQueryResult> {
     });
   }
 
-  public currentResult(): ApolloQueryResult {
+  public currentResult(): ApolloCurrentResult {
     const { data, partial } = this.queryManager.getCurrentQueryResult(this);
     const queryStoreValue = this.queryManager.getApolloState().queries[this.queryId];
+
+    if (queryStoreValue && (queryStoreValue.graphQLErrors || queryStoreValue.networkError)) {
+      const error = new ApolloError({
+        graphQLErrors: queryStoreValue.graphQLErrors,
+        networkError: queryStoreValue.networkError,
+      });
+      return { data: {}, loading: false, error };
+    }
+
     const queryLoading = !queryStoreValue || queryStoreValue.loading;
 
     // We need to be careful about the loading state we show to the user, to try

--- a/test/ObservableQuery.ts
+++ b/test/ObservableQuery.ts
@@ -47,6 +47,10 @@ describe('ObservableQuery', () => {
     },
   };
 
+  const error = {
+    name: 'people_one',
+    message: 'is offline.',
+  };
 
   describe('setOptions', () => {
     describe('to change pollInterval', () => {
@@ -360,6 +364,28 @@ describe('ObservableQuery', () => {
             data: dataOne,
             loading: false,
           });
+        });
+    });
+
+    it('returns errors from the store immediately', () => {
+      const queryManager = mockQueryManager({
+        request: { query, variables },
+        result: { errors: [error] },
+      });
+
+      const observable = queryManager.watchQuery({
+        query,
+        variables,
+      });
+
+      return observable.result()
+        .catch((theError: any) => {
+          assert.deepEqual(theError.graphQLErrors, [error]);
+
+          const currentResult = observable.currentResult();
+
+          assert.equal(currentResult.loading, false);
+          assert.deepEqual(currentResult.error.graphQLErrors, [error]);
         });
     });
 


### PR DESCRIPTION
Fix issue as discussed @helfer. Has been released in 0.4.22