### PR TITLE
Refactor: Enable TypeScript strict null checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Expect active development and potentially significant breaking changes in the `0
 - Fix bug where there could be store inconsistencies for two dependent optimistic updates [PR #1144](https://github.com/apollostack/apollo-client/pull/1144)
 - expose partial in ObservableQuery#currentResult [PR #1097](https://github.com/apollostack/apollo-client/pull/1097)
 - Calculate `loading` from `networkStatus`. [PR #1202](https://github.com/apollostack/apollo-client/pull/1202)
-- Fix typings error with `strictNullChecks` [PR #1188](https://github.com/apollostack/apollo-client/pull/1188)
+- Fix typings error with `strictNullChecks` and enable TypeScript strict null checking in source code. [PR #1188](https://github.com/apollostack/apollo-client/pull/1188) and [PR #1221](https://github.com/apollostack/apollo-client/pull/1221)
 - Gracefully handle `null` GraphQL errors. [PR #1208](https://github.com/apollostack/apollo-client/pull/1208)
 - *Breaking:* Remove undocumented `resultBehaviors` feature. [PR #1173](https://github.com/apollostack/apollo-client/pull/1173)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 3 to 6 months), to signal the start of a more stable API.
 
 ### vNEXT
-
+- Enable TypeScript strict null checking in source code. [PR #1221](https://github.com/apollostack/apollo-client/pull/1221)
 - ...
 
 ### 0.8.0
@@ -11,7 +11,7 @@ Expect active development and potentially significant breaking changes in the `0
 - Fix bug where there could be store inconsistencies for two dependent optimistic updates [PR #1144](https://github.com/apollostack/apollo-client/pull/1144)
 - expose partial in ObservableQuery#currentResult [PR #1097](https://github.com/apollostack/apollo-client/pull/1097)
 - Calculate `loading` from `networkStatus`. [PR #1202](https://github.com/apollostack/apollo-client/pull/1202)
-- Fix typings error with `strictNullChecks` and enable TypeScript strict null checking in source code. [PR #1188](https://github.com/apollostack/apollo-client/pull/1188) and [PR #1221](https://github.com/apollostack/apollo-client/pull/1221)
+- Fix typings error with `strictNullChecks` [PR #1188](https://github.com/apollostack/apollo-client/pull/1188)
 - Gracefully handle `null` GraphQL errors. [PR #1208](https://github.com/apollostack/apollo-client/pull/1208)
 - *Breaking:* Remove undocumented `resultBehaviors` feature. [PR #1173](https://github.com/apollostack/apollo-client/pull/1173)
 

--- a/src/ApolloClient.ts
+++ b/src/ApolloClient.ts
@@ -91,10 +91,10 @@ export default class ApolloClient {
   public queryManager: QueryManager;
   public reducerConfig: ApolloReducerConfig;
   public addTypename: boolean;
-  public resultTransformer: ResultTransformer;
-  public resultComparator: ResultComparator;
+  public resultTransformer: ResultTransformer | undefined;
+  public resultComparator: ResultComparator | undefined;
   public shouldForceFetch: boolean;
-  public dataId: IdGetter;
+  public dataId: IdGetter | undefined;
   public fieldWithArgs: (fieldName: string, args?: Object) => string;
   public version: string;
   public queryDeduplication: boolean;
@@ -148,7 +148,7 @@ export default class ApolloClient {
     connectToDevTools?: boolean,
     queryDeduplication?: boolean,
   } = {}) {
-    let {
+    const {
       networkInterface,
       reduxRootKey,
       reduxRootSelector,
@@ -227,11 +227,7 @@ export default class ApolloClient {
       !isProduction() &&
       typeof window !== 'undefined' && (!(window as any).__APOLLO_CLIENT__);
 
-    if (typeof connectToDevTools === 'undefined') {
-      connectToDevTools = defaultConnectToDevTools;
-    }
-
-    if (connectToDevTools) {
+    if (typeof connectToDevTools === 'undefined' ? defaultConnectToDevTools : connectToDevTools) {
       (window as any).__APOLLO_CLIENT__ = this;
     }
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -83,7 +83,7 @@ export interface MutationInitAction {
   variables: Object;
   operationName: string;
   mutationId: string;
-  optimisticResponse: Object;
+  optimisticResponse: Object | undefined;
   extraReducers?: ApolloReducer[];
   updateQueries?: { [queryId: string]: MutationQueryReducer };
 }

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -126,7 +126,10 @@ export class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
     const { data, partial } = this.queryManager.getCurrentQueryResult(this, true);
     const queryStoreValue = this.queryManager.getApolloState().queries[this.queryId];
 
-    if (queryStoreValue && (queryStoreValue.graphQLErrors || queryStoreValue.networkError)) {
+    if (queryStoreValue && (
+      (queryStoreValue.graphQLErrors && queryStoreValue.graphQLErrors.length > 0) ||
+      queryStoreValue.networkError
+    )) {
       const error = new ApolloError({
         graphQLErrors: queryStoreValue.graphQLErrors,
         networkError: queryStoreValue.networkError,

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -49,7 +49,7 @@ export interface FetchMoreOptions {
 }
 
 export interface UpdateQueryOptions {
-  variables: Object;
+  variables?: Object;
 }
 
 export class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
@@ -307,7 +307,7 @@ export class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
 
     // If forceFetch went from false to true or noFetch went from true to false
     const tryFetch: boolean = (!oldOptions.forceFetch && opts.forceFetch)
-      || (oldOptions.noFetch && !opts.noFetch);
+      || (oldOptions.noFetch && !opts.noFetch) || false;
 
     return this.setVariables(this.options.variables, tryFetch);
   }
@@ -335,7 +335,7 @@ export class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
       ...variables,
     };
 
-    const nullPromise = new Promise((resolve) => resolve(null));
+    const nullPromise = new Promise((resolve) => resolve());
 
     if (isEqual(newVariables, this.variables) && !tryFetch) {
       // If we have no observers, then we don't actually want to make a network

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -250,9 +250,11 @@ export class QueryManager {
 
     // Create a map of update queries by id to the query instead of by name.
     const updateQueries: { [queryId: string]: MutationQueryReducer } = {};
-    Object.keys(updateQueriesByName || {}).forEach(queryName => (this.queryIdsByName[queryName] || []).forEach(queryId => {
-      updateQueries[queryId] = updateQueriesByName[queryName];
-    }));
+    if (updateQueriesByName) {
+      Object.keys(updateQueriesByName).forEach(queryName => (this.queryIdsByName[queryName] || []).forEach(queryId => {
+        updateQueries[queryId] = updateQueriesByName[queryName];
+      }));
+    }
 
     this.store.dispatch({
       type: 'APOLLO_MUTATION_INIT',

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -342,7 +342,10 @@ export class QueryManager {
 
         // If we have either a GraphQL error or a network error, we create
         // an error and tell the observer about it.
-        if (queryStoreValue.graphQLErrors || queryStoreValue.networkError) {
+        if (
+          (queryStoreValue.graphQLErrors && queryStoreValue.graphQLErrors.length > 0) ||
+          queryStoreValue.networkError
+        ) {
           const apolloError = new ApolloError({
             graphQLErrors: queryStoreValue.graphQLErrors,
             networkError: queryStoreValue.networkError,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -40,4 +40,4 @@ export enum FetchType {
   poll = 3,
 }
 
-export type IdGetter = (value: Object) => string;
+export type IdGetter = (value: Object) => string | null | undefined;

--- a/src/data/readFromStore.ts
+++ b/src/data/readFromStore.ts
@@ -256,7 +256,7 @@ export function diffQueryAgainstStore({
     // Global settings
     store,
     returnPartialData,
-    customResolvers: config && config.customResolvers,
+    customResolvers: (config && config.customResolvers) || {},
 
     // Flag set during execution
     hasMissingField: false,

--- a/src/data/store.ts
+++ b/src/data/store.ts
@@ -142,8 +142,9 @@ export function data(
       });
 
       // If this action wants us to update certain queries. Let’s do it!
-      if (constAction.updateQueries) {
-        Object.keys(constAction.updateQueries).forEach(queryId => {
+      const { updateQueries } = constAction;
+      if (updateQueries) {
+        Object.keys(updateQueries).forEach(queryId => {
           const query = queries[queryId];
           if (!query) {
             return;
@@ -158,7 +159,7 @@ export function data(
             config,
           });
 
-          const reducer = constAction.updateQueries[queryId];
+          const reducer = updateQueries[queryId];
 
           // Run our reducer using the current query result and the mutation result.
           const nextQueryResult = tryFunctionOrLogError(() => reducer(currentQueryResult, {

--- a/src/data/storeUtils.ts
+++ b/src/data/storeUtils.ts
@@ -138,7 +138,7 @@ export interface JsonValue {
   json: any;
 }
 
-export type StoreValue = number | string | string[] | IdValue | JsonValue | void;
+export type StoreValue = number | string | string[] | IdValue | JsonValue | null | undefined | void;
 
 export function isIdValue(idObject: StoreValue): idObject is IdValue {
   return (

--- a/src/data/writeToStore.ts
+++ b/src/data/writeToStore.ts
@@ -61,7 +61,7 @@ export function writeQueryToStore({
   query,
   store = {} as NormalizedCache,
   variables,
-  dataIdFromObject = null,
+  dataIdFromObject,
   fragmentMap = {} as FragmentMap,
 }: {
   result: Object,
@@ -99,7 +99,7 @@ export function writeResultToStore({
   document,
   store = {} as NormalizedCache,
   variables,
-  dataIdFromObject = null,
+  dataIdFromObject,
 }: {
   dataId: string,
   result: any,
@@ -172,7 +172,7 @@ export function writeSelectionSetToStore({
         fragment = selection;
       } else {
         // Named fragment
-        fragment = fragmentMap[selection.name.value];
+        fragment = (fragmentMap || {})[selection.name.value];
 
         if (!fragment) {
           throw new Error(`No fragment named ${selection.name.value}.`);
@@ -236,7 +236,7 @@ function writeFieldToStore({
   // specifies if we need to merge existing keys in the store
   let shouldMerge = false;
   // If we merge, this will be the generatedKey
-  let generatedKey: string;
+  let generatedKey: string = '';
 
   // If this is a scalar value...
   if (!field.selectionSet || value === null) {

--- a/src/errors/ApolloError.ts
+++ b/src/errors/ApolloError.ts
@@ -33,7 +33,7 @@ import { GraphQLError } from 'graphql';
 export class ApolloError extends Error {
   public message: string;
   public graphQLErrors: GraphQLError[];
-  public networkError: Error;
+  public networkError: Error | null;
 
   // An object that can be used to provide some additional information
   // about an error, e.g. specifying the type of error this is. Used
@@ -50,13 +50,13 @@ export class ApolloError extends Error {
     extraInfo,
   }: {
     graphQLErrors?: GraphQLError[],
-    networkError?: Error,
+    networkError?: Error | null,
     errorMessage?: string,
     extraInfo?: any,
   }) {
     super(errorMessage);
-    this.graphQLErrors = graphQLErrors;
-    this.networkError = networkError;
+    this.graphQLErrors = graphQLErrors || [];
+    this.networkError = networkError || null;
 
     // set up the stack trace
     this.stack = new Error().stack;

--- a/src/mutations/store.ts
+++ b/src/mutations/store.ts
@@ -18,7 +18,7 @@ export interface MutationStoreValue {
   mutationString: string;
   variables: Object;
   loading: boolean;
-  error: Error;
+  error: Error | null;
 }
 
 export interface SelectionSetWithRoot {

--- a/src/queries/directives.ts
+++ b/src/queries/directives.ts
@@ -7,11 +7,7 @@ import {
 } from 'graphql';
 
 
-export function shouldInclude(selection: SelectionNode, variables?: { [name: string]: any }): boolean {
-  if (!variables) {
-    variables = {};
-  }
-
+export function shouldInclude(selection: SelectionNode, variables: { [name: string]: any } = {}): boolean {
   if (!selection.directives) {
     return true;
   }
@@ -25,19 +21,19 @@ export function shouldInclude(selection: SelectionNode, variables?: { [name: str
     }
 
     //evaluate the "if" argument and skip (i.e. return undefined) if it evaluates to true.
-    const directiveArguments = directive.arguments;
+    const directiveArguments = directive.arguments || [];
     const directiveName = directive.name.value;
     if (directiveArguments.length !== 1) {
       throw new Error(`Incorrect number of arguments for the @${directiveName} directive.`);
     }
 
 
-    const ifArgument = directive.arguments[0];
+    const ifArgument = directiveArguments[0];
     if (!ifArgument.name || ifArgument.name.value !== 'if') {
       throw new Error(`Invalid argument for the @${directiveName} directive.`);
     }
 
-    const ifValue = directive.arguments[0].value;
+    const ifValue = directiveArguments[0].value;
     let evaledValue: boolean = false;
     if (!ifValue || ifValue.kind !== 'BooleanValue') {
       // means it has to be a variable value if this is a valid @skip or @include directive

--- a/src/queries/getFromAST.ts
+++ b/src/queries/getFromAST.ts
@@ -8,7 +8,7 @@ import {
 export function getMutationDefinition(doc: DocumentNode): OperationDefinitionNode {
   checkDocument(doc);
 
-  let mutationDef: OperationDefinitionNode = null;
+  let mutationDef: OperationDefinitionNode | null = null;
   doc.definitions.forEach((definition) => {
     if (definition.kind === 'OperationDefinition'
         && (definition as OperationDefinitionNode).operation === 'mutation') {
@@ -55,9 +55,8 @@ string in a "gql" tag? http://docs.apollostack.com/apollo-client/core.html#gql`)
 export function getOperationName(doc: DocumentNode): string {
   let res: string = '';
   doc.definitions.forEach((definition) => {
-    if (definition.kind === 'OperationDefinition'
-        && (definition as OperationDefinitionNode).name) {
-      res = (definition as OperationDefinitionNode).name.value;
+    if (definition.kind === 'OperationDefinition' && definition.name) {
+      res = definition.name.value;
     }
   });
   return res;
@@ -79,7 +78,7 @@ export function getFragmentDefinitions(doc: DocumentNode): FragmentDefinitionNod
 export function getQueryDefinition(doc: DocumentNode): OperationDefinitionNode {
   checkDocument(doc);
 
-  let queryDef: OperationDefinitionNode = null;
+  let queryDef: OperationDefinitionNode | null = null;
   doc.definitions.map((definition) => {
     if (definition.kind === 'OperationDefinition'
        && (definition as OperationDefinitionNode).operation === 'query') {
@@ -98,7 +97,7 @@ export function getQueryDefinition(doc: DocumentNode): OperationDefinitionNode {
 export function getOperationDefinition(doc: DocumentNode): OperationDefinitionNode {
   checkDocument(doc);
 
-  let opDef: OperationDefinitionNode = null;
+  let opDef: OperationDefinitionNode | null = null;
   doc.definitions.map((definition) => {
     if (definition.kind === 'OperationDefinition') {
       opDef = definition as OperationDefinitionNode;

--- a/src/queries/queryTransform.ts
+++ b/src/queries/queryTransform.ts
@@ -15,7 +15,6 @@ import { cloneDeep } from '../util/cloneDeep';
 
 const TYPENAME_FIELD: FieldNode = {
   kind: 'Field',
-  alias: null,
   name: {
     kind: 'Name',
     value: '__typename',
@@ -26,7 +25,7 @@ function addTypenameToSelectionSet(
   selectionSet: SelectionSetNode,
   isRoot = false,
 ) {
-  if (selectionSet && selectionSet.selections) {
+  if (selectionSet.selections) {
     if (! isRoot) {
       const alreadyHasThisField = selectionSet.selections.some((selection) => {
         return selection.kind === 'Field' && (selection as FieldNode).name.value === '__typename';
@@ -39,7 +38,9 @@ function addTypenameToSelectionSet(
 
     selectionSet.selections.forEach((selection) => {
       if (selection.kind === 'Field' || selection.kind === 'InlineFragment') {
-        addTypenameToSelectionSet((selection as FieldNode | InlineFragmentNode).selectionSet);
+        if (selection.selectionSet) {
+          addTypenameToSelectionSet(selection.selectionSet);
+        }
       }
     });
   }

--- a/src/queries/store.ts
+++ b/src/queries/store.ts
@@ -126,7 +126,7 @@ export function queries(
     newState[action.queryId] = {
       ...previousState[action.queryId],
       networkError: null,
-      graphQLErrors: resultHasGraphQLErrors ? action.result.errors : null,
+      graphQLErrors: resultHasGraphQLErrors ? action.result.errors : [],
       previousVariables: null,
       networkStatus: NetworkStatus.ready,
     };

--- a/src/queries/store.ts
+++ b/src/queries/store.ts
@@ -31,9 +31,9 @@ export type QueryStoreValue = {
   queryString: string;
   document: DocumentNode;
   variables: Object;
-  previousVariables: Object;
+  previousVariables: Object | null;
   networkStatus: NetworkStatus;
-  networkError: Error;
+  networkError: Error | null;
   graphQLErrors: GraphQLError[];
   forceFetch: boolean;
   returnPartialData: boolean;
@@ -65,7 +65,7 @@ export function queries(
 
     let isSetVariables = false;
 
-    let previousVariables: Object;
+    let previousVariables: Object | null = null;
     if (
       action.storePreviousVariables &&
       previousQuery &&
@@ -101,7 +101,7 @@ export function queries(
       variables: action.variables,
       previousVariables,
       networkError: null,
-      graphQLErrors: null,
+      graphQLErrors: [],
       networkStatus: newNetworkStatus,
       forceFetch: action.forceFetch,
       returnPartialData: action.returnPartialData,
@@ -166,7 +166,7 @@ export function queries(
       // and do not need to hit the server. Not sure when we'd fire this action if the result is not complete, so that bears explanation.
       // We should write that down somewhere.
       networkStatus: action.complete ? NetworkStatus.ready : NetworkStatus.loading,
-    } as QueryStoreValue;
+    };
 
     return newState;
   } else if (isQueryStopAction(action)) {

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -73,7 +73,7 @@ export class QueryScheduler {
 
   public startPollingQuery<T>(
     options: WatchQueryOptions,
-    queryId?: string,
+    queryId: string,
     listener?: QueryListener,
   ): string {
     if (!options.pollInterval) {
@@ -134,6 +134,10 @@ export class QueryScheduler {
   // and query options must have been added to this.registeredQueries before this function is called.
   public addQueryOnInterval<T>(queryId: string, queryOptions: WatchQueryOptions) {
     const interval = queryOptions.pollInterval;
+
+    if (!interval) {
+      throw new Error(`A poll interval is required to start polling query with id '${queryId}'.`);
+    }
 
     // If there are other queries on this interval, this query will just fire with those
     // and we don't need to create a new timer.

--- a/src/transport/batchedNetworkInterface.ts
+++ b/src/transport/batchedNetworkInterface.ts
@@ -141,5 +141,5 @@ export function createBatchingNetworkInterface(options: BatchingNetworkInterface
   if (! options) {
     throw new Error('You must pass an options argument to createNetworkInterface.');
   }
-  return new HTTPBatchedNetworkInterface(options.uri, options.batchInterval, options.opts);
+  return new HTTPBatchedNetworkInterface(options.uri, options.batchInterval, options.opts || {});
 }

--- a/src/transport/batching.ts
+++ b/src/transport/batching.ts
@@ -54,7 +54,7 @@ export class QueryBatcher {
 
   // Consumes the queue. Called on a polling interval.
   // Returns a list of promises (one for each query).
-  public consumeQueue(): Promise<ExecutionResult>[] | undefined {
+  public consumeQueue(): (Promise<ExecutionResult> | undefined)[] | undefined {
     if (this.queuedRequests.length < 1) {
       return undefined;
     }
@@ -67,7 +67,7 @@ export class QueryBatcher {
       };
     });
 
-    const promises: Promise<ExecutionResult>[] = [];
+    const promises: (Promise<ExecutionResult> | undefined)[] = [];
     const resolvers: any[] = [];
     const rejecters: any[] = [];
     this.queuedRequests.forEach((fetchRequest, index) => {

--- a/src/transport/networkInterface.ts
+++ b/src/transport/networkInterface.ts
@@ -88,7 +88,7 @@ export class HTTPFetchNetworkInterface implements NetworkInterface {
   public _middlewares: MiddlewareInterface[];
   public _afterwares: AfterwareInterface[];
 
-  constructor(uri: string, opts: RequestInit = {}) {
+  constructor(uri: string | undefined, opts: RequestInit = {}) {
     if (!uri) {
       throw new Error('A remote endpoint is required for a network layer');
     }
@@ -112,7 +112,9 @@ export class HTTPFetchNetworkInterface implements NetworkInterface {
         const next = () => {
           if (funcs.length > 0) {
             const f = funcs.shift();
-            f.applyMiddleware.apply(scope, [{ request, options }, next]);
+            if (f) {
+              f.applyMiddleware.apply(scope, [{ request, options }, next]);
+            }
           } else {
             resolve({
               request,
@@ -229,8 +231,8 @@ export function createNetworkInterface(
     throw new Error('You must pass an options argument to createNetworkInterface.');
   }
 
-  let uri: string;
-  let opts: RequestInit;
+  let uri: string | undefined;
+  let opts: RequestInit | undefined;
 
   // We want to change the API in the future so that you just pass all of the options as one
   // argument, so even though the internals work with two arguments we're warning here.
@@ -238,10 +240,10 @@ export function createNetworkInterface(
     console.warn(`Passing the URI as the first argument to createNetworkInterface is deprecated \
 as of Apollo Client 0.5. Please pass it as the "uri" property of the network interface options.`);
     opts = secondArgOpts;
-    uri = uriOrInterfaceOpts as string;
+    uri = uriOrInterfaceOpts;
   } else {
-    opts = (uriOrInterfaceOpts as NetworkInterfaceOptions).opts;
-    uri = (uriOrInterfaceOpts as NetworkInterfaceOptions).uri;
+    opts = uriOrInterfaceOpts.opts;
+    uri = uriOrInterfaceOpts.uri;
   }
   return new HTTPFetchNetworkInterface(uri, opts);
 }

--- a/test/ObservableQuery.ts
+++ b/test/ObservableQuery.ts
@@ -256,8 +256,8 @@ describe('ObservableQuery', () => {
     });
 
     it('does a network request if noFetch becomes true then store is reset then noFetch becomes false', (done) => {
-      let queryManager: QueryManager = null;
-      let observable: ObservableQuery<any> = null;
+      let queryManager: QueryManager;
+      let observable: ObservableQuery<any>;
       const testQuery = gql`
         query {
           author {
@@ -309,8 +309,8 @@ describe('ObservableQuery', () => {
     });
 
     it('does a network request if noFetch becomes false', (done) => {
-      let queryManager: QueryManager = null;
-      let observable: ObservableQuery<any> = null;
+      let queryManager: QueryManager;
+      let observable: ObservableQuery<any>;
       const testQuery = gql`
         query {
           author {
@@ -637,7 +637,7 @@ describe('ObservableQuery', () => {
           const currentResult = observable.currentResult();
 
           assert.equal(currentResult.loading, false);
-          assert.deepEqual(currentResult.error.graphQLErrors, [error]);
+          assert.deepEqual(currentResult.error!.graphQLErrors, [error]);
         });
     });
 

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -128,7 +128,7 @@ describe('QueryManager', () => {
     });
     const finalOptions = assign({ query, variables }, queryOptions) as WatchQueryOptions;
     return queryManager.watchQuery<any>(finalOptions).subscribe({
-      next: wrap(done, observer.next),
+      next: wrap(done, observer.next!),
       error: observer.error,
     });
   };
@@ -463,7 +463,7 @@ describe('QueryManager', () => {
         error: (error) => {
           const apolloError = error as ApolloError;
           assert(apolloError.networkError);
-          assert.include(apolloError.networkError.message, 'Network error');
+          assert.include(apolloError.networkError!.message, 'Network error');
           done();
         },
       },
@@ -555,7 +555,7 @@ describe('QueryManager', () => {
       result: expResult,
     });
 
-    const observable = Rx.Observable.from(handle);
+    const observable = Rx.Observable.from(handle as any);
 
 
     observable
@@ -2272,7 +2272,7 @@ describe('QueryManager', () => {
     });
 
     it('should only refetch once when we store reset', () => {
-      let queryManager: QueryManager = null;
+      let queryManager: QueryManager;
       const query = gql`
         query {
           author {
@@ -2311,8 +2311,8 @@ describe('QueryManager', () => {
     });
 
     it('should not refetch toredown queries', (done) => {
-      let queryManager: QueryManager = null;
-      let observable: ObservableQuery<any> = null;
+      let queryManager: QueryManager;
+      let observable: ObservableQuery<any>;
       const query = gql`
         query {
           author {
@@ -2356,7 +2356,7 @@ describe('QueryManager', () => {
     });
 
     it('should not error on queries that are already in the store', () => {
-      let queryManager: QueryManager = null;
+      let queryManager: QueryManager;
       const query = gql`
         query {
           author {
@@ -2436,7 +2436,7 @@ describe('QueryManager', () => {
       const mockObservableQuery: ObservableQuery<any> = {
         refetch(variables: any): Promise<ExecutionResult> {
           done();
-          return null;
+          return null as never;
         },
         options: {
           query: query,
@@ -2466,7 +2466,7 @@ describe('QueryManager', () => {
         refetch(variables: any): Promise<ExecutionResult> {
           refetchCount ++;
           done();
-          return null;
+          return null as never;
         },
         options,
         queryManager: queryManager,
@@ -2483,7 +2483,7 @@ describe('QueryManager', () => {
     });
 
     it('should throw an error on an inflight query() if the store is reset', (done) => {
-      let queryManager: QueryManager = null;
+      let queryManager: QueryManager;
       const query = gql`
         query {
           author {
@@ -2534,9 +2534,9 @@ describe('QueryManager', () => {
 
       assert(apolloError.message);
       assert.equal(apolloError.networkError, networkError);
-      assert(!apolloError.graphQLErrors);
+      assert.deepEqual(apolloError.graphQLErrors, []);
       done();
-    });
+    }).catch(done);
   });
 
   it('should error when we attempt to give an id beginning with $', (done) => {
@@ -2864,7 +2864,7 @@ describe('QueryManager', () => {
           errorCallbacks: [
             // This isn't the best error message, but at least people will know they are missing
             // data in the store.
-            (error: ApolloError) => assert.include(error.networkError.message, 'find field'),
+            (error: ApolloError) => assert.include(error.networkError!.message, 'find field'),
           ],
           wait: 60,
         },

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -428,7 +428,7 @@ describe('QueryManager', () => {
         }
       }`,
       result: {
-        errors: [null],
+        errors: [null as any],
       },
       observer: {
         next() {

--- a/test/batching.ts
+++ b/test/batching.ts
@@ -92,9 +92,9 @@ describe('QueryBatcher', () => {
       });
 
       myBatcher.enqueueRequest(request);
-      const promises: Promise<ExecutionResult>[] = myBatcher.consumeQueue();
+      const promises: (Promise<ExecutionResult> | undefined)[] = myBatcher.consumeQueue()!;
       assert.equal(promises.length, 1);
-      promises[0].then((resultObj) => {
+      promises[0]!.then((resultObj) => {
         assert.equal(myBatcher.queuedRequests.length, 0);
         assert.deepEqual(resultObj, { data } );
         done();
@@ -121,12 +121,12 @@ describe('QueryBatcher', () => {
       });
       myBatcher.enqueueRequest(request);
       myBatcher.enqueueRequest(request2);
-      const promises: Promise<ExecutionResult>[] = myBatcher.consumeQueue();
+      const promises: (Promise<ExecutionResult> | undefined)[] = myBatcher.consumeQueue()!;
       assert.equal(batcher.queuedRequests.length, 0);
       assert.equal(promises.length, 2);
-      promises[0].then((resultObj1) => {
+      promises[0]!.then((resultObj1) => {
         assert.deepEqual(resultObj1, { data });
-        promises[1].then((resultObj2) => {
+        promises[1]!.then((resultObj2) => {
           assert.deepEqual(resultObj2, { data });
           done();
         });

--- a/test/client.ts
+++ b/test/client.ts
@@ -475,7 +475,7 @@ describe('client', () => {
           variables: {},
           networkStatus: NetworkStatus.ready,
           networkError: null,
-          graphQLErrors: null,
+          graphQLErrors: [],
           forceFetch: false,
           returnPartialData: false,
           lastRequestId: 2,
@@ -1329,7 +1329,7 @@ it('should not let errors in observer.next reach the store', (done) => {
       done(new Error('Returned a result when it should not have.'));
     }).catch((error: ApolloError) => {
       assert(error.networkError);
-      assert.equal(error.networkError.message, networkError.message);
+      assert.equal(error.networkError!.message, networkError.message);
       done();
     });
   });

--- a/test/diffAgainstStore.ts
+++ b/test/diffAgainstStore.ts
@@ -106,7 +106,6 @@ describe('diffing queries against the store', () => {
       diffQueryAgainstStore({
         store,
         query: unionQuery,
-        variables: null,
       });
     }, /No fragment/);
   });
@@ -148,7 +147,6 @@ describe('diffing queries against the store', () => {
     const { isMissing } = diffQueryAgainstStore({
       store,
       query: unionQuery,
-      variables: null,
       returnPartialData: false,
     });
 
@@ -193,7 +191,6 @@ describe('diffing queries against the store', () => {
     const { isMissing } = diffQueryAgainstStore({
       store,
       query: unionQuery,
-      variables: null,
       returnPartialData: false,
     });
 
@@ -239,7 +236,6 @@ describe('diffing queries against the store', () => {
       diffQueryAgainstStore({
         store,
         query: unionQuery,
-        variables: null,
         returnPartialData: false,
       });
     });
@@ -305,7 +301,6 @@ describe('diffing queries against the store', () => {
     const simpleDiff = diffQueryAgainstStore({
       store,
       query: simpleQuery,
-      variables: null,
     });
 
     assert.deepEqual(simpleDiff.result, {
@@ -317,7 +312,6 @@ describe('diffing queries against the store', () => {
     const inlineDiff = diffQueryAgainstStore({
       store,
       query: inlineFragmentQuery,
-      variables: null,
     });
 
     assert.deepEqual(inlineDiff.result, {
@@ -329,7 +323,6 @@ describe('diffing queries against the store', () => {
     const namedDiff = diffQueryAgainstStore({
       store,
       query: namedFragmentQuery,
-      variables: null,
     });
 
     assert.deepEqual(namedDiff.result, {
@@ -342,7 +335,6 @@ describe('diffing queries against the store', () => {
       diffQueryAgainstStore({
         store,
         query: simpleQuery,
-        variables: null,
         returnPartialData: false,
       });
     });

--- a/test/mocks/mockFetch.ts
+++ b/test/mocks/mockFetch.ts
@@ -52,7 +52,7 @@ export class MockFetch {
       throw new Error(`No more mocked fetch responses for the params ${url} and ${opts}`);
     }
 
-    const { result, delay } = responses.shift();
+    const { result, delay } = responses.shift()!;
 
     if (!result) {
       throw new Error(`Mocked fetch response should contain a result.`);

--- a/test/mocks/mockNetworkInterface.ts
+++ b/test/mocks/mockNetworkInterface.ts
@@ -92,7 +92,7 @@ export class MockNetworkInterface implements NetworkInterface {
         throw new Error(`No more mocked responses for the query: ${print(request.query)}, variables: ${JSON.stringify(request.variables)}`);
       }
 
-      const { result, error, delay } = responses.shift();
+      const { result, error, delay } = responses.shift()!;
 
       if (!result && !error) {
         throw new Error(`Mocked response should contain either result or error: ${key}`);
@@ -150,10 +150,11 @@ export class MockSubscriptionNetworkInterface extends MockNetworkInterface imple
       };
     const key = requestToKey(parsedRequest);
     if (this.mockedSubscriptionsByKey.hasOwnProperty(key)) {
-      const subscription = this.mockedSubscriptionsByKey[key].shift();
-      this.handlersById[subscription.id] = handler;
-      this.mockedSubscriptionsById[subscription.id] = subscription;
-      return subscription.id;
+      const subscription = this.mockedSubscriptionsByKey[key].shift()!;
+      const id = subscription.id!;
+      this.handlersById[id] = handler;
+      this.mockedSubscriptionsById[id] = subscription;
+      return id;
     } else {
       throw new Error('Network interface does not have subscription associated with this request.');
     }
@@ -164,11 +165,11 @@ export class MockSubscriptionNetworkInterface extends MockNetworkInterface imple
     const handler = this.handlersById[id];
     if (this.mockedSubscriptionsById.hasOwnProperty(id.toString())) {
       const subscription = this.mockedSubscriptionsById[id];
-      if (subscription.results.length === 0) {
+      if (subscription.results!.length === 0) {
         throw new Error(`No more mocked subscription responses for the query: ` +
         `${print(subscription.request.query)}, variables: ${JSON.stringify(subscription.request.variables)}`);
       }
-      const response = subscription.results.shift();
+      const response = subscription.results!.shift()!;
       setTimeout(() => {
         handler(response.error, response.result);
       }, response.delay ? response.delay : 0);

--- a/test/mocks/mockWatchQuery.ts
+++ b/test/mocks/mockWatchQuery.ts
@@ -8,7 +8,7 @@ export default (...mockedResponses: MockedResponse[]) => {
   const queryManager = mockQueryManager(...mockedResponses);
   const firstRequest = mockedResponses[0].request;
   return queryManager.watchQuery({
-    query: firstRequest.query,
+    query: firstRequest.query!,
     variables: firstRequest.variables,
   });
 };

--- a/test/mutationResults.ts
+++ b/test/mutationResults.ts
@@ -328,7 +328,7 @@ describe('mutation results', () => {
             counter++;
             if (isMutationResultAction(action)) {
               const newResult = cloneDeep(previousResult) as any;
-              newResult.todoList.todos.unshift(action.result.data['createTodo']);
+              newResult.todoList.todos.unshift(action.result.data!['createTodo']);
               return newResult;
             }
             return previousResult;
@@ -384,7 +384,7 @@ describe('mutation results', () => {
             counter++;
             if (isMutationResultAction(action) && variables['id'] === 5) {
               const newResult = cloneDeep(previousResult) as any;
-              newResult.todoList.todos.unshift(action.result.data['createTodo']);
+              newResult.todoList.todos.unshift(action.result.data!['createTodo']);
               return newResult;
             }
             return previousResult;
@@ -439,7 +439,7 @@ describe('mutation results', () => {
             if (isMutationResultAction(action) && action.operationName === 'createTodo') {
               counter++;
               const newResult = cloneDeep(previousResult) as any;
-              newResult.todoList.todos.unshift(action.result.data['createTodo']);
+              newResult.todoList.todos.unshift(action.result.data!['createTodo']);
               return newResult;
             }
             return previousResult;
@@ -456,7 +456,7 @@ describe('mutation results', () => {
             if (isMutationResultAction(action) && action.operationName === 'wrongName') {
               counter++; // shouldn't be called, so counter shouldn't increase.
               const newResult = cloneDeep(previousResult) as any;
-              newResult.todoList.todos.unshift(action.result.data['createTodo']);
+              newResult.todoList.todos.unshift(action.result.data!['createTodo']);
               return newResult;
             }
             return previousResult;
@@ -504,7 +504,7 @@ describe('mutation results', () => {
             counter++;
             if (isQueryResultAction(action)) {
               const newResult = cloneDeep(previousResult) as any;
-              newResult.todoList.todos.unshift(action.result.data['newTodos'][0]);
+              newResult.todoList.todos.unshift(action.result.data!['newTodos'][0]);
               return newResult;
             }
             return previousResult;
@@ -588,7 +588,7 @@ describe('mutation results', () => {
             counter++;
             if (isMutationResultAction(action)) {
               const newResult = cloneDeep(previousResult) as any;
-              newResult.todoList.todos.unshift(action.result.data['createTodo']);
+              newResult.todoList.todos.unshift(action.result.data!['createTodo']);
               return newResult;
             }
             return previousResult;
@@ -601,9 +601,9 @@ describe('mutation results', () => {
           forceFetch: true, // need force-fetch to get the filteredTodos,
           reducer: (previousResult, action) => {
             counter2++;
-            if (isMutationResultAction(action) && action.result.data['createTodo'].completed) {
+            if (isMutationResultAction(action) && action.result.data!['createTodo'].completed) {
               const newResult = cloneDeep(previousResult) as any;
-              newResult.todoList.filteredTodos.unshift(action.result.data['createTodo']);
+              newResult.todoList.filteredTodos.unshift(action.result.data!['createTodo']);
               return newResult;
             }
             return previousResult;

--- a/test/networkInterface.ts
+++ b/test/networkInterface.ts
@@ -108,7 +108,7 @@ describe('network interface', () => {
     // We won't be too careful about counting calls or closely checking
     // parameters, but just do the basic stuff to ensure the request looks right
     fetchMock.post(swapiUrl, (url, opts) => {
-      const { query, variables } = JSON.parse((opts as RequestInit).body.toString());
+      const { query, variables } = JSON.parse((opts as RequestInit).body!.toString());
 
       if (query === print(simpleQueryWithNoVars)) {
         return simpleResult;
@@ -138,7 +138,7 @@ describe('network interface', () => {
   describe('creating a network interface', () => {
     it('should throw without an argument', () => {
       assert.throws(() => {
-        createNetworkInterface(null);
+        createNetworkInterface(undefined as any);
       }, /must pass an options argument/);
     });
 

--- a/test/optimistic.ts
+++ b/test/optimistic.ts
@@ -899,7 +899,7 @@ describe('optimistic mutation results', () => {
         reducer: (previousResult, action) => {
           if (isMutationResultAction(action)) {
             const newResult = cloneDeep(previousResult) as any;
-            newResult.todoList.todos.unshift(action.result.data['createTodo']);
+            newResult.todoList.todos.unshift(action.result.data!['createTodo']);
             return newResult;
           }
           return previousResult;

--- a/test/optimistic.ts
+++ b/test/optimistic.ts
@@ -790,7 +790,7 @@ describe('optimistic mutation results', () => {
             counter++;
             if (isMutationResultAction(action)) {
               const newResult = cloneDeep(previousResult) as any;
-              newResult.todoList.todos.unshift(action.result.data['createTodo']);
+              newResult.todoList.todos.unshift(action.result.data!['createTodo']);
               return newResult;
             }
             return previousResult;

--- a/test/scheduler.ts
+++ b/test/scheduler.ts
@@ -37,7 +37,7 @@ describe('QueryScheduler', () => {
       query,
     };
     assert.throws(() => {
-      scheduler.startPollingQuery(queryOptions);
+      scheduler.startPollingQuery(queryOptions, null as never);
     });
   });
 

--- a/test/store.ts
+++ b/test/store.ts
@@ -151,11 +151,11 @@ describe('createApolloStore', () => {
       queries: {
         'test.0': {
           'forceFetch': false,
-          'graphQLErrors': null as any,
+          'graphQLErrors': [],
           'lastRequestId': 1,
           'networkStatus': 1,
-          'networkError': null as any,
-          'previousVariables': undefined as any,
+          'networkError': null,
+          'previousVariables': null,
           'queryString': '',
           'document': queryDocument,
           'returnPartialData': false,

--- a/test/util/observableToPromise.ts
+++ b/test/util/observableToPromise.ts
@@ -33,7 +33,7 @@ export function observableToPromiseAndSubscription({
   ...cbs: ResultCallback[],
 ): { promise: Promise<any[]>, subscription: Subscription } {
 
-  let subscription: Subscription;
+  let subscription: Subscription = null as never;
   const promise = new Promise((resolve, reject) => {
     let errorIndex = 0;
     let cbIndex = 0;

--- a/test/util/wrap.ts
+++ b/test/util/wrap.ts
@@ -12,7 +12,7 @@ export default (done: MochaDone, cb: (...args: any[]) => any) => (...args: any[]
 };
 
 export function withWarning(func: Function, regex: RegExp) {
-  let message: string;
+  let message: string = null as never;
   const oldWarn = console.warn;
 
   console.warn = (m: string) => message = m;

--- a/test/writeToStore.ts
+++ b/test/writeToStore.ts
@@ -878,7 +878,7 @@ describe('writing to the store', () => {
             generated: false,
           },
         },
-        [dataIdFromObject(data.author)]: {
+        [dataIdFromObject(data.author)!]: {
           firstName: data.author.firstName,
           id: data.author.id,
           __typename: data.author.__typename,
@@ -917,7 +917,7 @@ describe('writing to the store', () => {
             generated: false,
           },
         },
-        [dataIdFromObject(data.author)]: {
+        [dataIdFromObject(data.author)!]: {
           __typename: data.author.__typename,
           id: data.author.id,
           info: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "removeComments": true,
     "noImplicitAny": true,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "strictNullChecks": true
   },
   "files": [
     "node_modules/typescript/lib/lib.es2015.d.ts",


### PR DESCRIPTION
Enables TypeScript `strictNullChecks` for increased type safety guarantees. A longer term solution to https://github.com/apollostack/apollo-client/issues/800

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change