### PR TITLE
Disable email notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,6 @@ script:
 
 # Allow Travis tests to run in containers.
 sudo: false
+
+notifications:
+  email: false


### PR DESCRIPTION
I get a lot of email notifications from Travis that are just noise. This disables email notifications. If you like getting emails we can enable them selectively: https://docs.travis-ci.com/user/notifications#Configuring-email-notifications

Talked to @helfer who is for this change.