### PR TITLE
Fix ts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,7 @@ language: node_js
 node_js:
   - "6"
   - "4"
-cache:
-  directories:
-    # cache node modules
-    - node_modules
+
 install:
   - npm install -g coveralls
   - npm prune

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,8 @@
     "noFallthroughCasesInSwitch": true
   },
   "files": [
+    "node_modules/typescript/lib/lib.es2015.d.ts",
+    "node_modules/typescript/lib/lib.dom.d.ts",
     "typings.d.ts",
     "fetch-mock.typings.d.ts",
     "src/index.ts",

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,114 +1,50 @@
-// This should (and generally does) get picked up automatically as it's installed
-// at @types/es6-shim, but it doesn't work in typedoc (or Atom it seems),
-// so we include it here manually
-/// <reference types="typed-graphql" />
-/// <reference path="node_modules/typescript/lib/lib.es2015.d.ts" />
-/// <reference path="node_modules/typescript/lib/lib.dom.d.ts" />
-
 /*
-
   LODASH
-
 */
 declare module 'lodash.isobject' {
-  import main = require('lodash');
-  export = main.isObject;
+  export = require('lodash.isObject');
 }
 
 declare module 'lodash.isequal' {
-  import main = require('lodash');
-  export = main.isEqual;
+  export = require('lodash.isEqual');
 }
 
 declare module 'lodash.isnull' {
-  import main = require('lodash');
-  export = main.isNull;
+  export = require('lodash.isNull');
 }
 
 declare module 'lodash.isstring' {
-  import main = require('lodash');
-  export = main.isString;
-}
-
-declare module 'lodash.has' {
-  import main = require('lodash');
-  export = main.has;
-}
-
-declare module 'lodash.assign' {
-  import main = require('lodash');
-  export = main.assign;
-}
-
-declare module 'lodash.merge' {
-  import main = require('lodash');
-  export = main.merge;
-}
-
-declare module 'lodash.includes' {
-  import main = require('lodash');
-  export = main.includes;
+  export = require('lodash.isString');
 }
 
 declare module 'lodash.isnumber' {
-  import main = require('lodash');
-  export = main.isNumber;
+  export = require('lodash.isNumber');
 }
 
 declare module 'lodash.isboolean' {
-  import main = require('lodash');
-  export = main.isBoolean;
+  export = require('lodash.isBoolean');
 }
 
 declare module 'lodash.isundefined' {
-  import main = require('lodash');
-  export = main.isUndefined;
+  export = require('lodash.isUndefined');
 }
 
 declare module 'lodash.forown' {
-  import main = require('lodash');
-  export = main.forOwn;
-}
-
-declare module 'lodash.omit' {
-  import main = require('lodash');
-  export = main.omit;
+  export = require('lodash.forOwn');
 }
 
 declare module 'lodash.mapvalues' {
-  import main = require('lodash');
-  export = main.mapValues;
+  export = require('lodash.mapValues');
 }
 
 declare module 'lodash.clonedeep' {
-  import main = require('lodash');
-  export = main.cloneDeep;
+  export = require('lodash.cloneDeep');
 }
 
 declare module 'lodash.countby' {
-  import main = require('lodash');
-  export = main.countBy;
+  export = require('lodash.countBy');
 }
 
-declare module 'lodash.identity' {
-  import main = require('lodash');
-  export = main.identity;
-}
-
-declare module 'lodash.flatten' {
-  import main = require('lodash');
-  export = main.flatten;
-}
-
-declare module 'lodash.pick' {
-  import main = require('lodash');
-  export = main.pick;
-}
-
-declare module 'lodash.uniq' {
-  import main = require('lodash');
-  export = main.uniq;
-}
 /*
 
   GRAPHQL
@@ -125,9 +61,4 @@ declare module 'graphql-tag/parser' {
 
 declare module 'graphql-tag/printer' {
   function print(ast: any): string;
-}
-
-declare module 'deep-assign' {
-  function deepAssign(...objects: any[]): any;
-  export = deepAssign;
 }


### PR DESCRIPTION
this removes the custom typing for lodash and uses `@typings/lodash` instead.
also removed the typing for deep-merge which isn't used

I had to disable the cache as well since it seems it uses old modules otherwise

<!--
  Thanks for filing a pull request on Apollo Client!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change
- [ ] Add your name and email to the AUTHORS file (optional)
- [ ] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion
