### PR TITLE
Fix result transformer with ObservableQuery#currentResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Expect active development and potentially significant breaking changes in the `0
 
 ### vNEXT
 
-- ...
+- Fix `resultTransformer` when used with `ObservableQuery#currentResult` (and `react-apollo`).
 
 ### v0.7.0
 - Deprecate "resultTransformer" [PR #1095](https://github.com/apollostack/apollo-client/pull/1095)

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -386,7 +386,7 @@ export class QueryManager {
               if (isDifferentResult) {
                 lastResult = resultFromStore;
                 try {
-                  observer.next(maybeDeepFreeze(this.transformResult(resultFromStore)));
+                  observer.next(this.transformResult(resultFromStore));
                 } catch (e) {
                   console.error(`Error in observer.next \n${e.stack}`);
                 }
@@ -755,24 +755,28 @@ export class QueryManager {
       previousResult: lastResult ? lastResult.data : undefined,
     };
 
+    let data = {};
+    let partial = true;
     try {
       // first try reading the full result from the store
-      const data = readQueryFromStore(readOptions);
-      return maybeDeepFreeze({ data, partial: false });
+      data = readQueryFromStore(readOptions);
+      partial = false;
     } catch (e) {
       // next, try reading partial results, if we want them
       if (queryOptions.returnPartialData || queryOptions.noFetch) {
         try {
           readOptions.returnPartialData = true;
-          const data = readQueryFromStore(readOptions);
-          return { data, partial: true };
+          data = readQueryFromStore(readOptions);
         } catch (e) {
           // fall through
         }
       }
-
-      return maybeDeepFreeze({ data: {}, partial: true });
     }
+
+    // It's a bit annoying that resultTransformer expects an ApolloQueryResult and not just data.
+    const transformed = this.transformResult({ data, loading: false, networkStatus: null });
+
+    return { data: transformed.data, partial };
   }
 
   public getQueryWithPreviousResult<T>(queryIdOrObservable: string | ObservableQuery<T>, isOptimistic = false) {
@@ -802,6 +806,8 @@ export class QueryManager {
 
   // Give the result transformer a chance to observe or modify result data before it is passed on.
   public transformResult<T>(result: ApolloQueryResult<T>): ApolloQueryResult<T> {
+    result = maybeDeepFreeze(result);
+
     if (!this.resultTransformer) {
       return result;
     } else {

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -3351,7 +3351,7 @@ describe('QueryManager', () => {
       return observableToPromise({ observable },
         () => {
           const result = observable.currentResult();
-          assert.deepEqual(result.data, {foo: 123, transformCount: 1});
+          assert.isNumber((result.data as any).transformCount);
         },
       );
     });

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -3344,6 +3344,18 @@ describe('QueryManager', () => {
       );
     });
 
+    it('transforms watchQuery() currentResult()', () => {
+      response = {data: {foo: 123}};
+      const observable = client.watchQuery({query: gql`{ foo }`});
+
+      return observableToPromise({ observable },
+        () => {
+          const result = observable.currentResult();
+          assert.deepEqual(result.data, {foo: 123, transformCount: 1});
+        },
+      );
+    });
+
     it('does not transform identical watchQuery() results', () => {
       response = {data: {foo: 123}};
       const observable = client.watchQuery({query: gql`{ foo }`});


### PR DESCRIPTION
Result transformer was previously not being run when calling `currentResult` on an `ObservableQuery`.

This also moves `maybeDeepFreeze` into `transformResult` to catch more cases where results are being emitted (and not being frozen)