### PR TITLE
Fix dependent optimistic updates

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -29,5 +29,5 @@ cp README.md npm/
 cp LICENSE npm/
 cp .npmignore npm/
 
-echo 'deploying to npm...'
-cd npm && npm publish
+# echo 'deploying to npm...'
+# cd npm && npm publish


### PR DESCRIPTION
Currently if you had two optimistic updates say that depended on the current state when one of the optimistic updates was removed because the mutation finished the second optimistic update’s patch in the store would be based on top of the last optimistic update which is no longer applied.

This issue manifested itself in https://github.com/apollostack/apollo-client/issues/1100. The client is put into a loading state after an error in the `graphql-anywhere` resolver is thrown as `graphql-anywhere` is trying to resolve data from a previous optimistic result that was removed when the mutation successfully returned. To illustrate using the specific error in https://github.com/apollostack/apollo-client/issues/1100:

We have state that looks like:

```yaml
data:
  ROOT_QUERY:
    items: [Item1, Item2]
  ...
```

Then a mutation is fired and an optimistic patch is added so now we have:

```yaml
data:
  ROOT_QUERY:
    items: [Item1, Item2]
  ...
optimistic:
  -
    ROOT_QUERY:
      items: [Item1, Item2, ItemA]
      ...
```

Where `ItemA` represents an item with a client generated id since the mutation has not given us a server-generated id. Then a second mutation is fired so our store looks like:

```yaml
data:
  ROOT_QUERY:
    items: [Item1, Item2]
  ...
optimistic:
  -
    ROOT_QUERY:
      items: [Item1, Item2, ItemA]
      ...
  -
    ROOT_QUERY:
      items: [Item1, Item2, ItemA, ItemB]
      ...
```

Where `ItemB` is another item with a client generated id. Then our first mutation resolves and our store looks like:

```yaml
data:
  ROOT_QUERY:
    items: [Item1, Item2]
  ...
optimistic:
  -
    ROOT_QUERY:
      items: [Item1, Item2, ItemA, ItemB]
      ...
```

This is where the error manifests. See how `ItemA` stuck around? `graphql-anywhere` will therefore throw when trying to resolve `ItemA`. It should be removed when the first mutation completes.

The correct solution in this case is to rewind all of our optimistic updates whenever one finishes and replay them one by one on the new store. That is what this PR implements.

At the time of this issue opening, I have not yet added tests or fixed the failing ones (the failing tests are trivial it would appear).

Closes https://github.com/apollostack/apollo-client/issues/1100

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change