### PR TITLE
fix result reducer bug with partialData

### DIFF
--- a/src/data/resultReducers.ts
+++ b/src/data/resultReducers.ts
@@ -41,7 +41,13 @@ export function createStoreReducer(
 ): ApolloReducer {
 
   return (store: NormalizedCache, action: ApolloAction) => {
-    const currentResult = readQueryFromStore({ store, query: document, variables });
+    const currentResult = readQueryFromStore({
+      store,
+      query: document,
+      variables,
+      returnPartialData: true,
+    });
+    // TODO add info about networkStatus
     const nextResult = resultReducer(currentResult, action); // action should include operation name
     if (currentResult !== nextResult) {
       return writeResultToStore({


### PR DESCRIPTION
Fixes an issue with result reducers running before a query finished loading and adds a test for it.

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change
- [ ] Add your name and email to the AUTHORS file (optional)
- [ ] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion
