### PR TITLE
fix: Typescript error with strictNullChecks

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -32,6 +32,7 @@ Oleksandr Stubailo <sashko@Oleksandrs-MacBook-Pro.local>
 Olivier Ricordeau <olivier@ricordeau.org>
 Pavol Fulop <pavol.fulop@regex.sk>
 Pavol Fulop <pavolfulop@gmail.com>
+Rasmus Eneman <rasmus@eneman.eu>
 Robin Ricard <ricard.robin@gmail.com>
 Sashko Stubailo <s.stubailo@gmail.com>
 Sashko Stubailo <sashko@stubailo.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@ Expect active development and potentially significant breaking changes in the `0
 
 ### vNEXT
 
+- Fix typings error with `strictNullChecks` [PR #1188](https://github.com/apollostack/apollo-client/pull/1188)
 - ...
 
 ### 0.7.3
 - *Fixed breaking change:* readQueryFromStore was incomptibale with Typescript 2.0 compiler. [PR #1171](https://github.com/apollostack/apollo-client/pull/1171)
 
 ### 0.7.2
-Re-release of 0.7.1 with proper internal directory structure 
+Re-release of 0.7.1 with proper internal directory structure
 
 ### 0.7.1
 - *Undo breaking change:* Add whatwg-fetch polyfill (most likely only until version 1.0) [PR #1155](https://github.com/apollostack/apollo-client/pull/1155)

--- a/src/ApolloClient.ts
+++ b/src/ApolloClient.ts
@@ -132,22 +132,7 @@ export default class ApolloClient {
    * with identical parameters (query, variables, operationName) is already in flight.
    *
    */
-  constructor({
-    networkInterface,
-    reduxRootKey,
-    reduxRootSelector,
-    initialState,
-    dataIdFromObject,
-    resultComparator,
-    ssrMode = false,
-    ssrForceFetchDelay = 0,
-    mutationBehaviorReducers = {} as MutationBehaviorReducerMap,
-    addTypename = true,
-    resultTransformer,
-    customResolvers,
-    connectToDevTools,
-    queryDeduplication = false,
-  }: {
+  constructor(options: {
     networkInterface?: NetworkInterface,
     reduxRootKey?: string,
     reduxRootSelector?: string | ApolloStateSelector,
@@ -163,6 +148,22 @@ export default class ApolloClient {
     connectToDevTools?: boolean,
     queryDeduplication?: boolean,
   } = {}) {
+    let {
+      networkInterface,
+      reduxRootKey,
+      reduxRootSelector,
+      initialState,
+      dataIdFromObject,
+      resultComparator,
+      ssrMode = false,
+      ssrForceFetchDelay = 0,
+      mutationBehaviorReducers = {} as MutationBehaviorReducerMap,
+      addTypename = true,
+      resultTransformer,
+      customResolvers,
+      connectToDevTools,
+      queryDeduplication = false,
+    } = options;
     if (reduxRootKey && reduxRootSelector) {
       throw new Error('Both "reduxRootKey" and "reduxRootSelector" are configured, but only one of two is allowed.');
     }


### PR DESCRIPTION
fixes #800

Enabling strictNullChecks in apollo-client itself caused a lot of errors so while it may be best solution over time, this is a quicker one that fixes the current errors.