### PR TITLE
setOptions now handle going from noFetch=true to noFetch=false

### DIFF
--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -271,8 +271,8 @@ export class ObservableQuery extends Observable<ApolloQueryResult> {
       this.stopPolling();
     }
 
-    // If forceFetch went from false to true
-    if (!oldOptions.forceFetch && opts.forceFetch) {
+    // If forceFetch went from false to true or noFetch went from true to false
+    if ((!oldOptions.forceFetch && opts.forceFetch) || (oldOptions.noFetch && !opts.noFetch)) {
       return this.queryManager.fetchQuery(this.queryId, this.options)
         .then(result => this.queryManager.transformResult(result));
     }

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -340,7 +340,7 @@ export class QueryManager {
       }
 
       const shouldNotifyIfLoading = queryStoreValue.returnPartialData
-        || queryStoreValue.previousVariables;
+        || queryStoreValue.previousVariables || options.noFetch;
 
       const networkStatusChanged = lastResult && queryStoreValue.networkStatus !== lastResult.networkStatus;
 

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -349,8 +349,10 @@ export class QueryManager {
         return;
       }
 
+      const noFetch = this.observableQueries[queryId] ? this.observableQueries[queryId].observableQuery.options.noFetch : options.noFetch;
+
       const shouldNotifyIfLoading = queryStoreValue.returnPartialData
-        || queryStoreValue.previousVariables || options.noFetch;
+        || queryStoreValue.previousVariables || noFetch;
 
       const networkStatusChanged = lastResult && queryStoreValue.networkStatus !== lastResult.networkStatus;
 
@@ -390,12 +392,13 @@ export class QueryManager {
                 store: this.getDataWithOptimisticResults(),
                 query: this.queryDocuments[queryId],
                 variables: queryStoreValue.previousVariables || queryStoreValue.variables,
-                returnPartialData: options.returnPartialData || options.noFetch,
+                returnPartialData: options.returnPartialData || noFetch,
                 config: this.reducerConfig,
               }),
               loading: queryStoreValue.loading,
               networkStatus: queryStoreValue.networkStatus,
             };
+
             if (observer.next) {
               if (this.isDifferentResult(lastResult, resultFromStore)) {
                 lastResult = resultFromStore;


### PR DESCRIPTION
Hi,

QueryObservable setOptions method does not handle switching from noFetch=true to noFetch=false.

This PR solves this.

If you agree, I can add test (eventually please give me some indication if it is not straightforward).
