### PR TITLE
Added an analyze script

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,6 +13,7 @@ Google Inc.
 Ian Grayson <ian133@gmail.com>
 Ian MacLeod <ian@nevir.net>
 James Baxley <james.baxley@newspring.cc>
+Jayden Seric <me@jaydenseric.com>
 Jesper Håkansson <jesper@jesperh.se>
 John Pinkerton <jpinkerton88@gmail.com>
 Jonas Helfer <helfer@users.noreply.github.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ Expect active development and potentially significant breaking changes in the `0
 ### vNEXT
 - Ensure transporters are using `isomorphic-fetch` instead of `whatwg-fetch` for universal compatibility [PR #1018](https://github.com/apollostack/apollo-client/pull/1018)
 
-- Added a new analyze script to the package.json that makes it possible to inspect what modules make it into the published package and how efficiently it bundles in a webpack v2 project. [PR #1044](https://github.com/apollostack/apollo-client/pull/1044)
-
 ### 0.5.21
 
 - Include a `version` field on every `ApolloClient` instance that represents the version of the 'apollo-client' package used to create it. [PR #1038](https://github.com/apollostack/apollo-client/pull/1038)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Expect active development and potentially significant breaking changes in the `0
 
 ### vNEXT
 
-- ...
+- Added a new analyze script to the package.json that makes it possible to inspect what modules make it into the published package and how efficiently it bundles in a webpack v2 project. [PR #1044](https://github.com/apollostack/apollo-client/pull/1044)
 
 ### 0.5.21
 

--- a/analyze/src/index.js
+++ b/analyze/src/index.js
@@ -1,0 +1,1 @@
+import ApolloClient from '../../lib/src';

--- a/analyze/webpack.config.js
+++ b/analyze/webpack.config.js
@@ -1,0 +1,14 @@
+const path = require('path');
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+
+module.exports = {
+  context: __dirname,
+  entry: './src/index.js',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'bundle.js'
+  },
+  plugins: [
+    new BundleAnalyzerPlugin()
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "lint": "grunt tslint",
     "coverage": "istanbul cover ./node_modules/mocha/bin/_mocha -- --reporter dot --full-trace lib/test/tests.js",
     "postcoverage": "remap-istanbul --input coverage/coverage.json --type lcovonly --output coverage/lcov.info",
-    "testonly": "mocha --reporter spec --full-trace lib/test/tests.js"
+    "testonly": "mocha --reporter spec --full-trace lib/test/tests.js",
+    "preanalyze": "npm run compile",
+    "analyze": "webpack -p --config analyze/webpack.config.js"
   },
   "repository": {
     "type": "git",
@@ -69,7 +71,9 @@
     "source-map-support": "^0.4.0",
     "tslint": "4.0.2",
     "typescript": "2.1.4",
-    "uglify-js": "^2.6.2"
+    "uglify-js": "^2.6.2",
+    "webpack": "^2.1.0-beta.28",
+    "webpack-bundle-analyzer": "^2.1.1"
   },
   "optionalDependencies": {
     "@types/async": "^2.0.31",


### PR DESCRIPTION
Added a new analyze script to the package.json that makes it possible to inspect what modules make it into the published package and how efficiently it bundles in a webpack v2 project.

The script runs a compilation and builds the analyze test project (that only imports this library) with webpack and the webpack-bundle-analyzer plugin in production mode. Once complete the plugin opens  your browser to an interactive analysis at http://localhost:8888.

See [discussion](https://github.com/apollostack/apollo-client/issues/684#issuecomment-266983921).