### PR TITLE
Remove unnecessary es6-promise

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
   "author": "Sashko Stubailo <sashko@stubailo.com>",
   "license": "MIT",
   "dependencies": {
-    "es6-promise": "^4.0.3",
     "graphql-anywhere": "^0.2.4",
     "graphql-tag": "^0.1.13",
     "lodash.assign": "^4.0.8",


### PR DESCRIPTION
I don't think it's needed in `dependencies`.

Also, it makes a problem because `es6-promise` is defined twice, in `dependencies` and `devDependencies` with different version requirements.