### PR TITLE
Fix reducers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Expect active development and potentially significant breaking changes in the `0
 ### vNEXT
 
 - ...
+- Fix bug that caused updateQuery and reducers to run on stopped queries [PR #1054](https://github.com/apollostack/apollo-client/pull/1054)
 
 ### 0.5.21
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -366,6 +366,11 @@ export class ObservableQuery extends Observable<ApolloQueryResult> {
 
     const retQuerySubscription = {
       unsubscribe: () => {
+        if (this.observers.findIndex(el => el === observer) < 0 ) {
+          // XXX can't unsubscribe if you've already unsubscribed...
+          // for some reason unsubscribe gets called multiple times by some of the tests
+          return;
+        }
         this.observers = this.observers.filter((obs) => obs !== observer);
 
         if (this.observers.length === 0) {
@@ -435,6 +440,9 @@ export class ObservableQuery extends Observable<ApolloQueryResult> {
     this.subscriptionHandles = [];
 
     this.queryManager.stopQuery(this.queryId);
+    if (this.shouldSubscribe) {
+      this.queryManager.removeObservableQuery(this.queryId);
+    }
     this.observers = [];
   }
 }

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -640,9 +640,7 @@ export class QueryManager {
     Object.keys(this.observableQueries).forEach((queryId) => {
       const storeQuery = this.reduxRootSelector(this.store.getState()).queries[queryId];
 
-      if (! this.observableQueries[queryId].observableQuery.options.noFetch &&
-        ! (storeQuery && storeQuery.stopped)
-      ) {
+      if (!this.observableQueries[queryId].observableQuery.options.noFetch) {
         this.observableQueries[queryId].observableQuery.refetch();
       }
     });

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -271,19 +271,6 @@ export class QueryManager {
 
     this.queryDocuments[mutationId] = mutation;
 
-    const extraReducers = Object.keys(this.observableQueries).map( queryId => {
-      const queryOptions = this.observableQueries[queryId].observableQuery.options;
-      if (queryOptions.reducer) {
-        return createStoreReducer(
-          queryOptions.reducer,
-          queryOptions.query,
-          queryOptions.variables,
-          this.reducerConfig,
-          );
-      }
-      return null;
-    }).filter( reducer => reducer !== null );
-
     this.store.dispatch({
       type: 'APOLLO_MUTATION_INIT',
       mutationString,
@@ -293,7 +280,7 @@ export class QueryManager {
       mutationId,
       optimisticResponse,
       resultBehaviors: [...resultBehaviors, ...updateQueriesResultBehaviors],
-      extraReducers,
+      extraReducers: this.getExtraReducers(),
     });
 
     return new Promise((resolve, reject) => {
@@ -315,7 +302,7 @@ export class QueryManager {
                 ...resultBehaviors,
                 ...this.collectResultBehaviorsFromUpdateQueries(updateQueries, result),
             ],
-            extraReducers,
+            extraReducers: this.getExtraReducers(),
           });
 
           refetchQueries.forEach((name) => { this.refetchQueryByName(name); });

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -150,7 +150,7 @@ export class QueryManager {
   private queryListeners: { [queryId: string]: QueryListener[] };
   private queryDocuments: { [queryId: string]: Document };
 
-  private idCounter = 0;
+  private idCounter = 1; // XXX let's not start at zero to avoid pain with bad checks
 
   // A map going from a requestId to a promise that has not yet been resolved. We use this to keep
   // track of queries that are inflight and reject them in case some
@@ -594,7 +594,7 @@ export class QueryManager {
     // Insert the ObservableQuery into this.observableQueriesByName if the query has a name
     const queryDef = getQueryDefinition(observableQuery.options.query);
     if (queryDef.name && queryDef.name.value) {
-      const queryName = getQueryDefinition(observableQuery.options.query).name.value;
+      const queryName = queryDef.name.value;
 
       // XXX we may we want to warn the user about query name conflicts in the future
       this.queryIdsByName[queryName] = this.queryIdsByName[queryName] || [];
@@ -604,11 +604,14 @@ export class QueryManager {
 
   public removeObservableQuery(queryId: string) {
     const observableQuery = this.observableQueries[queryId].observableQuery;
-    const queryName = getQueryDefinition(observableQuery.options.query).name.value;
+    const definition = getQueryDefinition(observableQuery.options.query);
+    const queryName = definition.name ? definition.name.value : null;
     delete this.observableQueries[queryId];
-    this.queryIdsByName[queryName] = this.queryIdsByName[queryName].filter((val) => {
-      return !(observableQuery.queryId === val);
-    });
+    if (queryName) {
+      this.queryIdsByName[queryName] = this.queryIdsByName[queryName].filter((val) => {
+        return !(observableQuery.queryId === val);
+      });
+    }
   }
 
   public resetStore(): void {

--- a/src/queries/store.ts
+++ b/src/queries/store.ts
@@ -182,13 +182,7 @@ export function queries(
   } else if (isQueryStopAction(action)) {
     const newState = assign({}, previousState) as QueryStore;
 
-    // TODO (NOW): actually remove stopped queries from store. Fix for real this time.
-    newState[action.queryId] = assign({}, previousState[action.queryId], {
-      loading: false,
-      stopped: true,
-      networkStatus: NetworkStatus.ready,
-    }) as QueryStoreValue;
-
+    delete newState[action.queryId];
     return newState;
   } else if (isStoreResetAction(action)) {
     return resetQueryState(previousState, action);

--- a/src/queries/store.ts
+++ b/src/queries/store.ts
@@ -182,6 +182,7 @@ export function queries(
   } else if (isQueryStopAction(action)) {
     const newState = assign({}, previousState) as QueryStore;
 
+    // TODO (NOW): actually remove stopped queries from store. Fix for real this time.
     newState[action.queryId] = assign({}, previousState[action.queryId], {
       loading: false,
       stopped: true,

--- a/src/queries/store.ts
+++ b/src/queries/store.ts
@@ -39,7 +39,6 @@ export type QueryStoreValue = {
   queryString: string;
   variables: Object;
   previousVariables: Object;
-  stopped: boolean;
   loading: boolean;
   networkStatus: NetworkStatus;
   networkError: Error;
@@ -108,7 +107,6 @@ export function queries(
       queryString: action.queryString,
       variables: action.variables,
       previousVariables,
-      stopped: false,
       loading: true,
       networkError: null,
       graphQLErrors: null,

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -535,7 +535,7 @@ describe('QueryManager', () => {
     });
   });
 
-  it('allows you to subscribe twice to the one query', (done) => {
+  it('allows you to subscribe twice to one query', (done) => {
     const request = {
       query: gql`
         query fetchLuke($id: String) {

--- a/test/client.ts
+++ b/test/client.ts
@@ -489,7 +489,6 @@ describe('client', () => {
           variables: undefined,
           loading: false,
           networkStatus: NetworkStatus.ready,
-          stopped: false,
           networkError: null,
           graphQLErrors: null,
           forceFetch: false,

--- a/test/client.ts
+++ b/test/client.ts
@@ -484,7 +484,7 @@ describe('client', () => {
 
     const finalState = { apollo: assign({}, initialState.apollo, {
       queries: {
-        '0': {
+        '1': {
           queryString: print(query),
           variables: undefined,
           loading: false,
@@ -494,7 +494,7 @@ describe('client', () => {
           graphQLErrors: null,
           forceFetch: false,
           returnPartialData: false,
-          lastRequestId: 1,
+          lastRequestId: 2,
           previousVariables: null,
           metadata: null,
         },

--- a/test/optimistic.ts
+++ b/test/optimistic.ts
@@ -825,6 +825,12 @@ describe('optimistic mutation results', () => {
       }, {
         request: { query: mutation },
         result: mutationResult2,
+        // XXX this test will uncover a flaw in the design of optimistic responses combined with
+        // updateQueries or result reducers if you un-comment the line below. The issue is that
+        // optimistic updates are not commutative but are treated as such. When undoing an
+        // optimistic update, other optimistic updates should be rolled back and re-applied in the
+        // same order as before, otherwise the store can end up in an inconsistent state.
+        // delay: 50,
       })
       .then(() => {
         // we have to actually subscribe to the query to be able to update it

--- a/test/store.ts
+++ b/test/store.ts
@@ -157,7 +157,6 @@ describe('createApolloStore', () => {
           'previousVariables': undefined as any,
           'queryString': '',
           'returnPartialData': false,
-          'stopped': false,
           'variables': {},
           'metadata': null,
         },


### PR DESCRIPTION
Fixes #902 #903 (?) #993 #1026 

This was a pretty hairy affair, but I think I've managed to untangle things enough so that stopped queries are now actually removed from the store and no longer tracked. That means that their reducers and updateQuery functions no longer run.

I don't think #903 is really fixed by this, but the discussion there is so long that I think it's better if we start a new issue about running reducers for other variables than the current query variables (cc @richburdon @yurigenin)



TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
- [x] Add your name and email to the AUTHORS file (optional)
- [x] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion
