### PR TITLE
updateQuery of subscribeToMore should be optional

### DIFF
--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -227,10 +227,20 @@ export class ObservableQuery extends Observable<ApolloQueryResult> {
       variables: options.variables,
     });
 
-    const reducer = options.updateQuery || ((previousResult) => previousResult);
+    const observer: Observer<any> = {
+      error: (err) => {
+        if (options.onError) {
+          options.onError(err);
+        } else {
+          console.error('Unhandled GraphQL subscription errror', err);
+        }
+      },
+    };
 
-    const subscription = observable.subscribe({
-      next: (data) => {
+    if (options.updateQuery) {
+      const reducer = options.updateQuery;
+
+      observer.next = (data) => {
         const mapFn = (previousResult: Object, { variables }: { variables: Object }) => {
           return reducer(
             previousResult, {
@@ -240,15 +250,11 @@ export class ObservableQuery extends Observable<ApolloQueryResult> {
           );
         };
         this.updateQuery(mapFn);
-      },
-      error: (err) => {
-        if (options.onError) {
-          options.onError(err);
-        } else {
-          console.error('Unhandled GraphQL subscription errror', err);
-        }
-      },
-    });
+      };
+    }
+
+    const subscription = observable.subscribe(observer);
+>>>>>>> subscribe doesn't need next function if SubscribeToMoreOptions has no updateQuery function
 
     this.subscriptionHandles.push(subscription);
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -227,7 +227,9 @@ export class ObservableQuery extends Observable<ApolloQueryResult> {
       variables: options.variables,
     });
 
-    const observer: Observer<any> = {
+    const reducer = options.updateQuery;
+
+    const subscription = observable.subscribe({
       error: (err) => {
         if (options.onError) {
           options.onError(err);
@@ -235,12 +237,7 @@ export class ObservableQuery extends Observable<ApolloQueryResult> {
           console.error('Unhandled GraphQL subscription errror', err);
         }
       },
-    };
-
-    if (options.updateQuery) {
-      const reducer = options.updateQuery;
-
-      observer.next = (data) => {
+      next: reducer ? (data) => {
         const mapFn = (previousResult: Object, { variables }: { variables: Object }) => {
           return reducer(
             previousResult, {
@@ -250,10 +247,8 @@ export class ObservableQuery extends Observable<ApolloQueryResult> {
           );
         };
         this.updateQuery(mapFn);
-      };
-    }
-
-    const subscription = observable.subscribe(observer);
+      } : () => {}
+    });
     this.subscriptionHandles.push(subscription);
 
     return () => {

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -254,8 +254,6 @@ export class ObservableQuery extends Observable<ApolloQueryResult> {
     }
 
     const subscription = observable.subscribe(observer);
->>>>>>> subscribe doesn't need next function if SubscribeToMoreOptions has no updateQuery function
-
     this.subscriptionHandles.push(subscription);
 
     return () => {

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -227,7 +227,7 @@ export class ObservableQuery extends Observable<ApolloQueryResult> {
       variables: options.variables,
     });
 
-    const reducer = options.updateQuery;
+    const reducer = options.updateQuery || ((previousResult) => previousResult);
 
     const subscription = observable.subscribe({
       next: (data) => {

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -91,7 +91,7 @@ export interface FetchMoreQueryOptions {
 export type SubscribeToMoreOptions = {
   document: Document;
   variables?: { [key: string]: any };
-  updateQuery: (previousQueryResult: Object, options: {
+  updateQuery?: (previousQueryResult: Object, options: {
     subscriptionData: { data: any },
     variables: { [key: string]: any },
   }) => Object;


### PR DESCRIPTION
As mentioned in #871, the updateQuery function can no be covered with the new graphql options.reducer. So it should be optional.