### PR TITLE
watchQuery should respect addTypename

### DIFF
--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -414,9 +414,14 @@ export class QueryManager {
     // Call just to get errors synchronously
     getQueryDefinition(options.query);
 
+    let transformedOptions = Object.assign({}, options) as WatchQueryOptions;
+    if (this.addTypename) {
+      transformedOptions.query = addTypenameToDocument(transformedOptions.query);
+    }
+
     let observableQuery = new ObservableQuery({
       scheduler: this.scheduler,
-      options: options,
+      options: transformedOptions,
       shouldSubscribe: shouldSubscribe,
     });
 


### PR DESCRIPTION
as explained here #870, the options.reducer function of graphql does currently not automatically include the `__typename`.