### PR TITLE
Revert "Ensure transporters are using isomorphic-fetch instead of browser only whatwg-fetch"

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,7 +9,6 @@ David Alan Hjelle <dahjelle+github.com@thehjellejar.com>
 David Glasser <glasser@meteor.com>
 Dhaivat Pandya <dhaivat@meteor.com>
 Dhaivat Pandya <dhaivatpandya@gmail.com>
-Guilherme Blanco <guilhermeblanco@hotmail.com>
 Google Inc.
 Ian Grayson <ian133@gmail.com>
 Ian MacLeod <ian@nevir.net>

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "lodash": "^4.17.2",
     "redux": "^3.3.1",
     "symbol-observable": "^1.0.2",
-    "isomorphic-fetch": "^2.2.1"
+    "whatwg-fetch": "^2.0.0"
   },
   "devDependencies": {
     "@types/chai-as-promised": "0.0.28",
@@ -58,6 +58,7 @@
     "grunt": "1.0.1",
     "grunt-tslint": "4.0.0",
     "gzip-size": "^3.0.0",
+    "isomorphic-fetch": "^2.2.1",
     "istanbul": "^0.4.5",
     "lodash": "^4.17.1",
     "minimist": "^1.2.0",

--- a/src/transport/batchedNetworkInterface.ts
+++ b/src/transport/batchedNetworkInterface.ts
@@ -2,7 +2,7 @@ import {
   GraphQLResult,
 } from 'graphql';
 
-import 'isomorphic-fetch';
+import 'whatwg-fetch';
 
 import assign = require('lodash/assign');
 import isNumber = require('lodash/isNumber');

--- a/src/transport/networkInterface.ts
+++ b/src/transport/networkInterface.ts
@@ -1,7 +1,7 @@
 import isString = require('lodash/isString');
 import assign = require('lodash/assign');
 import mapValues = require('lodash/mapValues');
-import 'isomorphic-fetch';
+import 'whatwg-fetch';
 
 import {
   GraphQLResult,

--- a/test/batchedNetworkInterface.ts
+++ b/test/batchedNetworkInterface.ts
@@ -19,7 +19,7 @@ import { AfterwareInterface } from '../src/transport/afterware';
 
 import { GraphQLResult } from 'graphql';
 
-import 'isomorphic-fetch';
+import 'whatwg-fetch';
 
 import gql from 'graphql-tag';
 

--- a/test/mocks/mockFetch.ts
+++ b/test/mocks/mockFetch.ts
@@ -1,7 +1,7 @@
-import 'isomorphic-fetch';
+import 'whatwg-fetch';
 
-// This is an implementation of a mocked window.fetch/global.fetch implementation
-// similar in structure to the MockedNetworkInterface.
+// This is an implementation of a mocked window.fetch implementation similar in
+// structure to the MockedNetworkInterface.
 
 export interface MockedIResponse {
   json(): Promise<JSON>;


### PR DESCRIPTION
Reverts apollostack/apollo-client#1018

Turns out isomorphic-fetch doesn't work in react native.