### PR TITLE
Make storing IDs in arrays consistent with the rest of the store

### DIFF
--- a/src/data/readFromStore.ts
+++ b/src/data/readFromStore.ts
@@ -121,7 +121,9 @@ const readStoreResolver: Resolver = (
   context: ReadStoreContext
 ) => {
   if (! isIdValue(idValue)) {
-    throw new Error('Got incorrect root value during store execution. Please file an issue.');
+    throw new Error(`Encountered a sub-selection on the query, but the store doesn't have \
+an object reference. This should never happen during normal use unless you have custom code \
+that is directly manipulating the store; please file an issue.`);
   }
 
   const objId = idValue.id;

--- a/src/data/readFromStore.ts
+++ b/src/data/readFromStore.ts
@@ -74,11 +74,13 @@ type ReadStoreContext = {
 let haveWarned = false;
 
 const fragmentMatcher: FragmentMatcher = (
-  objId: string,
+  idValue: IdValue,
   typeCondition: string,
   context: ReadStoreContext
 ): boolean => {
-  const obj = context.store[objId];
+  assertIdValue(idValue);
+
+  const obj = context.store[idValue.id];
 
   if (! obj) {
     return false;
@@ -120,11 +122,7 @@ const readStoreResolver: Resolver = (
   args: any,
   context: ReadStoreContext
 ) => {
-  if (! isIdValue(idValue)) {
-    throw new Error(`Encountered a sub-selection on the query, but the store doesn't have \
-an object reference. This should never happen during normal use unless you have custom code \
-that is directly manipulating the store; please file an issue.`);
-  }
+  assertIdValue(idValue);
 
   const objId = idValue.id;
   const obj = context.store[objId];
@@ -188,4 +186,12 @@ export function diffQueryAgainstStore({
     result,
     isMissing: context.hasMissingField,
   };
+}
+
+function assertIdValue(idValue: IdValue) {
+  if (! isIdValue(idValue)) {
+    throw new Error(`Encountered a sub-selection on the query, but the store doesn't have \
+an object reference. This should never happen during normal use unless you have custom code \
+that is directly manipulating the store; please file an issue.`);
+  }
 }

--- a/src/data/writeToStore.ts
+++ b/src/data/writeToStore.ts
@@ -357,6 +357,7 @@ function processArrayValue(
 
       if (semanticId) {
         itemDataId = semanticId;
+        generated = false;
       }
     }
 

--- a/src/data/writeToStore.ts
+++ b/src/data/writeToStore.ts
@@ -365,6 +365,6 @@ function processArrayValue(
       context,
     });
 
-    return itemDataId;
+    return itemDataId as IdValue;
   });
 }

--- a/src/data/writeToStore.ts
+++ b/src/data/writeToStore.ts
@@ -350,6 +350,8 @@ function processArrayValue(
       return processArrayValue(item, itemDataId, selectionSet, context);
     }
 
+    let generated = true;
+
     if (context.dataIdFromObject) {
       const semanticId = context.dataIdFromObject(item);
 
@@ -365,6 +367,12 @@ function processArrayValue(
       context,
     });
 
-    return itemDataId as IdValue;
+    const idStoreValue: IdValue = {
+      type: 'id',
+      id: itemDataId,
+      generated,
+    };
+
+    return idStoreValue;
   });
 }

--- a/test/client.ts
+++ b/test/client.ts
@@ -458,7 +458,11 @@ describe('client', () => {
             name: 'Luke Skywalker',
           },
           'ROOT_QUERY.allPeople({"first":1})': {
-            people: [ 'ROOT_QUERY.allPeople({"first":"1"}).people.0' ],
+            people: [ {
+              type: 'id',
+              generated: true,
+              id: 'ROOT_QUERY.allPeople({"first":"1"}).people.0',
+            } ],
           },
           ROOT_QUERY: {
             'allPeople({"first":1})': {

--- a/test/mutationResults.ts
+++ b/test/mutationResults.ts
@@ -561,17 +561,17 @@ describe('mutation results', () => {
     });
   });
 
-  describe('array cleaning for ARRAY_DELETE', () => {
+  describe('array cleaning for DELETE behavior', () => {
     it('maintains reference on flat array', () => {
-      const array = [1, 2, 3, 4, 5];
+      const array = [1, 2, 3, 4, 5].map(x => ({id: x}));
       assert.isTrue(cleanArray(array, 6) === array);
       assert.isFalse(cleanArray(array, 3) === array);
     });
 
     it('works on nested array', () => {
       const array = [
-        [1, 2, 3, 4, 5],
-        [6, 7, 8, 9, 10],
+        [1, 2, 3, 4, 5].map(x => ({id: x})),
+        [6, 7, 8, 9, 10].map(x => ({id: x})),
       ];
 
       const cleaned = cleanArray(array, 5);
@@ -581,8 +581,8 @@ describe('mutation results', () => {
 
     it('maintains reference on nested array', () => {
       const array = [
-        [1, 2, 3, 4, 5],
-        [6, 7, 8, 9, 10],
+        [1, 2, 3, 4, 5].map(x => ({id: x})),
+        [6, 7, 8, 9, 10].map(x => ({id: x})),
       ];
 
       assert.isTrue(cleanArray(array, 11) === array);

--- a/test/optimistic.ts
+++ b/test/optimistic.ts
@@ -564,8 +564,8 @@ describe('optimistic mutation results', () => {
         assert.equal((dataInStore['TodoList5'] as any).todos.length, 4);
         assert.notProperty(dataInStore, 'Todo99');
         assert.property(dataInStore, 'Todo66');
-        assert.include((dataInStore['TodoList5'] as any).todos, 'Todo66');
-        assert.notInclude((dataInStore['TodoList5'] as any).todos, 'Todo99');
+        assert.include((dataInStore['TodoList5'] as any).todos, realIdValue('Todo66'));
+        assert.notInclude((dataInStore['TodoList5'] as any).todos, realIdValue('Todo99'));
       });
     });
     it('can run 2 mutations concurrently and handles all intermediate states well', () => {
@@ -574,8 +574,8 @@ describe('optimistic mutation results', () => {
         assert.equal((dataInStore['TodoList5'] as any).todos.length, 5);
         assert.property(dataInStore, 'Todo99');
         assert.property(dataInStore, 'Todo66');
-        assert.include((dataInStore['TodoList5'] as any).todos, 'Todo66');
-        assert.include((dataInStore['TodoList5'] as any).todos, 'Todo99');
+        assert.include((dataInStore['TodoList5'] as any).todos, realIdValue('Todo66'));
+        assert.include((dataInStore['TodoList5'] as any).todos, realIdValue('Todo99'));
         assert.equal((dataInStore['Todo99'] as any).text, expectedText1);
         assert.equal((dataInStore['Todo66'] as any).text, expectedText2);
       }
@@ -839,8 +839,8 @@ describe('optimistic mutation results', () => {
         assert.equal((dataInStore['TodoList5'] as any).todos.length, 4);
         assert.notProperty(dataInStore, 'Todo99');
         assert.property(dataInStore, 'Todo66');
-        assert.include((dataInStore['TodoList5'] as any).todos, 'Todo66');
-        assert.notInclude((dataInStore['TodoList5'] as any).todos, 'Todo99');
+        assert.include((dataInStore['TodoList5'] as any).todos, realIdValue('Todo66'));
+        assert.notInclude((dataInStore['TodoList5'] as any).todos, realIdValue('Todo99'));
       });
     });
   });
@@ -1170,3 +1170,11 @@ describe('optimistic mutation - githunt comments', () => {
     });
   });
 });
+
+function realIdValue(id: string) {
+  return {
+    type: 'id',
+    generated: false,
+    id,
+  };
+}

--- a/test/readFromStore.ts
+++ b/test/readFromStore.ts
@@ -179,7 +179,6 @@ describe('reading from the store', () => {
         nestedObj: {
           type: 'id',
           id: 'abcde',
-          nullField: null,
           generated: false,
         },
       }) as StoreObject,
@@ -188,7 +187,6 @@ describe('reading from the store', () => {
           type: 'id',
           id: 'abcdef',
           generated: false,
-          nullField: null,
         },
       }) as StoreObject,
       abcdef: result.deepNestedObj as StoreObject,

--- a/test/readFromStore.ts
+++ b/test/readFromStore.ts
@@ -270,8 +270,8 @@ describe('reading from the store', () => {
     const store = {
       'ROOT_QUERY': _.assign({}, _.assign({}, _.omit(result, 'nestedArray')), {
         nestedArray: [
-          'abcd.nestedArray.0',
-          'abcd.nestedArray.1',
+          { type: 'id', generated: true, id: 'abcd.nestedArray.0' },
+          { type: 'id', generated: true, id: 'abcd.nestedArray.1' },
         ],
       }) as StoreObject,
       'abcd.nestedArray.0': result.nestedArray[0],
@@ -329,7 +329,7 @@ describe('reading from the store', () => {
       'ROOT_QUERY': _.assign({}, _.assign({}, _.omit(result, 'nestedArray')), {
         nestedArray: [
           null,
-          'abcd.nestedArray.1',
+          { type: 'id', generated: true, id: 'abcd.nestedArray.1' },
         ],
       }) as StoreObject,
       'abcd.nestedArray.1': result.nestedArray[1],
@@ -384,7 +384,7 @@ describe('reading from the store', () => {
       'ROOT_QUERY': _.assign({}, _.assign({}, _.omit(result, 'nestedArray')), {
         nestedArray: [
           null,
-          'abcde',
+          { type: 'id', generated: false, id: 'abcde' },
         ],
       }) as StoreObject,
       'abcde': result.nestedArray[1],

--- a/test/writeToStore.ts
+++ b/test/writeToStore.ts
@@ -332,7 +332,11 @@ describe('writing to the store', () => {
       dataIdFromObject: getIdField,
     }), {
       'ROOT_QUERY': _.assign({}, _.assign({}, _.omit(result, 'nestedArray')), {
-        nestedArray: result.nestedArray.map(_.property('id')),
+        nestedArray: result.nestedArray.map((obj: any) => ({
+          type: 'id',
+          id: obj.id,
+          generated: false,
+        })),
       }),
       [result.nestedArray[0].id]: result.nestedArray[0],
       [result.nestedArray[1].id]: result.nestedArray[1],
@@ -378,7 +382,7 @@ describe('writing to the store', () => {
     }), {
       'ROOT_QUERY': _.assign({}, _.assign({}, _.omit(result, 'nestedArray')), {
         nestedArray: [
-          result.nestedArray[0].id,
+          { type: 'id', id: result.nestedArray[0].id, generated: false },
           null,
         ],
       }),
@@ -428,8 +432,8 @@ describe('writing to the store', () => {
     assert.deepEqual(normalized, {
       'ROOT_QUERY': _.assign({}, _.assign({}, _.omit(result, 'nestedArray')), {
         nestedArray: [
-          `ROOT_QUERY.nestedArray.0`,
-          `ROOT_QUERY.nestedArray.1`,
+          { type: 'id', generated: true, id: `ROOT_QUERY.nestedArray.0` },
+          { type: 'id', generated: true, id: `ROOT_QUERY.nestedArray.1` },
         ],
       }),
       [`ROOT_QUERY.nestedArray.0`]: result.nestedArray[0],
@@ -476,7 +480,7 @@ describe('writing to the store', () => {
       'ROOT_QUERY': _.assign({}, _.assign({}, _.omit(result, 'nestedArray')), {
         nestedArray: [
           null,
-          `ROOT_QUERY.nestedArray.1`,
+          { type: 'id', generated: true, id: `ROOT_QUERY.nestedArray.1` },
         ],
       }),
       [`ROOT_QUERY.nestedArray.1`]: result.nestedArray[1],


### PR DESCRIPTION
I was hacking around with some ideas for inspecting the store, and ran into a problem - ID references are not always stored the same way.

When it's an object field, the reference looks like:

```js
fieldKey: {
  type: 'id',
  id: 'asdf',
  generated: false,
}
```

When it's an array field, it's not wrapped at all:

```js
fieldKey: [
  'asdf',
  'qwer',
]
```

This is problematic if one wants to write a tool that can follow query trees through the store. Looks like when we initially refactored to escape these IDs in the store, we didn't go all the way and totally forgot about arrays.

This PR fixes it to look like:

```js
fieldKey: [
  { type: 'id', id: 'asdf', generated: false },
  { type: 'id', id: 'qwer', generated: false },
}
```

Note: This involved updating some of the old mutation behavior code. We should deprecate that and delete it/move it to an auxiliary package.

Questions:

- Is this a breaking change? I suppose in some ways it is, because it changes the store format. But I would be surprised if people were relying on the old behavior because someone else would have brought up that it was inconsistent?

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change