### PR TITLE
Fix error handling for observer.next

### DIFF
--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -373,8 +373,9 @@ export class QueryManager {
             console.error('Unhandled error', apolloError, apolloError.stack);
           }
         } else {
+          let resultFromStore: any;
           try {
-            const resultFromStore = {
+            resultFromStore = {
               data: readQueryFromStore({
                 store: this.getDataWithOptimisticResults(),
                 query: this.queryDocuments[queryId],
@@ -384,17 +385,18 @@ export class QueryManager {
               loading: queryStoreValue.loading,
               networkStatus: queryStoreValue.networkStatus,
             };
-            if (observer.next) {
-              if (this.isDifferentResult(lastResult, resultFromStore)) {
-                lastResult = resultFromStore;
-                observer.next(this.transformResult(resultFromStore));
-              }
-            }
           } catch (error) {
             if (observer.error) {
               observer.error(new ApolloError({
                 networkError: error,
               }));
+            }
+            return;
+          }
+          if (observer.next) {
+            if (this.isDifferentResult(lastResult, resultFromStore)) {
+              lastResult = resultFromStore;
+              observer.next(this.transformResult(resultFromStore));
             }
           }
         }


### PR DESCRIPTION
When `observer.next` is called in `queryListenerForObserver` based on the results of a given query and *itself* throws an error, the error handling logic surrounding it automatically casts that error into an `ApolloError`, even though it didn't originate within `apollo-client`. 

This is a big problem in `react-apollo` (see [this issue](https://github.com/apollostack/react-apollo/issues/326)). `observer.next` calls the method that forces a rerender, and when child components throw an error they bubble up and wind up being handled by the `catch` statement in `queryListenerForObserver`, which turns it into an `ApolloError`, effectively swallowing the error.

This PR rearranges the error handling logic in order to effectively capture errors that occur *within* `apollo-client` (such as mismatches in data being read from the store) and allows errors that occur outside of `apollo-client` (when thrown from within `observer.next`) to propagate correctly.

TODO:

- [ ] ~If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)~
- [X] Make sure all of the significant new logic is covered by tests
- [X] Rebase your changes on master so that they can be merged easily
- [X] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change
- [ ] ~Add your name and email to the AUTHORS file (optional)~
- [ ] ~If this was a change that affects the external API, update the docs and post a link to the PR in the discussion~

