### PR TITLE
remove appveyor cache

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,3 @@ test_script:
 # nothing to compile in this project
 build: off
 deploy: off
-
-cache:
-  - node_modules


### PR DESCRIPTION

disables node_modules caching since the npm client can't update dependencies properly
