### PR TITLE
Safe Apollo Reducers that can't crash the store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 3 to 6 months), to signal the start of a more stable API.
 
 ### vNEXT
-- Prevent Redux from crashing when an uncatched apollo error is raised in an Apollo reducer. [PR #874](https://github.com/apollostack/apollo-client/pull/874)
+- Prevent Redux from crashing when an uncaught ApolloError is raised in an Apollo reducer. [PR #874](https://github.com/apollostack/apollo-client/pull/874)
 
 ### 0.5.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 3 to 6 months), to signal the start of a more stable API.
 
 ### vNEXT
+- Prevent Redux from crashing when an uncatched apollo error is raised in an Apollo reducer. [PR #874](https://github.com/apollostack/apollo-client/pull/874)
 
 ### 0.5.6
 - Refactor polling query logic to fix startPolling and stopPolling [#938](https://github.com/apollostack/apollo-client/pull/938)

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -962,9 +962,15 @@ export class QueryManager {
           } catch (e) {}
           /* tslint:enable */
 
+          const {reducerError} = this.getApolloState();
+          if (!resultFromStore && reducerError) {
+            return Promise.reject(reducerError);
+          }
+
           // return a chainable promise
           this.removeFetchQueryPromise(requestId);
           resolve({ data: resultFromStore, loading: false, networkStatus: NetworkStatus.ready });
+          return null;
         }).catch((error: Error) => {
           // This is for the benefit of `refetch` promises, which currently don't get their errors
           // through the store like watchQuery observers do

--- a/src/store.ts
+++ b/src/store.ts
@@ -51,6 +51,7 @@ export interface Store {
   queries: QueryStore;
   mutations: MutationStore;
   optimistic: OptimisticStore;
+  reducerError: Error | null;
 }
 
 /**
@@ -79,32 +80,40 @@ export type ApolloReducer = (store: NormalizedCache, action: ApolloAction) => No
 
 export function createApolloReducer(config: ApolloReducerConfig): Function {
   return function apolloReducer(state = {} as Store, action: ApolloAction) {
-    const newState = {
-      queries: queries(state.queries, action),
-      mutations: mutations(state.mutations, action),
+    try {
+      const newState: Store = {
+        queries: queries(state.queries, action),
+        mutations: mutations(state.mutations, action),
 
-      // Note that we are passing the queries into this, because it reads them to associate
-      // the query ID in the result with the actual query
-      data: data(state.data, action, state.queries, state.mutations, config),
-      optimistic: [] as any,
-    };
+        // Note that we are passing the queries into this, because it reads them to associate
+        // the query ID in the result with the actual query
+        data: data(state.data, action, state.queries, state.mutations, config),
+        optimistic: [] as any,
 
-    // use the two lines below to debug tests :)
-    // console.log('ACTION', action.type);
-    // console.log('new state', newState);
+        reducerError: null,
+      };
 
-    // Note, we need to have the results of the
-    // APOLLO_MUTATION_INIT action to simulate
-    // the APOLLO_MUTATION_RESULT action. That's
-    // why we pass in newState
-    newState.optimistic = optimistic(
-      state.optimistic,
-      action,
-      newState,
-      config
-    );
+      // use the two lines below to debug tests :)
+      // console.log('ACTION', action.type);
+      // console.log('new state', newState);
 
-    return newState;
+      // Note, we need to have the results of the
+      // APOLLO_MUTATION_INIT action to simulate
+      // the APOLLO_MUTATION_RESULT action. That's
+      // why we pass in newState
+      newState.optimistic = optimistic(
+        state.optimistic,
+        action,
+        newState,
+        config
+      );
+
+      return newState;
+    } catch (reducerError) {
+      return Object.assign({}, state, {
+         reducerError,
+       });
+    }
   };
 }
 

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -2019,6 +2019,7 @@ describe('QueryManager', () => {
         mutations: {},
         queries: {},
         optimistic: [],
+        reducerError: null,
       };
 
       assert.deepEqual(currentState, expectedState);

--- a/test/client.ts
+++ b/test/client.ts
@@ -172,6 +172,7 @@ describe('client', () => {
           mutations: {},
           data: {},
           optimistic: [],
+          reducerError: null,
         },
       }
     );
@@ -493,6 +494,7 @@ describe('client', () => {
         },
       },
       mutations: {},
+      reducerError: null,
     }) };
 
     const client = new ApolloClient({

--- a/test/store.ts
+++ b/test/store.ts
@@ -3,6 +3,7 @@ const { assert } = chai;
 import gql from 'graphql-tag';
 
 import {
+  Store,
   createApolloStore,
 } from '../src/store';
 
@@ -21,6 +22,7 @@ describe('createApolloStore', () => {
         mutations: {},
         data: {},
         optimistic: [],
+        reducerError: null,
       }
     );
   });
@@ -37,6 +39,7 @@ describe('createApolloStore', () => {
         mutations: {},
         data: {},
         optimistic: [],
+        reducerError: null,
       }
     );
   });
@@ -61,6 +64,7 @@ describe('createApolloStore', () => {
         mutations: {},
         data: initialState.apollo.data,
         optimistic: initialState.apollo.optimistic,
+        reducerError: null,
       },
     });
   });
@@ -110,11 +114,12 @@ describe('createApolloStore', () => {
       },
     };
 
-    const emptyState = {
+    const emptyState: Store = {
       queries: { },
       mutations: { },
       data: { },
       optimistic: ([] as any[]),
+      reducerError: null,
     };
 
     const store = createApolloStore({
@@ -140,7 +145,7 @@ describe('createApolloStore', () => {
       },
     };
 
-    const emptyState = {
+    const emptyState: Store = {
       queries: {
         'test.0': {
           'forceFetch': false,
@@ -159,6 +164,7 @@ describe('createApolloStore', () => {
       mutations: {},
       data: {},
       optimistic: ([] as any[]),
+      reducerError: null,
     };
 
     const store = createApolloStore({


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
- [x] Add your name and email to the AUTHORS file (optional)
- [x] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion

We prevent throwing inside the reducer by wrapping it in a try/catch block. The error will still be reported to the user.