### PR TITLE
Add compare dates fail test

### DIFF
--- a/src/util/isEqual.ts
+++ b/src/util/isEqual.ts
@@ -1,6 +1,11 @@
 /**
  * Performs a deep equality check on two JavaScript values.
  */
+const toString = Object.prototype.toString;
+const isDate = function(obj: any): boolean {
+  return toString.call(obj) === '[object Date]';
+};
+
 export function isEqual (a: any, b: any): boolean {
   // If the two values are strictly equal, we are good.
   if (a === b) {
@@ -27,6 +32,11 @@ export function isEqual (a: any, b: any): boolean {
         return false;
       }
     }
+
+    if (isDate(a) && isDate(b)) {
+      return +a === +b;
+    }
+
     // If we made it this far the objects are equal!
     return true;
   }

--- a/test/isEqual.ts
+++ b/test/isEqual.ts
@@ -55,4 +55,10 @@ describe('isEqual', () => {
     assert(!isEqual({ x: { a: 1, b: 2, c: 3 } }, { x: { a: 1, b: 2 } }));
     assert(!isEqual({ x: { a: 1, b: 2 } }, { x: { a: 1, b: 2, c: 3 } }));
   });
+
+  it('should correctly compare dates', () => {
+    assert(isEqual(new Date(2017, 5, 16), new Date(2017, 5, 16)), 'Date objects referencing identical times are equal');
+    assert(!isEqual(new Date(2016, 4, 15), new Date(2017, 5, 16)), 'Date objects referencing different times are not equal');
+    assert(!isEqual(new Date('Curly'), new Date('Curly')), 'Invalid dates are not equal');
+  });
 });


### PR DESCRIPTION
I have queries that need to be rerun when dates variable are changed.

I realised that they did reach to the server. 
After a bit of digging I found that the `isEqual` used [here](https://github.com/apollostack/apollo-client/blob/master/src/core/ObservableQuery.ts#L316) method returned true for different variables when the difference is the dates.

I add fail test for isEqual and try to solve will the second commit. 
However the change make the test really slow and cause to over tests to fail.

Is `isEqual` doesn't compare dates on purpose?
Do you have a suggestion on how to solve this?

my query looks like 
```
gql`
  query CityWithEventsQuery($city: String, $startDate: Date, $endDate: Date) {
    city(city: $city) {
      id
      name
      events(startDate: $startDate, endDate: $endDate) {
         name
        startDate
        endDate
      }
    }
  }
`
```
