### PR TITLE
Expose SubscriptionOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ Expect active development and potentially significant breaking changes in the `0
 
 ### vNext
 - **new Feature**: Enable chaining of `use` and `useAfter` function calls in network interface. [PR #860](https://github.com/apollostack/apollo-client/pull/860) [Issue #564](https://github.com/apollostack/apollo-client/issues/564)
-- Create and expose the `MutationOptions` [PR #866](https://github.com/apollostack/apollo-client/pull/866)
+- Create and expose the `MutationOptions` [PR #866]
+(https://github.com/apollostack/apollo-client/pull/866)
+- Expose `SubscriptionOptions` [PR #868](https://github.com/apollostack/apollo-client/pull/868)
 
 ### v0.5.0
 - Add a `createdBatchingNetworkInterface` function and export it.

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import {
 import {
   WatchQueryOptions,
   MutationOptions,
+  DeprecatedSubscriptionOptions,
 } from './core/watchQueryOptions';
 
 import {
@@ -100,6 +101,7 @@ export {
   MutationBehavior,
   MutationQueryReducersMap,
   Subscription,
+  DeprecatedSubscriptionOptions as SubscriptionOptions,
   ApolloStore,
   ApolloClient
 };


### PR DESCRIPTION
@helfer This way you could switch `DeprecatedSubscriptionOptions` with some new interface that is not deprecated and it won't break `angular2-apollo`