### PR TITLE
Catch `fetchQuery` errors in `startQuery`.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -21,6 +21,7 @@ Louis DeScioli <louis@grovelabs.io>
 Marc-Andre Giroux <mgiroux0@gmail.com>
 Martijn Walraven <martijn@martijnwalraven.com>
 Maxime Quandalle <maxime@quandalle.com>
+Michiel ter Reehorst <michiel@jamiter.com>
 Oleksandr Stubailo <sashko@Oleksandrs-MacBook-Pro.local>
 Olivier Ricordeau <olivier@ricordeau.org>
 Pavol Fulop <pavol.fulop@regex.sk>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Expect active development and potentially significant breaking changes in the `0
 
 ### vNEXT
 
+- Catch uncaught promise errors in QueryManager [#950](https://github.com/apollostack/apollo-client/pull/950)
+
 ### 0.5.6
 - Refactor polling query logic to fix startPolling and stopPolling [#938](https://github.com/apollostack/apollo-client/pull/938)
 - Add convenience method to obtain initial state from SSR [#941](https://github.com/apollostack/apollo-client/pull/941)

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -638,7 +638,10 @@ export class QueryManager {
   public startQuery(queryId: string, options: WatchQueryOptions, listener: QueryListener) {
     this.addQueryListener(queryId, listener);
 
-    this.fetchQuery(queryId, options);
+    this.fetchQuery(queryId, options)
+    // `fetchQuery` returns a Promise. In case of a failure it should be caucht or else the
+    // console will show an `Uncaught (in promise)` message. Ignore the error for now.
+    .catch((error: Error) => undefined);
 
     return queryId;
   }


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] ~~If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)~~
- [ ] ~~Make sure all of the significant new logic is covered by tests~~
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
- [x] Add your name and email to the AUTHORS file (optional)
- [ ] ~~If this was a change that affects the external API, update the docs and post a link to the PR in the discussion~~

Fixes https://github.com/apollostack/apollo-client/issues/891

The error wasn't caught anywhere. Should anything be done with the error? For subscriptions it is handled via the store I believe.