### PR TITLE
Make typings work w/o using `compilerOptions.lib`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,13 +65,13 @@
   "devDependencies": {
     "@types/chai": "^3.4.32",
     "@types/chai-as-promised": "0.0.28",
+    "@types/es6-shim": "^0.31.32",
     "@types/mocha": "^2.2.31",
     "browserify": "^13.0.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
     "colors": "^1.1.2",
     "es6-promise": "^4.0.4",
-    "typed-graphql": "1.0.2",
     "fetch-mock": "^5.5.0",
     "grunt": "1.0.1",
     "grunt-tslint": "3.3.0",
@@ -88,6 +88,7 @@
     "sinon": "^1.17.4",
     "source-map-support": "^0.4.0",
     "tslint": "3.15.1",
+    "typed-graphql": "1.0.2",
     "typescript": "2.0.3",
     "uglify-js": "^2.6.2"
   },

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -198,12 +198,7 @@ describe('QueryManager', () => {
     variables?: Object,
   }) => {
     return mockMutation(opts).then(({ result }) => {
-      try {
-        assert.deepEqual(result.data, opts.data);
-        return Promise.resolve(true);
-      } catch (e) {
-        return Promise.reject(e);
-      }
+      assert.deepEqual(result.data, opts.data);
     });
   };
 
@@ -2609,11 +2604,13 @@ describe('QueryManager', () => {
     );
 
     const observable = queryManager.watchQuery({ query });
-    return Promise.all([
+    return Promise.all<any[] | void>([
       // we wait for a little bit to ensure the result of the second query
       // don't trigger another subscription event
       observableToPromise({ observable, wait: 100 },
-        (result) => assert.deepEqual(result.data, data)
+        (result) => {
+          assert.deepEqual(result.data, data);
+        }
       ),
       queryManager.query({ query }).then((result) => {
         assert.deepEqual(result.data, data);

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1,4 +1,11 @@
 /* tslint:disable */
+
+// These should (and generally do) get picked up automatically as they're installed
+// at @types/es6-shim, but it doesn't work in typedoc (or Atom it seems),
+// so we include them here manually
+/// <reference types="node" />
+/// <reference types="mocha" />
+
 // ensure support for fetch and promise
 import 'es6-promise';
 import 'isomorphic-fetch';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "target": "es5",
     "module": "commonjs",
-    "lib": ["es6", "dom"],
     "moduleResolution": "node",
     "sourceMap": true,
     "declaration": true,
@@ -12,8 +11,7 @@
     "removeComments": true,
     "noImplicitAny": true,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    "types": [ "mocha", "node" ]
+    "noFallthroughCasesInSwitch": true
   },
   "files": [
     "typings.d.ts",

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,5 +1,10 @@
 /// <reference types="typed-graphql" />
 
+// This should (and generally does) get picked up automatically as it's installed
+// at @types/es6-shim, but it doesn't work in typedoc (or Atom it seems),
+// so we include it here manually
+/// <reference types="es6-shim" />
+
 /*
 
   LODASH


### PR DESCRIPTION
This is primarily to make it work w/ typedoc.