### PR TITLE
Expose NetworkStatus enum in the public API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,10 @@ import {
 } from './queries/getFromAST';
 
 import {
+  NetworkStatus,
+} from './queries/store';
+
+import {
   ApolloError,
 } from './errors/ApolloError';
 
@@ -84,6 +88,7 @@ export {
   writeQueryToStore,
   print as printAST,
   createFragmentMap,
+  NetworkStatus,
   ApolloError,
 
   // fragment stuff


### PR DESCRIPTION
Enables writing:
```js
<RefreshControl
  refreshing={this.props.data.networkStatus === NetworkStatus.refetch}
  onRefresh={this.handleRefetch}
/>
```
instead of current:
```js
<RefreshControl
  refreshing={this.props.data.networkStatus === 4}
  onRefresh={this.handleRefetch}
/>
```

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
- [x] Add your name and email to the AUTHORS file (optional)
- [ ] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion
