### PR TITLE
Add whatwg-fetch back in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ Expect active development and potentially significant breaking changes in the `0
 ### vNEXT
 
 - ...
+
+### 0.7.1
 - Add whatwg-fetch polyfill (most likely only until version 1.0) [PR #1155](https://github.com/apollostack/apollo-client/pull/1155)
 
-### v0.7.0
+### 0.7.0
 - Deprecate "resultTransformer" [PR #1095](https://github.com/apollostack/apollo-client/pull/1095)
 - Deep freeze results in development and test mode [PR #1095](https://github.com/apollostack/apollo-client/pull/1095)
 - Allow using typescript generics for query and mutation [PR #914](https://github.com/apollostack/apollo-client/pull/914)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Expect active development and potentially significant breaking changes in the `0
 ### vNEXT
 
 - ...
+- Add whatwg-fetch polyfill (most likely only until version 1.0) [PR #1155](https://github.com/apollostack/apollo-client/pull/1155)
 
 ### v0.7.0
 - Deprecate "resultTransformer" [PR #1095](https://github.com/apollostack/apollo-client/pull/1095)

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "graphql-anywhere": "^2.0.0",
     "graphql-tag": "^1.1.1",
     "redux": "^3.4.0",
-    "symbol-observable": "^1.0.2"
+    "symbol-observable": "^1.0.2",
+    "whatwg-fetch": "^2.0.0"
   },
   "devDependencies": {
     "@types/chai": "^3.4.32",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-client",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "A simple yet functional GraphQL client.",
   "main": "./lib/apollo.umd.js",
   "module": "./lib/src/index.js",

--- a/src/transport/batchedNetworkInterface.ts
+++ b/src/transport/batchedNetworkInterface.ts
@@ -2,6 +2,8 @@ import {
   ExecutionResult,
 } from 'graphql';
 
+import 'whatwg-fetch';
+
 import {
   HTTPFetchNetworkInterface,
   HTTPNetworkInterface,

--- a/src/transport/networkInterface.ts
+++ b/src/transport/networkInterface.ts
@@ -243,16 +243,5 @@ as of Apollo Client 0.5. Please pass it as the "uri" property of the network int
     opts = (uriOrInterfaceOpts as NetworkInterfaceOptions).opts;
     uri = (uriOrInterfaceOpts as NetworkInterfaceOptions).uri;
   }
-
-  // Warn if there is no global `fetch` implementation.
-  if (typeof fetch === 'undefined') {
-    console.warn([
-      '[apollo-client]: An implementation for the fetch browser API could not be found. Apollo',
-      'client requires fetch to execute GraphQL queries against your API server. Please include a',
-      'global fetch implementation such as [whatwg-fetch](http://npmjs.com/whatwg-fetch) so that',
-      'Apollo client can run in this environment.',
-    ].join(' '));
-  }
-
   return new HTTPFetchNetworkInterface(uri, opts);
 }

--- a/src/transport/networkInterface.ts
+++ b/src/transport/networkInterface.ts
@@ -1,3 +1,5 @@
+import 'whatwg-fetch';
+
 import {
   ExecutionResult,
   DocumentNode,

--- a/test/batchedNetworkInterface.ts
+++ b/test/batchedNetworkInterface.ts
@@ -21,6 +21,8 @@ import { ExecutionResult } from 'graphql';
 
 import gql from 'graphql-tag';
 
+import 'whatwg-fetch';
+
 describe('HTTPBatchedNetworkInterface', () => {
   // Helper method that tests a roundtrip given a particular set of requests to the
   // batched network interface and the

--- a/test/mocks/mockFetch.ts
+++ b/test/mocks/mockFetch.ts
@@ -1,3 +1,5 @@
+import 'whatwg-fetch';
+
 // This is an implementation of a mocked window.fetch implementation similar in
 // structure to the MockedNetworkInterface.
 

--- a/test/networkInterface.ts
+++ b/test/networkInterface.ts
@@ -154,29 +154,6 @@ describe('network interface', () => {
       }, /Passing the URI as the first argument to createNetworkInterface is deprecated/);
     });
 
-    it('will warn if there is no global fetch implementation', () => {
-      const origWarn = console.warn;
-      const origFetch = (global as any).fetch;
-
-      const warnCalls: Array<Array<any>> = [];
-
-      console.warn = (...args: Array<any>) => warnCalls.push(args);
-
-      delete (global as any).fetch;
-
-      assert.equal(warnCalls.length, 0);
-
-      createNetworkInterface({ uri: '/graphql' });
-
-      assert.equal(warnCalls.length, 1);
-      assert.equal(warnCalls[0].length, 1);
-      assert(/the fetch browser API could not be found/.test(warnCalls[0][0]));
-
-      // Put everything back the way it was.
-      console.warn = origWarn;
-      (global as any).fetch = origFetch;
-    });
-
     it('should create an instance with a given uri', () => {
       const networkInterface = createNetworkInterface({ uri: '/graphql' });
       assert.equal(networkInterface._uri, '/graphql');


### PR DESCRIPTION
After much discussion we decided to add whatwg-fetch back in, at least until version 1.0.

No longer including a fetch polyfill will break Apollo Client for users on older browsers or Safari, and developers might not find out about it in their tests, so it seems prudent to keep it until we can find out a way to make it very clear that a fetch polyfill should be installed alongside Apollo Client.