### PR TITLE
Pass query variables to reducer function

### DIFF
--- a/src/data/mutationResults.ts
+++ b/src/data/mutationResults.ts
@@ -311,7 +311,7 @@ export type MutationQueryReducersMap = {
   [queryName: string]: MutationQueryReducer;
 };
 
-export type OperationResultReducer = (previousResult: Object, action: ApolloAction) => Object;
+export type OperationResultReducer = (previousResult: Object, action: ApolloAction, variables: Object) => Object;
 
 export type OperationResultReducerMap = {
   [queryId: string]: OperationResultReducer;

--- a/src/data/resultReducers.ts
+++ b/src/data/resultReducers.ts
@@ -50,7 +50,7 @@ export function createStoreReducer(
     });
     // TODO add info about networkStatus
 
-    const nextResult = resultReducer(currentResult, action); // action should include operation name
+    const nextResult = resultReducer(currentResult, action, variables); // action should include operation name
 
     if (currentResult !== nextResult) {
       return writeResultToStore({


### PR DESCRIPTION
References issue #939.

This allows the reducer to use variables passed to the query in order to determine whether the data is relevant to that query or not.

