### PR TITLE
Only check queries on Apollo actions

### DIFF
--- a/src/ApolloClient.ts
+++ b/src/ApolloClient.ts
@@ -462,14 +462,17 @@ export default class ApolloClient {
 
       return (next: any) => (action: any) => {
         const returnValue = next(action);
-        this.queryManager.broadcastNewStore(store.getState());
 
-        if (this.devToolsHookCb) {
-          this.devToolsHookCb({
-            action,
-            state: this.queryManager.getApolloState(),
-            dataWithOptimisticResults: this.queryManager.getDataWithOptimisticResults(),
-          });
+        if (/^APOLLO_/.test(action.type)) {
+          this.queryManager.broadcastNewStore(store.getState());
+
+          if (this.devToolsHookCb) {
+            this.devToolsHookCb({
+              action,
+              state: this.queryManager.getApolloState(),
+              dataWithOptimisticResults: this.queryManager.getDataWithOptimisticResults(),
+            });
+          }
         }
 
         return returnValue;


### PR DESCRIPTION
This is an optimization for when Apollo shares the Redux store with the application, so that no needless checks are performed.

TODO:

- [x] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change
