### PR TITLE
Use lodash/assign instead of Object.assign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 3 to 6 months), to signal the start of a more stable API.
 
 ### vNEXT
-- Replace usages of `Object.assign` with lodash's assign function.
+- Replace usages of `Object.assign` with lodash's assign function [PR #1009](https://github.com/apollostack/apollo-client/pull/1009)
 
 ### 0.5.12
 - Errors thrown in afterwares bubble up [PR #982](https://github.com/apollostack/apollo-client/pull/982)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,6 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 3 to 6 months), to signal the start of a more stable API.
 
 ### vNEXT
-
-### 0.5.13
 - Replace usages of `Object.assign` with lodash's assign function.
 
 ### 0.5.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Expect active development and potentially significant breaking changes in the `0
 
 ### vNEXT
 
+### 0.5.13
+- Replace usages of `Object.assign` with lodash's assign function.
+
 ### 0.5.12
 - Errors thrown in afterwares bubble up [PR #982](https://github.com/apollostack/apollo-client/pull/982)
 - Replaced individual lodash packages with original lodash package [PR #997](https://github.com/apollostack/apollo-client/pull/997)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-client",
-  "version": "0.5.13",
+  "version": "0.5.12",
   "description": "A simple yet functional GraphQL client.",
   "main": "./lib/src/index.js",
   "typings": "./lib/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-client",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "description": "A simple yet functional GraphQL client.",
   "main": "./lib/src/index.js",
   "typings": "./lib/src/index.d.ts",

--- a/src/ApolloClient.ts
+++ b/src/ApolloClient.ts
@@ -276,7 +276,7 @@ export default class ApolloClient {
     // We add the fragments to the document to pass only the document around internally.
     const fullDocument = addFragmentsToDocument(options.query, options.fragments);
 
-    const realOptions = Object.assign({}, options, {
+    const realOptions = assign({}, options, {
       query: fullDocument,
     });
     delete realOptions.fragments;
@@ -326,7 +326,7 @@ export default class ApolloClient {
     // We add the fragments to the document to pass only the document around internally.
     const fullDocument = addFragmentsToDocument(options.query, options.fragments);
 
-    const realOptions = Object.assign({}, options, {
+    const realOptions = assign({}, options, {
       query: fullDocument,
     });
     delete realOptions.fragments;
@@ -384,7 +384,7 @@ export default class ApolloClient {
     // We add the fragments to the document to pass only the document around internally.
     const fullDocument = addFragmentsToDocument(options.mutation, options.fragments);
 
-    const realOptions = Object.assign({}, options, {
+    const realOptions = assign({}, options, {
       mutation: fullDocument,
     });
     delete realOptions.fragments;
@@ -411,7 +411,7 @@ export default class ApolloClient {
     // We add the fragments to the document to pass only the document around internally.
     const fullDocument = addFragmentsToDocument(options.query, options.fragments);
 
-    const realOptions = Object.assign({}, options, {
+    const realOptions = assign({}, options, {
       document: fullDocument,
     });
     delete realOptions.fragments;

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -6,6 +6,7 @@ import {
 
 import forOwn = require('lodash/forOwn');
 import isEqual = require('lodash/isEqual');
+import assign = require('lodash/assign');
 
 import {
   ApolloStore,
@@ -431,7 +432,7 @@ export class QueryManager {
     // Call just to get errors synchronously
     getQueryDefinition(options.query);
 
-    let transformedOptions = Object.assign({}, options) as WatchQueryOptions;
+    let transformedOptions = assign({}, options) as WatchQueryOptions;
     if (this.addTypename) {
       transformedOptions.query = addTypenameToDocument(transformedOptions.query);
     }

--- a/src/store.ts
+++ b/src/store.ts
@@ -110,7 +110,7 @@ export function createApolloReducer(config: ApolloReducerConfig): Function {
 
       return newState;
     } catch (reducerError) {
-      return Object.assign({}, state, {
+      return assign({}, state, {
          reducerError,
        });
     }


### PR DESCRIPTION
This PR changes any places that uses `Object.assign` with lodash's assign function. This is so the library is usable on IE without having to use polyfills. Other places in the code were using lodash/assign aside from these two spots. 
