### PR TITLE
Only attach distinct fragments to document

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -45,3 +45,5 @@ Vladimir Guguiev <wizardzloy@gmail.com>
 Edvin Eriksson <edvinerikson@gmail.com>
 Agustin Polo <poloagustin@gmail.com>
 Chris Metz <metzc@users.noreply.github.com>
+jon wong <jon@coursera.org>
+jon wong <j@jnwng.com>

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "lodash.mapvalues": "^4.4.0",
     "lodash.merge": "^4.6.0",
     "lodash.pick": "^4.2.0",
-    "lodash.uniq": "^4.5.0",
+    "lodash.uniqwith": "^4.5.0",
     "redux": "^3.3.1",
     "symbol-observable": "^1.0.2",
     "whatwg-fetch": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "lodash.mapvalues": "^4.4.0",
     "lodash.merge": "^4.6.0",
     "lodash.pick": "^4.2.0",
+    "lodash.uniq": "^4.5.0",
     "redux": "^3.3.1",
     "symbol-observable": "^1.0.2",
     "whatwg-fetch": "^2.0.0"

--- a/src/queries/getFromAST.ts
+++ b/src/queries/getFromAST.ts
@@ -7,6 +7,7 @@ import {
 import assign = require('lodash.assign');
 import countBy = require('lodash.countby');
 import identity = require('lodash.identity');
+import uniq = require('lodash.uniq');
 
 export function getMutationDefinition(doc: Document): OperationDefinition {
   checkDocument(doc);
@@ -154,6 +155,6 @@ export function addFragmentsToDocument(queryDoc: Document,
   }
   checkDocument(queryDoc);
   return assign({}, queryDoc, {
-    definitions: queryDoc.definitions.concat(fragments),
+    definitions: queryDoc.definitions.concat(uniq(fragments)),
   }) as Document;
 }

--- a/src/queries/getFromAST.ts
+++ b/src/queries/getFromAST.ts
@@ -7,6 +7,7 @@ import {
 import assign = require('lodash.assign');
 import countBy = require('lodash.countby');
 import identity = require('lodash.identity');
+import includes = require('lodash.includes');
 import uniq = require('lodash.uniq');
 
 export function getMutationDefinition(doc: Document): OperationDefinition {
@@ -154,7 +155,14 @@ export function addFragmentsToDocument(queryDoc: Document,
     return queryDoc;
   }
   checkDocument(queryDoc);
+
+  const existingFragmentNames = getFragmentDefinitions(queryDoc)
+    .map((fragment) => fragment.name.value) as String[];
+   const distinctFragments = uniq(fragments.filter((fragment) => {
+     return !includes(existingFragmentNames, fragment.name.value);
+   })) as FragmentDefinition[];
+
   return assign({}, queryDoc, {
-    definitions: queryDoc.definitions.concat(uniq(fragments)),
+    definitions: queryDoc.definitions.concat(distinctFragments),
   }) as Document;
 }

--- a/src/queries/getFromAST.ts
+++ b/src/queries/getFromAST.ts
@@ -7,8 +7,8 @@ import {
 import assign = require('lodash.assign');
 import countBy = require('lodash.countby');
 import identity = require('lodash.identity');
-import includes = require('lodash.includes');
-import uniq = require('lodash.uniq');
+import uniqwith = require('lodash.uniqwith');
+import isequal = require('lodash.isequal');
 
 export function getMutationDefinition(doc: Document): OperationDefinition {
   checkDocument(doc);
@@ -155,14 +155,7 @@ export function addFragmentsToDocument(queryDoc: Document,
     return queryDoc;
   }
   checkDocument(queryDoc);
-
-  const existingFragmentNames = getFragmentDefinitions(queryDoc)
-    .map((fragment) => fragment.name.value) as String[];
-   const distinctFragments = uniq(fragments.filter((fragment) => {
-     return !includes(existingFragmentNames, fragment.name.value);
-   })) as FragmentDefinition[];
-
   return assign({}, queryDoc, {
-    definitions: queryDoc.definitions.concat(distinctFragments),
+    definitions: uniqwith(queryDoc.definitions.concat(fragments), isequal),
   }) as Document;
 }

--- a/test/getFromAST.ts
+++ b/test/getFromAST.ts
@@ -284,4 +284,54 @@ fragment businessAreaInfo on BusinessArea {
 }
 `);
   });
+
+  it('should only attach distinct fragments', () => {
+    const subjectInfo = createFragment(gql`
+      fragment subjectInfo on Subject {
+        id
+        name
+      }`
+    );
+
+    const businessAreaInfo = createFragment(gql`
+      fragment businessAreaInfo on BusinessArea {
+        id
+        name
+        subjects {
+          ...subjectInfo
+        }
+      }`,
+      [subjectInfo, subjectInfo],
+    );
+
+    const query = gql`
+      query {
+        businessAreas {
+          ...businessAreaInfo
+        }
+      }
+    `;
+
+    const fullDoc = addFragmentsToDocument(query, businessAreaInfo);
+
+    assert.equal(print(fullDoc), `{
+  businessAreas {
+    ...businessAreaInfo
+  }
+}
+
+fragment subjectInfo on Subject {
+  id
+  name
+}
+
+fragment businessAreaInfo on BusinessArea {
+  id
+  name
+  subjects {
+    ...subjectInfo
+  }
+}
+`);
+  });
 });

--- a/test/getFromAST.ts
+++ b/test/getFromAST.ts
@@ -310,6 +310,11 @@ fragment businessAreaInfo on BusinessArea {
           ...businessAreaInfo
         }
       }
+
+      fragment subjectInfo on Subject {
+        id
+        name
+      }
     `;
 
     const fullDoc = addFragmentsToDocument(query, businessAreaInfo);

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -105,11 +105,10 @@ declare module 'lodash.pick' {
   export = main.pick;
 }
 
-declare module 'lodash.uniq' {
+declare module 'lodash.uniqwith' {
   import main = require('lodash');
-  export = main.uniq;
+  export = main.uniqWith;
 }
-
 /*
 
   GRAPHQL

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -105,6 +105,11 @@ declare module 'lodash.pick' {
   export = main.pick;
 }
 
+declare module 'lodash.uniq' {
+  import main = require('lodash');
+  export = main.uniq;
+}
+
 /*
 
   GRAPHQL


### PR DESCRIPTION
See this [issue](https://github.com/apollostack/react-apollo/issues/325) on `react-apollo` to see what lead to this coming to this particular repo, and #897 for information on the bug / temporary workarounds.
- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [ ] ~~Update CHANGELOG.md with your change~~ (omitted because I'm not fully sure I should be doing this)
- [x] Add your name and email to the AUTHORS file (optional)
- [ ] ~~If this was a change that affects the external API, update the docs and post a link to the PR in the discussion~~ (omitted because it does not change an external API)

Attaching multiple references to the same fragment results in the creation of an invalid document - we want to make sure we’re only attaching _distinct_ fragments to the document.

## Steps to Reproduce
Attaching multiple references to the same fragment like:
```js
const someFragment = createFragment(gql`
  fragment SomeFragment on SomeEdge {
    someField
  }
`);

const someOtherFragment = createFragment(gql`
  fragment SomeOtherFragment on SomeEdge {
    ...SomeFragment
  }
`, [someFragment, someFragment]);
```
results in a query document that looks like
```graphql
query {
  fragment SomeOtherFragment on SomeEdge {
    ...SomeFragment
  }
  fragment SomeFragment on SomeEdge {
    someField
  }
  fragment SomeFragment on SomeEdge {
    someField
  }
}
```
(note that the fragment definition gets attached more than once). Per the [GraphQL spec](https://facebook.github.io/graphql/#sec-Fragment-Name-Uniqueness), having multiple fragments with the same name is invalid, and while we guard against _registering_ multiple fragments with the same name [here](https://github.com/apollostack/apollo-client/blob/8030a2f/src/fragments.ts#L39-L43), we need to also make sure we're not attaching multiple instances of the same fragment in our document.

Do also note that the example above is boiled down to the exact steps that it would take to reproduce the issue, but in more realistic use cases this occurs when sibling fragments both include a dependency on another fragment (they wouldn't know that the other fragment had already included the required fragment in the document).