### PR TITLE
Support optional arguments in mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 3 to 6 months), to signal the start of a more stable API.
 
 ### vNEXT
-
-- ...
+- Allow optional mutation arguments. [PR #1174](https://github.com/apollostack/apollo-client/pull/1174)
 
 ### 0.7.1
 - *Undo breaking change:* Add whatwg-fetch polyfill (most likely only until version 1.0) [PR #1155](https://github.com/apollostack/apollo-client/pull/1155)

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -284,6 +284,13 @@ export class QueryManager {
             extraReducers: this.getExtraReducers(),
           });
 
+          // If there was an error in our reducers, reject this promise!
+          const { reducerError } = this.getApolloState();
+          if (reducerError) {
+            reject(reducerError);
+            return;
+          }
+
           refetchQueries.forEach((name) => { this.refetchQueryByName(name); });
           delete this.queryDocuments[mutationId];
           resolve(this.transformResult(<ApolloQueryResult<T>>result));

--- a/src/data/storeUtils.ts
+++ b/src/data/storeUtils.ts
@@ -16,7 +16,6 @@ import {
 } from 'graphql';
 
 function isStringValue(value: ValueNode): value is StringValueNode {
-
   return value.kind === 'StringValue';
 }
 
@@ -58,10 +57,7 @@ function valueToObjectRepresentation(argObj: any, name: NameNode, value: ValueNo
     value.fields.map((obj) => valueToObjectRepresentation(nestedArgObj, obj.name, obj.value, variables));
     argObj[name.value] = nestedArgObj;
   } else if (isVariable(value)) {
-    if (! variables || !(value.name.value in variables)) {
-      throw new Error(`The inline argument "${value.name.value}" is expected as a variable but was not provided.`);
-    }
-    const variableValue = (variables as any)[value.name.value];
+    const variableValue = (variables || {} as any)[value.name.value];
     argObj[name.value] = variableValue;
   } else if (isListValue(value)) {
     argObj[name.value] = value.values.map((listValue) => {

--- a/test/mutationResults.ts
+++ b/test/mutationResults.ts
@@ -1427,4 +1427,121 @@ describe('mutation results', () => {
 
     watchedQuery.refetch(variables2);
   });
+
+  it('allows mutations with optional arguments', done => {
+    let count = 0;
+
+    client = new ApolloClient({
+      addTypename: false,
+      networkInterface: {
+        query ({ variables }) {
+          switch (count++) {
+            case 0:
+              assert.deepEqual(variables, { a: 1, b: 2 });
+              return Promise.resolve({ data: { result: 'hello' } });
+            case 1:
+              assert.deepEqual(variables, { a: 1, c: 3 });
+              return Promise.resolve({ data: { result: 'world' } });
+            case 2:
+              assert.deepEqual(variables, { a: undefined, b: 2, c: 3 });
+              return Promise.resolve({ data: { result: 'goodbye' } });
+            case 3:
+              assert.equal(variables, undefined);
+              return Promise.resolve({ data: { result: 'moon' } });
+            default:
+              return Promise.reject(new Error('Too many network calls.'));
+          }
+        },
+      },
+    });
+
+    const mutation = gql`
+      mutation ($a: Int!, $b: Int, $c: Int) {
+        result(a: $a, b: $b, c: $c)
+      }
+    `;
+
+    Promise.all([
+      client.mutate({
+        mutation,
+        variables: { a: 1, b: 2 },
+      }),
+      client.mutate({
+        mutation,
+        variables: { a: 1, c: 3 },
+      }),
+      client.mutate({
+        mutation,
+        variables: { a: undefined, b: 2, c: 3 },
+      }),
+      client.mutate({
+        mutation,
+      }),
+    ]).then(() => {
+      assert.deepEqual(client.queryManager.getApolloState().data, {
+        ROOT_MUTATION: {
+          'result({"a":1,"b":2})': 'hello',
+          'result({"a":1,"c":3})': 'world',
+          'result({"b":2,"c":3})': 'goodbye',
+          'result({})': 'moon',
+        },
+      });
+      done();
+    }).catch(done);
+  });
+
+  it('will pass null to the network interface when provided', done => {
+    let count = 0;
+
+    client = new ApolloClient({
+      addTypename: false,
+      networkInterface: {
+        query ({ variables }) {
+          switch (count++) {
+            case 0:
+              assert.deepEqual(variables, { a: 1, b: 2, c: null });
+              return Promise.resolve({ data: { result: 'hello' } });
+            case 1:
+              assert.deepEqual(variables, { a: 1, b: null, c: 3 });
+              return Promise.resolve({ data: { result: 'world' } });
+            case 2:
+              assert.deepEqual(variables, { a: null, b: null, c: null });
+              return Promise.resolve({ data: { result: 'moon' } });
+            default:
+              return Promise.reject(new Error('Too many network calls.'));
+          }
+        },
+      },
+    });
+
+    const mutation = gql`
+      mutation ($a: Int!, $b: Int, $c: Int) {
+        result(a: $a, b: $b, c: $c)
+      }
+    `;
+
+    Promise.all([
+      client.mutate({
+        mutation,
+        variables: { a: 1, b: 2, c: null },
+      }),
+      client.mutate({
+        mutation,
+        variables: { a: 1, b: null, c: 3 },
+      }),
+      client.mutate({
+        mutation,
+        variables: { a: null, b: null, c: null },
+      }),
+    ]).then(() => {
+      assert.deepEqual(client.queryManager.getApolloState().data, {
+        ROOT_MUTATION: {
+          'result({"a":1,"b":2,"c":null})': 'hello',
+          'result({"a":1,"b":null,"c":3})': 'world',
+          'result({"a":null,"b":null,"c":null})': 'moon',
+        },
+      });
+      done();
+    }).catch(done);
+  });
 });

--- a/test/writeToStore.ts
+++ b/test/writeToStore.ts
@@ -1013,43 +1013,6 @@ describe('writing to the store', () => {
     assert.deepEqual(storeWithId, expStoreWithId);
   });
 
-  it('throw an error if a variable is not provided', () => {
-    const testData = [
-      {
-        mutation: gql`mutation mut($v: ID) { mut(v: $v) { id } }`,
-        variables: { not_the_proper_variable_name: '1' },
-        expected: /The inline argument "v" is expected as a variable but was not provided./,
-      },
-    ];
-
-    const result: any = { mut: { id: '1' } };
-
-    function isOperationDefinition(value: ASTNode): value is OperationDefinitionNode {
-      return value.kind === 'OperationDefinition';
-    }
-
-    testData.forEach(({mutation, variables, expected}) => {
-      mutation.definitions.map((def: OperationDefinitionNode) => {
-        assert.throws(() => {
-          if (isOperationDefinition(def)) {
-            writeSelectionSetToStore({
-              dataId: '5',
-              selectionSet: def.selectionSet,
-              result: cloneDeep(result),
-              context: {
-                store: {},
-                variables,
-                dataIdFromObject: () => '5',
-              },
-            });
-          } else {
-            throw 'No operation definition found';
-          }
-        }, expected);
-      });
-    });
-  });
-
   it('does not swallow errors other than field errors', () => {
     const query = gql`
       query {


### PR DESCRIPTION
Fixes https://github.com/apollostack/apollo-client/issues/852 and https://github.com/apollostack/apollo-client/issues/1094 but only for mutations (its the Apollo reducer errors that get swallowed, not user reducer errors. Although user code may be called from the Apollo reducer).

This invalidates a previously expected behavior so I had to delete an old test. However the old behavior was a rejection of functionality allowed by the spec (or more accurately by GraphQL server implementations). By removing the test and changing the functionality we are not introducing a breaking change.

In https://github.com/apollostack/apollo-client/issues/852 @stubailo also mentioned updating [`graphql-anywhere`](https://github.com/apollostack/graphql-anywhere/blob/5335986c60786d62734f701385648a7da59ecff1/src/storeUtils.ts#L56) or potentially merging the `storeUtils` functions. Which direction to we want to go for this? This PR only allows optional arguments for mutations currently until `graphql-anywhere` can be updated.

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change