### PR TITLE
bind resetStore to this

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Expect active development and potentially significant breaking changes in the `0
 (https://github.com/apollostack/apollo-client/pull/866)
 - Expose `SubscriptionOptions` [PR #868](https://github.com/apollostack/apollo-client/pull/868)
 - Fix issue with `currentResult` and optimistic responses [Issue #877](https://github.com/apollostack/apollo-client/issues/877)
+- Bind `resetStore` to ApolloClient [PR #882](https://github.com/apollostack/apollo-client/issues/882)
 
 ### v0.5.0
 - Add a `createdBatchingNetworkInterface` function and export it.

--- a/src/ApolloClient.ts
+++ b/src/ApolloClient.ts
@@ -212,6 +212,7 @@ export default class ApolloClient {
     this.query = this.query.bind(this);
     this.mutate = this.mutate.bind(this);
     this.setStore = this.setStore.bind(this);
+    this.resetStore = this.resetStore.bind(this);
   }
 
   /**


### PR DESCRIPTION
This will help with this problem: http://stackoverflow.com/questions/36677733/why-jsx-props-should-not-use-arrow-functions
TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
- [x] Add your name and email to the AUTHORS file (optional)
- [x] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion

